### PR TITLE
Add new analyzer

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/whoisxmlapi.py
+++ b/api_app/script_analyzers/observable_analyzers/whoisxmlapi.py
@@ -1,0 +1,30 @@
+import requests
+
+from api_app.exceptions import AnalyzerRunException
+from api_app.script_analyzers import classes
+from intel_owl import secrets
+
+class Whoisxmlapi(classes.ObservableAnalyzer):
+    url: str = "https://www.whoisxmlapi.com/whoisserver/WhoisService"
+
+    def set_config(self, additional_config_params):
+        self.api_key_name = additional_config_params.get(
+            "api_key_name", "WHOISXMLAPI_KEY"
+        )
+        self.__api_key = secrets.get_secret(self.api_key_name)
+
+    def run(self):
+        if not self.__api_key:
+            raise AnalyzerRunException(
+                f"No API key retrieved with name: {self.api_key_name}"
+            )
+
+        params = {
+            "apiKey": self.__api_key,
+            "domainName": self.observable_name,
+            "outputFormat": "JSON",
+        }
+        response = requests.get(self.url, params=params)
+        response.raise_for_status()
+
+        return response


### PR DESCRIPTION
#Thank for app!
It's a great app if I have it installed by default. However, I want to grow it up. I managed to successfully install on my Ubuntu. I read doc and know Intel Owl was designed to ease the addition of new analyzers.
I have tried the addition of new analyzers. I tried with Whoisxmlapi (https://whois.whoisxmlapi.com/). WHOIS API service provides the registration details, also known as the WHOIS record data, of a domain name, an IP address, or an email address.
I read doc (how-to-add-a-new-analyzer) and followed the instructions. New analyzer display when I run app, but It run fails when I search. Error display in web is:

    Scan Request Failed!
    server returned: Error in send_analysis_request.
    Check logs (500: Internal Server Error)

I delete code that I have tried the addition of new analyzers, then this app run successfully again. I don't know where I went wrong. I look forward to your help. 