### PR TITLE
Fix max int problem

### DIFF
--- a/api_app/script_analyzers/classes.py
+++ b/api_app/script_analyzers/classes.py
@@ -69,6 +69,8 @@ class BaseAnalyzerMixin(metaclass=ABCMeta):
                 result[i] = self._validate_result(result[i])
         elif isinstance(result, str):
             return result.replace("\u0000", "")
+        elif isinstance(result, int) and result > 9223372036854775807:  # max int 8bytes
+            result = 9223372036854775807
         return result
 
     def start(self):


### PR DESCRIPTION
Some db (e.g. Mongo) are not able to store int over 8 bytes. 
Since we already made a recursive function to remove some invalid value for postgres, this PR try to overcome the issue described. I don't think that we are losing any information applying this patch.
 