### PR TITLE
Upgraded yara to 4.0.2

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -74,7 +74,7 @@ urllib3==1.25.3
 uWSGI==2.0.18
 vine==1.3.0
 wrapt==1.11.2
-yara-python==3.11.0
+yara-python==4.0.2
 zipp==0.6.0
 djangorestframework-guardian==0.3.0
 quark-engine==20.8


### PR DESCRIPTION
Checked if the internal error 30 is raised. [The error 30 means too many matches](https://github.com/VirusTotal/yara/blob/2289bbabb539045d18200a5d7c49fca6e4866d06/libyara/include/yara/error.h#L75), but it is not possible to attach a callback to check which match triggers. Or at least I wasn't able to.