### PR TITLE
query abuse.ch via google, to search also IP domain and urls

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -26,6 +26,8 @@ WORKDIR $PYTHONPATH
 RUN pip3 install --no-cache-dir --compile -r requirements.txt
 # install elasticsearch-dsl's appropriate version as specified by user
 RUN pip3 install --no-cache-dir django-elasticsearch-dsl==${ELASTICSEARCH_DSL_VERSION}
+# install google for mb_google
+RUN pip3 install --no-cache-dir google
 
 COPY . $PYTHONPATH
 

--- a/api_app/script_analyzers/observable_analyzers/mb_google.py
+++ b/api_app/script_analyzers/observable_analyzers/mb_google.py
@@ -1,0 +1,29 @@
+import googlesearch
+import json
+import requests
+
+from api_app.exceptions import AnalyzerRunException
+from api_app.script_analyzers import classes
+from api_app.script_analyzers.observable_analyzers import mb_get
+
+
+class MB_GOOGLE(classes.ObservableAnalyzer):
+    def run(self):
+        if self.observable_classification not in ["ip", "domain", "url"]:
+            raise AnalyzerRunException(
+                f"not supported observable type {self.observable_classification}."
+                f" Supported: ip, domain, url"
+            )
+
+        query = "{} site:bazaar.abuse.ch".format(self.observable_name)
+        ret = []
+        for url in googlesearch.search(query, stop=20):
+            mb_hash = url.split("/")[-2]
+            _mb_get = mb_get.MB_GET(
+                "MalwareBazaar_Google_Observable", self.job_id, mb_hash, "hash", {}
+            )
+            res = _mb_get.start()
+            ret.append(res)
+            del _mb_get
+
+        return ret

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -355,6 +355,18 @@
     "python_module": "ha_get.HybridAnalysisGet",
     "soft_time_limit": 30
   },
+  "IPInfo": {
+    "type": "observable",
+    "observable_supported": ["ip"],
+    "external_service": true,
+    "description": "Brief Information regarding given IP",
+    "requires_configuration": true,
+    "python_module": "ipinfo.IPInfo",
+    "additional_config_params": {
+      "api_key_name": "IPINFO_KEY"
+    },
+    "soft_time_limit": 30
+  },
   "IntelX_Phonebook": {
     "type": "observable",
     "observable_supported": [
@@ -384,18 +396,6 @@
     "requires_configuration": true,
     "python_module": "intezer_scan.IntezerScan",
     "soft_time_limit": 180
-  },
-  "IPInfo": {
-    "type": "observable",
-    "observable_supported": ["ip"],
-    "external_service": true,
-    "description": "Brief Information regarding given IP",
-    "requires_configuration": true,
-    "python_module": "ipinfo.IPInfo",
-    "additional_config_params": {
-      "api_key_name": "IPINFO_KEY"
-    },
-    "soft_time_limit": 30
   },
   "MISP": {
     "type": "observable",
@@ -469,6 +469,18 @@
     "external_service": true,
     "description": "Check if a particular malware hash is known to MalwareBazaar",
     "python_module": "mb_get.MB_GET",
+    "soft_time_limit": 50
+  },
+  "MalwareBazaar_Google_Observable": {
+    "type": "observable",
+    "observable_supported": [
+      "ip",
+      "domain",
+      "url"
+    ],
+    "external_service": true,
+    "description": "Check if a particular IP, domain or url is known to MalwareBazaar using google search",
+    "python_module": "mb_google.MB_GOOGLE",
     "soft_time_limit": 50
   },
   "MaxMindGeoIP": {
@@ -1165,7 +1177,7 @@
         "/opt/deploy/yara/stratosphere_rules/protocols"
       ]
     }
-  },
+  }
   "ZoomEye": {
     "type": "observable",
     "observable_supported": ["ip", "domain"],

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -24,6 +24,7 @@ from api_app.script_analyzers.observable_analyzers import (
     honeydb,
     hunter,
     mb_get,
+    mb_google,
     threatminer,
     auth0,
     securitytrails,
@@ -527,6 +528,16 @@ class HashAnalyzersTests(
     def test_mb_get(self, mock_get=None, mock_post=None):
         report = mb_get.MB_GET(
             "MalwareBazaar_Get_Observable",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    def test_mb_google(self, mock_get=None, mock_post=None):
+        report = mb_google.MB_GOOGLE(
+            "MalwareBazaar_Google_Observable",
             self.job_id,
             self.observable_name,
             self.observable_classification,


### PR DESCRIPTION
abuse.ch API/search doesn't support lookup of IP addresse, domain or url.
using mb_google analyzer added with this PR it's now possible to use google search to achieve a similar result