### PR TITLE
Using JWT for auth using drf-simplejwt package + retention days to env variable

### DIFF
--- a/api_app/admin.py
+++ b/api_app/admin.py
@@ -1,5 +1,12 @@
 from django.contrib import admin
+
+from rest_framework_simplejwt.token_blacklist.admin import OutstandingTokenAdmin
+from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.utils import datetime_from_epoch
+
 from .models import Job, Tag
+from intel_owl.settings import CLIENT_TOKEN_LIFETIME_DAYS, SIMPLE_JWT as jwt_settings
 
 
 class JobAdminView(admin.ModelAdmin):
@@ -21,5 +28,89 @@ class TagAdminView(admin.ModelAdmin):
     search_fields = ("label", "color")
 
 
+# SimpleJWT stuff
+class CustomOutstandingTokenAdmin(OutstandingTokenAdmin):
+    """
+    Custom admin view for OutstandingToken model of simplejwt package\n
+    allows bulk deletion and refresh token creation
+    """
+
+    # default actions
+    actions = []
+
+    # searchable fields
+    search_fields = (
+        "user__username",
+        "user__id",
+        "jti",
+    )
+
+    __fieldsets_custom = [
+        (
+            "Create API Token For",
+            {
+                "fields": ("user", "token",),
+                "description": f"""
+                    <h3>Token will be auto-generated on save.</h3>
+                    <h5>Please note that this token,</h5>
+                    <ol>
+                      <li>can only be used with the PyIntelOwl client.</li>
+                      <li>is rotated on every authenticated request
+                      and saves itself via pyintelowl</li>
+                      <li>
+                        automatically expires if goes
+                        unused for {CLIENT_TOKEN_LIFETIME_DAYS} days.
+                    </li>
+                    </ol>
+                """,
+            },
+        ),
+    ]
+
+    def add_view(self, request, extra_content=None):
+        self.fieldsets = self.__fieldsets_custom
+        return super(CustomOutstandingTokenAdmin, self).add_view(request)
+
+    def get_readonly_fields(self, *args, **kwargs):
+        fields = [f.name for f in self.model._meta.fields]
+        # only user field is writeable
+        fields.remove("user")
+        return fields
+
+    def has_delete_permission(self, *args, **kwargs):
+        return True
+
+    def has_add_permission(self, *args, **kwargs):
+        return True
+
+    def has_change_permission(self, *args, **kwargs):
+        return False
+
+    def save_model(self, request, obj, form, change):
+        if obj.user:
+            refresh = RefreshToken()
+            # custom claims
+            refresh["client"] = "pyintelowl"
+            refresh["user_id"] = obj.user.id
+            # overwrite lifetime/expiry
+            refresh.set_exp(
+                lifetime=jwt_settings.get("PYINTELOWL_TOKEN_LIFETIME", None)
+            )
+            token = OutstandingToken.objects.create(
+                user=obj.user,
+                jti=refresh.payload["jti"],
+                token=str(refresh),
+                created_at=refresh.current_time,
+                expires_at=datetime_from_epoch(refresh["exp"]),
+            )
+            return token
+
+        return None
+
+
 admin.site.register(Job, JobAdminView)
 admin.site.register(Tag, TagAdminView)
+# Unregister the default admin view for OutstandingToken
+admin.site.unregister(OutstandingToken)
+# Register our custom admin view for OutstandingToken
+admin.site.register(OutstandingToken, CustomOutstandingTokenAdmin)

--- a/api_app/auth.py
+++ b/api_app/auth.py
@@ -1,0 +1,137 @@
+import logging
+
+from django.contrib.auth import authenticate, login, logout
+from rest_framework.response import Response
+from rest_framework import status
+from rest_framework.exceptions import APIException
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.views import TokenRefreshView
+from rest_framework.decorators import (
+    api_view,
+    authentication_classes,
+    permission_classes,
+)
+
+from api_app import serializers
+
+
+logger = logging.getLogger(__name__)
+
+
+""" Auth API endpoints """
+
+
+@api_view(["POST"])
+@authentication_classes([])
+@permission_classes([])
+def obtain_user_token(request):
+    """
+    REST endpoint to obtain user auth token via authentication
+
+    :param username: string
+        username of registered user
+    :param password: string
+        password of registered user
+
+    :return 202:
+        if accepted
+    :return 404:
+        if failed
+    """
+    try:
+        username = request.data["username"]
+        logger.info(f"obtain_user_token received request for '{username}'.")
+        password = request.data["password"]
+        auth_user = authenticate(username=username, password=password)
+        if auth_user:
+            if auth_user.is_superuser:
+                try:
+                    logger.info(f"headers: {request.headers}")
+                    # pass admin user's session
+                    login(request, auth_user)
+                    logger.info(f"administrator:'{username}' was logged in.")
+                except Exception:
+                    logger.exception(f"administrator:'{username}' login failed.")
+
+            refresh = RefreshToken.for_user(auth_user)
+            logger.debug(f"obtain_user_token: token created for '{username}'.")
+            # adding custom 'username' claim
+            refresh["username"] = auth_user.username
+            return Response(
+                {"refresh": str(refresh), "access": str(refresh.access_token)},
+                status=status.HTTP_202_ACCEPTED,
+            )
+        raise APIException(
+            "No such user exists or Incorrect credentials",
+            code=status.HTTP_400_BAD_REQUEST,
+        )
+
+    except APIException as e:
+        logger.exception(f"obtain_user_token exception: {e}")
+        return Response({"error": str(e)}, status=e.status_code)
+
+
+class CustomTokenRefreshView(TokenRefreshView):
+    """
+    REST endpoint that returns new `token` object consisting of
+    `access` and `refresh` fields
+    given a valid `refresh` token.
+
+    :methods_allowed:
+        POST
+
+    :param request.data:
+        JSON[refresh]
+
+    :return 201:
+        if accepted and created new token
+    :return 400:
+        if failed
+    """
+
+    serializer_class = serializers.TokenRefreshPatchedSerializer
+
+
+@api_view(["POST"])
+def perform_logout(request):
+    """
+    REST endpoint to delete/invalidate user auth token and logout user.
+    Requires authentication.
+
+    :param refresh: string
+        user's current refresh token that will be blacklisted
+
+    :return 200:
+        if ok
+    :return 400:
+        if failed
+    """
+    try:
+        user = request.user
+        logger.info(f"perform_logout received request from {user.username}.")
+        recvd_refresh_token = request.data["refresh"]
+        refresh = RefreshToken(recvd_refresh_token)
+        if user.is_superuser:
+            try:
+                logout(request)
+                logger.info(f"administrator:'{user.username}' was logged out.")
+            except Exception:
+                logger.exception(
+                    f"administrator:'{user.username}' session logout failed."
+                )
+        try:
+            # Attempt to blacklist the given refresh token
+            refresh.blacklist()
+            logger.info("perform_logout: current token was blacklisted.")
+        except AttributeError:
+            # If blacklist app not installed, `blacklist` method will
+            # not be present
+            logger.exception("perform_logout: token_blacklist app is not installed.")
+
+        return Response(
+            {"status": "You've been logged out."}, status=status.HTTP_200_OK
+        )
+    except Exception as e:
+        str_err = str(e)
+        logger.exception(f"perform_logout exception: {str_err}")
+        return Response({"error": str_err}, status=status.HTTP_400_BAD_REQUEST)

--- a/api_app/crons.py
+++ b/api_app/crons.py
@@ -5,6 +5,7 @@ from django.core import management
 from api_app.models import Job
 from api_app.script_analyzers import general
 from api_app.utilities import get_now
+from intel_owl import secrets
 
 logger = logging.getLogger(__name__)
 
@@ -46,7 +47,10 @@ def remove_old_jobs():
     """
     logger.info("started remove_old_jobs")
 
-    retention_days = 3
+    retention_days = secrets.get_secret("OLD_JOBS_RETENTION_DAYS")
+    if not retention_days:
+        retention_days = 3
+    retention_days = int(retention_days)
     now = get_now()
     date_to_check = now - datetime.timedelta(days=retention_days)
     old_jobs = Job.objects.filter(finished_analysis_time__lt=date_to_check)

--- a/api_app/crons.py
+++ b/api_app/crons.py
@@ -1,6 +1,7 @@
 import datetime
 import logging
 
+from django.core import management
 from api_app.models import Job
 from api_app.script_analyzers import general
 from api_app.utilities import get_now
@@ -55,3 +56,12 @@ def remove_old_jobs():
 
     logger.info("finished remove_old_jobs")
     return num_jobs_to_delete
+
+
+def flush_expired_tokens():
+    """
+    flushes all expired tokens from OutstandingToken and BlacklistedToken models.
+    """
+    logger.info("started flush_expired_tokens")
+    management.call_command("flushexpiredtokens")
+    logger.info("finished flush_expired_tokens")

--- a/api_app/serializers.py
+++ b/api_app/serializers.py
@@ -1,5 +1,10 @@
 from rest_framework import serializers
+from rest_framework_simplejwt.tokens import RefreshToken
+from rest_framework_simplejwt.token_blacklist.models import OutstandingToken
+from rest_framework_simplejwt.utils import datetime_from_epoch
+
 from api_app.models import Job, Tag
+from intel_owl.settings import SIMPLE_JWT as jwt_settings
 
 
 class TagSerializer(serializers.ModelSerializer):
@@ -44,3 +49,56 @@ class JobListSerializer(serializers.ModelSerializer):
     class Meta:
         model = Job
         exclude = ("analysis_reports", "errors")
+
+
+class TokenRefreshPatchedSerializer(serializers.Serializer):
+    """
+    SimpleJWT's Custom RefreshToken serializer\n
+    Issue: https://github.com/SimpleJWT/django-rest-framework-simplejwt/issues/25
+    Patched TokenRefresh serializer so it
+    stores the new refresh token to the list of Outstanding tokens immediately
+    """
+
+    refresh = serializers.CharField()
+
+    def validate(self, attrs):
+        # wrap the given refresh token as a RefreshToken object
+        refresh = RefreshToken(attrs["refresh"])
+        # create response data
+        data = {"access": str(refresh.access_token)}
+
+        if jwt_settings["ROTATE_REFRESH_TOKENS"]:
+            blacklisted_token = None
+            if jwt_settings["BLACKLIST_AFTER_ROTATION"]:
+                try:
+                    # Attempt to blacklist the given refresh token
+                    blacklisted_token, _ = refresh.blacklist()
+                except AttributeError:
+                    # If blacklist app not installed, `blacklist` method will
+                    # not be present
+                    pass
+
+            # rotate refresh token
+            refresh.set_jti()
+            if refresh.get("client", False) == "pyintelowl":
+                refresh.set_exp(
+                    lifetime=jwt_settings.get("PYINTELOWL_TOKEN_LIFETIME", None)
+                )
+            else:
+                refresh.set_exp()
+
+            data["refresh"] = str(refresh)
+
+            # PATCHED - Create Outstanding Token in the db
+            if blacklisted_token:
+                user = blacklisted_token.token.user
+                if user:
+                    OutstandingToken.objects.create(
+                        user=user,
+                        jti=refresh.payload["jti"],
+                        token=str(refresh),
+                        created_at=refresh.current_time,
+                        expires_at=datetime_from_epoch(refresh["exp"]),
+                    )
+
+        return data

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -5,14 +5,13 @@ from .api import (
     ask_analysis_availability,
     send_analysis_request,
     ask_analysis_result,
-    obtain_user_token,
-    perform_logout,
-    get_user_info,
     get_analyzer_configs,
     download_sample,
     TagViewSet,
     JobViewSet,
 )
+
+from .auth import obtain_user_token, perform_logout, CustomTokenRefreshView
 
 
 # Routers provide an easy way of automatically determining the URL conf.
@@ -22,13 +21,16 @@ router.register(r"jobs", JobViewSet)
 
 # These come after /api/..
 urlpatterns = [
+    # Auth APIs
+    path("auth/login", obtain_user_token),
+    path("auth/logout", perform_logout),
+    path("auth/refresh-token", CustomTokenRefreshView.as_view(), name="refresh_token"),
+    # Main APIs
     path("ask_analysis_availability", ask_analysis_availability),
     path("send_analysis_request", send_analysis_request),
     path("ask_analysis_result", ask_analysis_result),
-    path("auth/login", obtain_user_token),
-    path("auth/logout", perform_logout),
-    path("auth/user", get_user_info),
     path("get_analyzer_configs", get_analyzer_configs),
     path("download_sample", download_sample),
+    # Viewsets
     path(r"", include(router.urls)),
 ]

--- a/env_file_app_template
+++ b/env_file_app_template
@@ -5,6 +5,12 @@ DB_PORT=5432
 DB_USER=user
 DB_PASSWORD=password
 
+# Additional Config variables
+# jobs older than this would be flushed from the database periodically. Default: 3 days
+OLD_JOBS_RETENTION_DAYS=3
+# IntelOwl's API token will expire if unused for how many days ? Default: 7 days
+PYINTELOWL_TOKEN_LIFETIME=7
+
 # Optional API keys
 SHODAN_KEY=
 ABUSEIPDB_KEY=

--- a/intel_owl/celery.py
+++ b/intel_owl/celery.py
@@ -24,6 +24,11 @@ app.conf.beat_schedule = {
         "task": "intel_owl.tasks.check_stuck_analysis",
         "schedule": crontab(minute="*/5"),
     },
+    # execute every 6 hours to cleanup expired tokens
+    "flush_expired_tokens": {
+        "task": "intel_owl.tasks.flush_expired_tokens",
+        "schedule": crontab(hour="*/6"),
+    },
     # Executes only on Wed because on Tue it's updated
     "maxmind_updater": {
         "task": "intel_owl.tasks.maxmind_updater",

--- a/intel_owl/settings.py
+++ b/intel_owl/settings.py
@@ -1,5 +1,6 @@
 # flake8: noqa
 import os
+from datetime import timedelta
 
 from intel_owl import secrets
 
@@ -39,7 +40,7 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "rest_framework",
-    "rest_framework.authtoken",
+    "rest_framework_simplejwt.token_blacklist",
     "api_app.apps.ApiAppConfig",
 ]
 
@@ -74,7 +75,12 @@ TEMPLATES = [
 WSGI_APPLICATION = "intel_owl.wsgi.application"
 
 REST_FRAMEWORK = {
-    "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer",]
+    "DEFAULT_RENDERER_CLASSES": ["rest_framework.renderers.JSONRenderer",],
+    "DEFAULT_AUTHENTICATION_CLASSES": [
+        "rest_framework_simplejwt.authentication.JWTAuthentication",
+    ],
+    "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
+    "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",
 }
 
 DB_HOST = secrets.get_secret("DB_HOST")
@@ -92,6 +98,23 @@ DATABASES = {
         "USER": DB_USER,
         "PASSWORD": DB_PASSWORD,
     },
+}
+
+# Simple JWT Stuff
+SIMPLE_JWT = {
+    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
+    "REFRESH_TOKEN_LIFETIME": timedelta(hours=12),
+    "ROTATE_REFRESH_TOKENS": True,
+    "BLACKLIST_AFTER_ROTATION": True,
+    "ALGORITHM": "HS512",
+    "SIGNING_KEY": SECRET_KEY,
+    "AUTH_HEADER_TYPES": ("Token",),
+    "USER_ID_FIELD": "id",
+    "USER_ID_CLAIM": "user_id",
+    "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
+    "TOKEN_TYPE_CLAIM": "token_type",
+    "JTI_CLAIM": "jti",
+    "PYINTELOWL_TOKEN_LIFETIME": timedelta(days=7),
 }
 
 

--- a/intel_owl/settings.py
+++ b/intel_owl/settings.py
@@ -12,7 +12,6 @@ SECRET_KEY = secrets.get_secret("DJANGO_SECRET")
 # SECURITY WARNING: don't run with debug turned on in production!
 DEBUG = True if os.environ.get("DEBUG", False) == "True" else False
 
-LOGIN_URL = "/gui/login"
 DJANGO_LOG_DIRECTORY = "/var/log/intel_owl/django"
 PROJECT_LOCATION = "/opt/deploy/intel_owl"
 MEDIA_ROOT = "/opt/deploy/files_required"
@@ -24,11 +23,15 @@ MOCK_CONNECTIONS = (
     True if os.environ.get("MOCK_CONNECTIONS", False) == "True" else False
 )
 
+# Security Stuff
 HTTPS_ENABLED = os.environ.get("HTTPS_ENABLED", "not_enabled")
 if HTTPS_ENABLED == "enabled":
     CSRF_COOKIE_SECURE = True
     SESSION_COOKIE_SECURE = True
 
+SESSION_COOKIE_SAMESITE = "Strict"
+CSRF_COOKIE_SAMESITE = "Strict"
+CSRF_COOKIE_HTTPONLY = True
 ALLOWED_HOSTS = ["*"]
 
 # Application definition
@@ -101,6 +104,9 @@ DATABASES = {
 }
 
 # Simple JWT Stuff
+
+CLIENT_TOKEN_LIFETIME_DAYS = int(os.environ.get("PYINTELOWL_TOKEN_LIFETIME", 7))
+
 SIMPLE_JWT = {
     "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
     "REFRESH_TOKEN_LIFETIME": timedelta(hours=12),
@@ -114,7 +120,7 @@ SIMPLE_JWT = {
     "AUTH_TOKEN_CLASSES": ("rest_framework_simplejwt.tokens.AccessToken",),
     "TOKEN_TYPE_CLAIM": "token_type",
     "JTI_CLAIM": "jti",
-    "PYINTELOWL_TOKEN_LIFETIME": timedelta(days=7),
+    "PYINTELOWL_TOKEN_LIFETIME": timedelta(days=CLIENT_TOKEN_LIFETIME_DAYS),
 }
 
 

--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -60,6 +60,11 @@ def check_stuck_analysis():
     crons.check_stuck_analysis()
 
 
+@shared_task(soft_time_limit=120)
+def flush_expired_tokens():
+    crons.flush_expired_tokens()
+
+
 @shared_task(soft_time_limit=30)
 def abuseipdb_run(
     analyzer_name,

--- a/intel_owl/urls.py
+++ b/intel_owl/urls.py
@@ -1,7 +1,9 @@
 from django.contrib import admin
+from django.views.generic.base import RedirectView
 from django.urls import include, path
 
 urlpatterns = [
-    path("admin/", admin.site.urls),
+    path("", RedirectView.as_view(pattern_name="admin", permanent=False)),
+    path("admin/", admin.site.urls, name="admin"),
     path("api/", include("api_app.urls")),
 ]

--- a/requirements.txt
+++ b/requirements.txt
@@ -74,5 +74,6 @@ vine==1.3.0
 wrapt==1.11.2
 yara-python==3.11.0
 zipp==0.6.0
+djangorestframework-simplejwt==4.4.0
 flake8==3.8.2 
 black==19.10b0


### PR DESCRIPTION
This PR introduces changes required to switch to JSON Web Tokens (JWT) for authentication instead of the default tokens by django-rest-framework.

- Introduces the `django-rest-framework-simplejwt` package. [Docs](https://django-rest-framework-simplejwt.readthedocs.io/).
- simplejwt package by default does not allow delete and create actions on `OutstandingToken` model from the django admin interface. Thus I have overwritten it's admin view implementing [`CustomOutstandingTokenAdmin`](https://github.com/intelowlproject/IntelOwl/pull/94/files#diff-618a96daf5cbbf7bc4d0bfd013ebc217R32) that allows these 2 operations. Related [issue](https://github.com/SimpleJWT/django-rest-framework-simplejwt/issues/258) on their GitHub.
- Refresh-access Token-pair working in brief:

   - Refresh tokens are rotated along with access tokens with lifetimes of,
   ```python
    ...
    "ACCESS_TOKEN_LIFETIME": timedelta(minutes=30),
    "REFRESH_TOKEN_LIFETIME": timedelta(hours=12),
    ...
    ```
   - The refresh token lifetime for tokens meant to be used with pyintelowl (ones created from admin interface and one with `client:pyintelowl` claim in their JWT) is set to 7 days. (can be edited from env variables)
   - Overwritten the `TokenRefreshSerializer` with [`TokenRefreshPatchedSerializer`](https://github.com/intelowlproject/IntelOwl/pull/94/files#diff-cf7d3c525eedcb42adb00bf181a930dbR54) to allow,
       - Refresh token used to obtain a new token-pair is immediately blacklisted. 
       - Stores the new refresh token to the list of Outstanding tokens immediately
       - Related [Issue](https://github.com/SimpleJWT/django-rest-framework-simplejwt/issues/25) on their GitHub.
 
    - [`flush_expired_tokens`](https://github.com/intelowlproject/IntelOwl/pull/94/files#diff-4dc50d190568ac02f59fb35fbfa59925R28): a crontab that runs every 6 hours and deletes expired tokens from `OutstandingToken` model.

- Instead of defining `Authentication` and `Permission` classes decorators on each view explicitly. I have moved it to `settings.py`. [diff](https://github.com/intelowlproject/IntelOwl/pull/94/files#diff-fa4841e2257216d729e889750faad355R80).
- [`api_app/auth.py`](api_app/auth.py) file contains 3 API endpoints, namely: `login`, `refresh-token`, and `logout`. These views have been moved from `api.py` to `auth.py`.
- `get_user_info` view is removed since it's not needed anymore.

PS: also has changes where I have replaced `django.http.JsonResponse` with `rest_framework.response.Response` class since this is [recommended by django-rest-framework](https://www.django-rest-framework.org/api-guide/responses/) and increases consistency throughout the code as well.

P.P.S: I have also added `OLD_JOBS_RETENTION_DAYS` env variable to `env_file_app_template`. For Issue #82)