### PR TITLE
modified PEframe to use the new flask-shell2http package

### DIFF
--- a/api_app/script_analyzers/file_analyzers/peframe.py
+++ b/api_app/script_analyzers/file_analyzers/peframe.py
@@ -1,5 +1,6 @@
 import requests
 import traceback
+import json
 import logging
 import time
 
@@ -10,26 +11,31 @@ logger = logging.getLogger(__name__)
 
 
 def run(analyzer_name, job_id, filepath, filename, md5, additional_config_params):
-    logger.info("started analyzer {} job_id {}" "".format(analyzer_name, job_id))
+    logger.info(f"started analyzer {analyzer_name} job_id {job_id}")
     report = general.get_basic_report_template(analyzer_name)
     try:
         # get binary
         binary = general.get_binary(job_id)
-        # run analysis
-        files = {"file": binary}
-        r = requests.post("http://peframe:4000/run_analysis", files=files)
+        # request new analysis
+        req_data = {"args": ["-j", "@filetoscan"]}
+        req_files = {"filetoscan": binary}
+        r = requests.post("http://peframe:4000/peframe", files=req_files, data=req_data)
         r_data = r.json()
-        if r.status_code == 200:
+        if r.status_code in (200, 202):
             max_tries = additional_config_params.get("max_tries", 15)
-            res = _poll_for_result(job_id, r_data["md5"], max_tries)
+            resp = _poll_for_result(job_id, r_data["key"], max_tries)
         else:
             raise AnalyzerRunException(r_data["error"])
 
         # limit the length of the strings dump
-        if "strings" in res and "dump" in res["strings"]:
-            res["strings"]["dump"] = res["strings"]["dump"][:100]
+        result = resp.get("report", None)
+        if result:
+            result = json.loads(result)
+            if "strings" in result and "dump" in result["strings"]:
+                result["strings"]["dump"] = result["strings"]["dump"][:100]
 
-        report["report"] = res
+        # set final report
+        report["report"] = result
     except AnalyzerRunException as e:
         error_message = (
             f"job_id:{job_id} analyzer:{analyzer_name}"
@@ -89,8 +95,8 @@ def _poll_for_result(job_id, hash, max_tries):
         )
 
 
-def _query_for_result(hash):
+def _query_for_result(key):
     headers = {"Accept": "application/json"}
-    resp = requests.get(f"http://peframe:4000/get_report/{hash}", headers=headers)
+    resp = requests.get(f"http://peframe:4000/peframe?key={key}", headers=headers)
     data = resp.json()
     return resp.status_code, data

--- a/api_app/script_analyzers/yara_repo_downloader.sh
+++ b/api_app/script_analyzers/yara_repo_downloader.sh
@@ -30,6 +30,8 @@ sed -i "/MalConfScan.yar/d" $community_yara_index
 sed -i "/RAT_PoetRATPython.yar/d" $community_yara_index
 sed -i "/Email_fake_it_maintenance_bulletin.yar/d" $community_yara_index
 sed -i "/Email_quota_limit_warning.yar/d" $community_yara_index
+sed -i "/RANSOM_acroware.yar/d" $community_yara_index
+sed -i "/TOOLKIT_THOR_HackTools.yar/d" $community_yara_index
 
 # Florian Roth rules
 git clone https://github.com/Neo23x0/signature-base.git

--- a/env_file_integrations_template
+++ b/env_file_integrations_template
@@ -3,7 +3,5 @@
 ### IMPORTANT: don't change these values unless you know what you are doing. It can have breaking changes!
 
 # PEframe
-FLASK_SECRET_KEY=
-FLASK_DEBUG=False
 WORKERS=1
 LOG_LEVEL=INFO

--- a/integrations/peframe/app.py
+++ b/integrations/peframe/app.py
@@ -1,232 +1,46 @@
 # system imports
 import os
-import subprocess
-import shutil
-import hashlib
-import json
-import time
 import logging
 
 # web imports
-from http import HTTPStatus
-from flask import Flask, request, jsonify, make_response
-from flask_sqlalchemy import SQLAlchemy
+from flask import Flask
 from flask_executor import Executor
-from werkzeug.utils import secure_filename
+from flask_shell2http import Shell2HTTP
 
 # Globals
 app = Flask(__name__)
 executor = Executor(app)
+shell2http = Shell2HTTP(app, executor)
+
+# with this, we can make http calls to the endpoint: /peframe
+shell2http.register_command(endpoint="peframe", command_name="peframe")
 
 # Config
 CONFIG = {
-    "SECRET_KEY": os.environ.get("FLASK_SECRET_KEY")
-    or __import__("secrets").token_hex(16),
-    "UPLOAD_PATH": os.environ.get("UPLOAD_PATH") or "uploads/",
-    "SQLALCHEMY_DATABASE_URI": os.environ.get("DATABASE_URL") or "sqlite:///site.db",
-    "SQLALCHEMY_TRACK_MODIFICATIONS": False,
-    "DEBUG": os.environ.get("FLASK_DEBUG") or False,
+    "SECRET_KEY": __import__("secrets").token_hex(16),
 }
 app.config.update(CONFIG)
-
-# SQLAlchemy Models
-db = SQLAlchemy(app)
-
-
-class Result(db.Model):
-    md5 = db.Column(db.String(128), primary_key=True, unique=True)
-    timestamp = db.Column(db.Float(), default=time.time())
-    report = db.Column(db.JSON(), nullable=True, default=None)
-    error = db.Column(db.TEXT(), nullable=True, default=None)
-    status = db.Column(db.String(20), nullable=True, default="failed")
-
-
-# Utility functions
-def call_peframe(f_loc, f_hash):
-    """
-    This function is called by the executor to run peframe
-    using a subprocess asynchronously.
-    """
-    try:
-        cmd = f"peframe -j {f_loc}"
-        proc = subprocess.Popen(
-            cmd.split(), stdout=subprocess.PIPE, stderr=subprocess.PIPE
-        )
-        stdout, stderr = proc.communicate()
-        stderr = stderr.decode("ascii")
-        err = None if ("SyntaxWarning" in stderr) else stderr
-        if err and stdout:
-            status = "reported_with_fails"
-        elif stdout and not err:
-            status = "success"
-        else:
-            status = "failed"
-
-        # This gets stored as Future.result
-        job_result = {
-            "file_location": f_loc,
-            "md5": f_hash,
-            "stdout": json.dumps(json.loads(stdout)),
-            "stderr": err,
-            "status": status,
-        }
-        app.logger.info(f"job_{f_hash} was successful.")
-        return job_result
-
-    except Exception as e:
-        job_key = f"job_{f_hash}"
-        app.logger.exception(f"Caught exception:{e}")
-        executor.futures._futures.get(job_key).cancel()
-        app.logger.error(f"{job_key} was cancelled")
-        job_result = {
-            "file_location": f_loc,
-            "md5": f_hash,
-            "stdout": None,
-            "stderr": str(e),
-            "status": "failed",
-        }
-        return job_result
-
-
-def add_result_to_db(future):
-    """
-    Default callable fn for Future object.
-    """
-    # get job result from future
-    job_res = future.result()
-    app.logger.debug(job_res)
-    # get and update corresponding db row object
-    result = Result.query.get(job_res.get("md5"))
-    result.status = job_res.get("status")
-    result.report = job_res.get("stdout")
-    result.error = job_res.get("stderr")
-
-    # delete file
-    os.remove(job_res.get("file_location"))
-    # finally commit changes to DB
-    db.session.commit()
-
-
-executor.add_default_done_callback(add_result_to_db)
-
-
-# API routes/endpoints
-@app.before_first_request
-def before_first_request():
-    try:
-        db.drop_all()
-        db.create_all()
-        app.logger.debug("Dropped current DB and created new instance")
-    except Exception as e:
-        app.logger.exception(f"Caught Exception:{e}")
-        db.create_all()
-        app.logger.debug("Created new DB instance")
-
-    _upload_path = app.config.get("UPLOAD_PATH")
-    try:
-        os.mkdir(_upload_path)
-    except FileExistsError:
-        app.logger.debug(f"Emptying upload_path:{_upload_path} folder.")
-        shutil.rmtree(_upload_path, ignore_errors=True)
-        os.mkdir(_upload_path)
-
-
-@app.route("/run_analysis", methods=["POST"])
-def run_analysis():
-    try:
-        # Check if file part exists
-        if "file" not in request.files:
-            app.logger.error("No file part in request")
-            return make_response(jsonify(error="No File part"), HTTPStatus.NOT_FOUND)
-
-        # get file and save it
-        req_file = request.files["file"]
-        f_name = secure_filename(req_file.filename)
-        f_loc = os.path.join(app.config.get("UPLOAD_PATH"), f_name)
-        req_file.save(f_loc)
-
-        # Calc file hash
-        with open(f_loc, "rb") as rf:
-            f_hash = hashlib.md5(rf.read()).hexdigest()
-
-        # Check if hash already in DB, and return directly if yes
-        res = Result.query.get(f_hash)
-        if res:
-            app.logger.info(f"Report already exists for md5:{f_hash}")
-            return make_response(
-                jsonify(info="Analysis already exists", status=res.status, md5=res.md5),
-                200,
-            )
-
-        app.logger.info(f"Analysis requested for md5:{f_hash}")
-
-        # add to DB
-        result = Result(md5=f_hash, status="running")
-        db.session.add(result)
-        db.session.commit()
-
-        # run executor job in background
-        job_key = f"job_{f_hash}"
-        executor.submit_stored(
-            future_key=job_key, fn=call_peframe, f_loc=f_loc, f_hash=f_hash
-        )
-        app.logger.info(f"Job created with key:{job_key}.")
-
-        return make_response(jsonify(status="running", md5=f_hash), 200)
-
-    except Exception as e:
-        app.logger.exception(f"unexpected error {e}")
-        return make_response(jsonify(error=str(e)), HTTPStatus.INTERNAL_SERVER_ERROR)
-
-
-@app.route("/get_report/<md5_to_get>", methods=["GET"])
-def ask_report(md5_to_get):
-    try:
-        app.logger.info(f"Report requested for md5:{md5_to_get}")
-        # check if job has been finished
-        future = executor.futures._futures.get(f"job_{md5_to_get}", None)
-        if future:
-            if future.done:
-                # pop future object since it has been finished
-                executor.futures.pop(f"job_{md5_to_get}")
-            else:
-                return make_response(jsonify(status="running", md5=md5_to_get), 200)
-        # if yes, get result from DB
-        res = Result.query.get(md5_to_get)
-        if not res:
-            raise Exception(f"Report does not exist for md5:{md5_to_get}")
-
-        return make_response(
-            jsonify(
-                status=res.status,
-                md5=res.md5,
-                report=json.loads(res.report),
-                error=res.error,
-                timestamp=res.timestamp,
-            ),
-            200,
-        )
-
-    except Exception as e:
-        app.logger.exception(f"Caught Exception:{e}")
-        return make_response(jsonify(error=str(e)), HTTPStatus.NOT_FOUND)
 
 
 # Application Runner
 if __name__ == "__main__":
     app.run(port=4000)
 else:
-    # set logger
+    # get flask-shell2http logger instance
+    logger = logging.getLogger("flask_shell2http")
+    # logger config
     formatter = logging.Formatter(
-        "%(asctime)s - %(name)s - %(funcName)s - %(levelname)s - %(message)s"
+        "%(asctime)s - %(name)s - %(levelname)s - %(message)s"
     )
     log_level = os.getenv("LOG_LEVEL", logging.INFO)
     log_path = "/var/log/intel_owl"
+    # create new file handlers
     fh = logging.FileHandler(f"{log_path}/peframe.log")
     fh.setFormatter(formatter)
     fh.setLevel(log_level)
-    app.logger.addHandler(fh)
     fh_err = logging.FileHandler(f"{log_path}/peframe_errors.log")
     fh_err.setFormatter(formatter)
     fh_err.setLevel(logging.ERROR)
-    app.logger.addHandler(fh_err)
+    # set the logger
+    logger.addHandler(fh)
+    logger.addHandler(fh_err)

--- a/integrations/peframe/requirements.txt
+++ b/integrations/peframe/requirements.txt
@@ -1,10 +1,9 @@
 click==7.1.1
 Flask==1.1.2
 Flask-Executor==0.9.3
-Flask-SQLAlchemy==2.4.1
-gunicorn==20.0.4
+Flask-Shell2HTTP==1.1.3
 itsdangerous==1.1.0
-Jinja2==2.11.1
+Jinja2==2.11.2
 MarkupSafe==1.1.1
-SQLAlchemy==1.3.16
 Werkzeug==1.0.1
+gunicorn==20.0.4

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -15,6 +15,33 @@ if settings.DISABLE_LOGGING_TEST:
     logging.disable(logging.CRITICAL)
 
 
+# class for mocking responses
+class MockResponse:
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+        self.text = ""
+        self.content = b""
+
+    def json(self):
+        return self.json_data
+
+    def raise_for_status(self):
+        pass
+
+
+# a mock response class that has no operation
+class MockResponseNoOp:
+    def __init__(self, json_data, status_code):
+        pass
+
+    def search(self, **kwargs):
+        return {}
+
+    def query(self, val):
+        return {}
+
+
 class ApiTests(TestCase):
     def setUp(self):
         self.client = APIClient()

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -24,6 +24,7 @@ from api_app.script_analyzers.observable_analyzers import vt3_get
 
 from api_app.models import Job
 from api_app.script_analyzers.file_analyzers import signature_info
+from .test_api import MockResponse
 
 from intel_owl import settings
 
@@ -39,122 +40,31 @@ def mock_connections(decorator):
 
 
 def mocked_requests(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({}, 200)
 
 
 def mocked_vt_get(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({"data": {"attributes": {"status": "completed"}}}, 200)
 
 
 def mocked_vt_post(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({"scan_id": "scan_id_test", "data": {"id": "id_test"}}, 200)
 
 
 def mocked_intezer(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({}, 201)
 
 
 def mocked_cuckoo_get(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({"task": {"status": "reported"}}, 200)
 
 
 def mocked_peframe_get(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
-    return MockResponse({"error": None, "key": "test", "status": "success"}, 200)
+    return MockResponse({"key": "test", "status": "success", "report": {}}, 200,)
 
 
 def mocked_peframe_post(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
-    return MockResponse({"key": "test", "status": "running"}, 200)
+    return MockResponse({"key": "test", "status": "running"}, 202)
 
 
 class FileAnalyzersEXETests(TestCase):
@@ -369,7 +279,7 @@ class FileAnalyzersDocTests(TestCase):
     @mock_connections(patch("requests.get", side_effect=mocked_peframe_get))
     @mock_connections(patch("requests.post", side_effect=mocked_peframe_post))
     def test_peframe_scan_file(self, mock_get=None, mock_post=None):
-        additional_params = {"max_tries": 10}
+        additional_params = {"max_tries": 1}
         report = peframe.run(
             "PEframe_Scan_File",
             self.job_id,

--- a/tests/test_files.py
+++ b/tests/test_files.py
@@ -137,7 +137,7 @@ def mocked_peframe_get(*args, **kwargs):
         def raise_for_status(self):
             pass
 
-    return MockResponse({"error": None, "md5": "test", "status": "success"}, 200)
+    return MockResponse({"error": None, "key": "test", "status": "success"}, 200)
 
 
 def mocked_peframe_post(*args, **kwargs):
@@ -154,7 +154,7 @@ def mocked_peframe_post(*args, **kwargs):
         def raise_for_status(self):
             pass
 
-    return MockResponse({"md5": "test", "status": "running"}, 200)
+    return MockResponse({"key": "test", "status": "running"}, 200)
 
 
 class FileAnalyzersEXETests(TestCase):

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -41,6 +41,7 @@ from api_app.script_analyzers.observable_analyzers import (
     cymru,
     tranco,
 )
+from .test_api import MockResponse, MockResponseNoOp
 from intel_owl import settings
 
 logger = logging.getLogger(__name__)
@@ -55,53 +56,19 @@ def mock_connections(decorator):
 
 
 def mocked_requests(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            self.json_data = json_data
-            self.status_code = status_code
-            self.text = ""
-            self.content = b""
-
-        def json(self):
-            return self.json_data
-
-        def raise_for_status(self):
-            pass
-
     return MockResponse({}, 200)
 
 
 def mocked_pymisp(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            pass
-
-        def search(self, **kwargs):
-            return {}
-
-    return MockResponse({}, 200)
+    return MockResponseNoOp({}, 200)
 
 
 def mocked_pypssl(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            pass
-
-        def query(self, ip):
-            return {}
-
-    return MockResponse({}, 200)
+    return MockResponseNoOp({}, 200)
 
 
 def mocked_pypdns(*args, **kwargs):
-    class MockResponse:
-        def __init__(self, json_data, status_code):
-            pass
-
-        def query(self, domain):
-            return []
-
-    return MockResponse({}, 200)
+    return MockResponseNoOp({}, 200)
 
 
 @mock_connections(patch("requests.get", side_effect=mocked_requests))


### PR DESCRIPTION
1. modified PEframe to use the new [flask-shell2http](https://github.com/Eshaan7/Flask-Shell2HTTP) package.
2. I have modified the testing suite to reduce some redundant code duplicacy.
   - Same `MockResponse` class was earlier defined at many places, I have moved it to the `test_api.py` and imported in the 
`test_files.py` and `test_observables.py`. 
   - The other mock response class has that does nothing been renamed to `MockResponseNoOp` to specify no-operation. This is also now defined in `test_api.py` and imported into `test_observable.py`.