### PR TITLE
add classic TokenAuth

### DIFF
--- a/.env
+++ b/.env
@@ -21,11 +21,12 @@ COMPOSE_FILE=docker-compose.yml
 # To run all additional integrations in development
 #COMPOSE_FILE=docker-compose-for-tests.yml:./integrations/docker-compose-for-tests.peframe.yml:./integrations/docker-compose-for-tests.thug.yml:./integrations/docker-compose-for-tests.capa.yml:./integrations/docker-compose-for-tests.boxjs.yml:./integrations/docker-compose-for-tests.apk.yml
 
-
 ###### For travis ######
 
 #COMPOSE_FILE=docker-compose-for-tests.yml:./integrations/docker-compose-for-tests.peframe.yml:./integrations/docker-compose-for-tests.thug.yml:./integrations/docker-compose-for-tests.capa.yml:./integrations/docker-compose-for-tests.boxjs.yml:./integrations/docker-compose-for-tests.apk.yml
 
+###### Add override file #####
+#:docker-compose-override.yml
 
 ##### Nginx Dockerfile for Tests
 DOCKERFILE_NGINX=Dockerfile_nginx

--- a/.flake8
+++ b/.flake8
@@ -10,4 +10,5 @@ exclude =
     venv,
     migrations,
     virtualenv,
-    ldap_config.py
+    ldap_config.py,
+    docs

--- a/intel_owl/settings.py
+++ b/intel_owl/settings.py
@@ -42,6 +42,7 @@ INSTALLED_APPS = [
     "django.contrib.staticfiles",
     "django.contrib.postgres",
     "rest_framework",
+    "rest_framework.authtoken",
     "rest_framework_simplejwt.token_blacklist",
     "guardian",
     "api_app.apps.ApiAppConfig",
@@ -84,6 +85,7 @@ REST_FRAMEWORK = {
     ],
     "DEFAULT_AUTHENTICATION_CLASSES": [
         "rest_framework_simplejwt.authentication.JWTAuthentication",
+        "rest_framework.authentication.TokenAuthentication",
     ],
     "DEFAULT_PERMISSION_CLASSES": ["rest_framework.permissions.IsAuthenticated"],
     "EXCEPTION_HANDLER": "rest_framework.views.exception_handler",

--- a/requirements.txt
+++ b/requirements.txt
@@ -75,7 +75,7 @@ vine==1.3.0
 wrapt==1.11.2
 yara-python==3.11.0
 zipp==0.6.0
-djangorestframework-simplejwt==4.4.0
+git+git://github.com/intelowlproject/django-rest-framework-simplejwt.git@patched_auth
 djangorestframework-guardian==0.3.0
 quark-engine==20.8
 git+git://github.com/DissectMalware/XLMMacroDeobfuscator.git@89fbce0c87014a4b5a22c1aef09c8b3ea9bf16c0


### PR DESCRIPTION
This is to support both authentication methods (JWT and simple Token)

However we already planned to move out from JWT completely and just keep the simple TokenAuth.

This is a intermediate PR that can be useful to maintain a state in the project where both are supported.