### PR TITLE
Fix Thug never getting past the is_test check

### DIFF
--- a/api_app/script_analyzers/classes.py
+++ b/api_app/script_analyzers/classes.py
@@ -279,7 +279,7 @@ class DockerBasedAnalyzer(ABC):
         """
 
         # handle in case this is a test
-        if hasattr(self, "is_test"):
+        if hasattr(self, "is_test") and getattr(self, "is_test"):
             # only happens in case of testing
             self.report["success"] = True
             return {}


### PR DESCRIPTION
- The ThugUrl class would set the `is_test` argument to either True or False.
- The `_docker_run` function was only checking whether argument `is_test` is set or not.
- This resulted in the Thug analysers never being run, they always return the empty json array.

I added a simple merge request to also check to see if the `is_test` argument is set to True and it fixed the issue.