### PR TITLE
Added dnstwist analyzer

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/dnstwist.py
+++ b/api_app/script_analyzers/observable_analyzers/dnstwist.py
@@ -1,0 +1,61 @@
+import subprocess
+import json
+import logging
+from shutil import which
+
+from api_app.exceptions import AnalyzerRunException
+from api_app.script_analyzers import classes
+
+logger = logging.getLogger(__name__)
+
+
+class DNStwist(classes.ObservableAnalyzer):
+    command: str = "dnstwist"
+    dictionary_base_path: str = "/opt/deploy/dnstwist-dictionaries/"
+
+    def set_config(self, additional_config_params):
+        self._ssdeep = additional_config_params.get("ssdeep", False)
+        self._mxcheck = additional_config_params.get("mxcheck", False)
+        self._tld = additional_config_params.get("tld", False)
+        self._tld_dict = additional_config_params.get("tld_dict", "abused_tlds.dict")
+
+    def run(self):
+        if not which(self.command):
+            self.report["success"] = False
+            raise AnalyzerRunException("dnstwist not installed!")
+
+        args = [self.command, "--registered", "--format", "json"]
+        final_report = {}
+
+        if self._ssdeep:
+            args.append("--ssdeep")
+            final_report["ssdeep"] = True
+        if self._mxcheck:
+            args.append("--mxcheck")
+            final_report["mxcheck"] = True
+        if self._tld:
+            args.append("--tld")
+            final_report["tld"] = True
+            args.append(self.dictionary_base_path + self._tld_dict)
+
+        args.append(self.observable_name)
+
+        process = subprocess.Popen(
+            args,
+            stdout=subprocess.PIPE,
+            stderr=subprocess.PIPE,
+        )
+        stdout, stderr = process.communicate()
+        logger.warning(stderr.decode("utf-8"))
+        final_report["error"] = stderr.decode("utf-8")
+
+        dns_report = stdout.decode("utf-8"), stderr
+        dns_str = dns_report[0]
+
+        try:
+            data = json.loads(dns_str)
+            final_report["data"] = data
+        except ValueError as e:
+            raise AnalyzerRunException(e)
+
+        return final_report

--- a/api_app/script_analyzers/yara_repo_downloader.sh
+++ b/api_app/script_analyzers/yara_repo_downloader.sh
@@ -49,3 +49,6 @@ svn export https://github.com/quark-engine/quark-engine/tags/v20.08/quark/rules 
 
 # chown directories
 chown -R www-data:www-data /opt/deploy/yara /opt/deploy/quark-rules
+
+# Clone dictionaries for dnstwist analyzer
+svn export https://github.com/elceef/dnstwist/tags/20201022/dictionaries dnstwist-dictionaries

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -163,6 +163,18 @@
       "api_version": 2
     }
   },
+  "DNStwist": {
+    "type": "observable",
+    "observable_supported": [
+      "domain",
+      "url"
+    ],
+    "external_service": true,
+    "description": "scans for potentially malicious permutations of a domain name",
+    "python_module": "dnstwist.DNStwist",
+    "additional_config_params": {
+    }
+  },
   "Doc_Info": {
     "type": "file",
     "supported_filetypes": [

--- a/docs/source/Advanced-Usage.md
+++ b/docs/source/Advanced-Usage.md
@@ -81,6 +81,11 @@ List of some of the analyzers with optional configuration:
     * `time_first_before`, `time_first_after`, `time_last_before`, `time_last_after`
 * `*_DNS` (all DNS resolvers analyzers):
     * `query_type`: query type against the chosen DNS resolver, default is "A"
+* `DNStwist`:
+    * `ssdeep` (default False): enable fuzzy hashing - compare HTML content of original domain with a potentially malicious one and determine similarity.
+    * `mxcheck` (default False): find suspicious mail servers and flag them with SPYING-MX string.
+    * `tld` (default False): check for domains with different TLDs by supplying a dictionary file.
+    * `tld_dict` (default abused_tlds.dict): dictionary to use with tld argument. (common_tlds.dict/abused_tlds.dict)
 
 There are two ways to do this:
 

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -125,6 +125,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)
 * `Quad9`: Scan an observable against Quad9 DB
+* `DNStwist`: Scan a url/domain to find potentially malicious permutations via dns fuzzing. 
 
 #### [Additional analyzers](https://intelowl.readthedocs.io/en/develop/Advanced-Usage.html#optional-analyzers) that can be enabled per your wish.
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -86,3 +86,5 @@ black==20.8b1
 pre-commit==2.8.1
 django-memoize==2.3.1
 django-rest-durin==0.1.0
+dnstwist==20201022
+ppdeep>=20200505

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -32,6 +32,7 @@ from api_app.script_analyzers.observable_analyzers import (
     checkdmarc,
     urlscan,
     phishtank,
+    dnstwist,
 )
 from .mock_utils import (
     MockResponse,
@@ -387,6 +388,17 @@ class DomainAnalyzersTests(
             self.observable_name,
             self.observable_classification,
             {},
+        ).start()
+
+        self.assertEqual(report.get("success", False), True)
+
+    def test_dnstwist(self, mock_get=None, mock_post=None):
+        report = dnstwist.DNStwist(
+            "DNStwist",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {"tld": True, "mxcheck": True, "ssdeep": True},
         ).start()
 
         self.assertEqual(report.get("success", False), True)


### PR DESCRIPTION
2 main issues so far:

1. dnstwist is not able to find dictionaries as such (directly running `dnstwist` in shell. I had to clone their source repo (which has a dictionaries folder) and then run it from inside the folder to make it work. It needs absolute path to dictionary. I'm not sure where the dictionaries folder is, when the program is downloaded via PyPi. We might need to store the dictionaries separately.

2. Even though I implemented the `additional_config_params`, the approach could be better. Would like to know how I can make it better.