### PR TITLE
Added triage observable analyzer

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/triage_search.py
+++ b/api_app/script_analyzers/observable_analyzers/triage_search.py
@@ -1,0 +1,115 @@
+import time
+import logging
+import requests
+
+from api_app.exceptions import AnalyzerRunException, AnalyzerConfigurationException
+from api_app.script_analyzers import classes
+from intel_owl import secrets
+
+
+logger = logging.getLogger(__name__)
+
+
+class TriageSearch(classes.ObservableAnalyzer):
+    # using public endpoint as the default url
+    base_url: str = "https://api.tria.ge/v0/"
+    private_url: str = "https://private.tria.ge/api/v0/"
+
+    def set_config(self, additional_config_params):
+        self.endpoint = additional_config_params.get("endpoint", "public")
+        if self.endpoint == "private":
+            self.base_url = self.private_url
+
+        self.api_key_name = additional_config_params.get("api_key_name", "TRIAGE_KEY")
+        self.__api_key = secrets.get_secret(self.api_key_name)
+        self.analysis_type = additional_config_params.get("analysis_type", "search")
+        self.report_type = additional_config_params.get("report_type", "overview")
+        self.max_tries = additional_config_params.get("max_tries", 200)
+        self.poll_distance = 5
+
+    def run(self):
+        if not self.__api_key:
+            raise AnalyzerRunException(
+                f"No API key retrieved with name: {self.api_key_name}"
+            )
+
+        self.session = requests.Session()
+        self.session.headers = {"Authorization": f"Bearer {self.__api_key}"}
+
+        response = None
+        if self.analysis_type == "search":
+            response = self.__triage_search()
+        elif self.analysis_type == "submit":
+            response = self.__triage_submit()
+        else:
+            raise AnalyzerConfigurationException(
+                f"analysis type '{self.analysis_type}' not supported."
+                "Supported are: 'search', 'submit'."
+            )
+
+        return response
+
+    def __triage_search(self):
+        if self.observable_classification == "hash":
+            params = {"query": self.observable_name}
+        else:
+            params = {
+                "query": f"{self.observable_classification}:{self.observable_name}"
+            }
+
+        response = self.session.get(self.base_url + "search", params=params)
+
+        return response.json()
+
+    def __triage_submit(self):
+        final_report = {}
+        data = {"kind": "url", "url": f"{self.observable_name}"}
+
+        logger.info(f"triage {self.observable_name} sending sample for analysis")
+        for _try in range(self.max_tries):
+            logger.info(
+                f"triage {self.observable_name} polling for result try #{_try + 1}"
+            )
+            response = self.session.post(self.base_url + "samples", json=data)
+            if response.status_code == 200:
+                break
+            time.sleep(self.poll_distance)
+
+        if response.status_code != 200:
+            raise AnalyzerRunException("max retry attempts exceeded")
+
+        sample_id = response.json().get("id", None)
+        if sample_id is None:
+            raise AnalyzerRunException("error sending sample")
+
+        self.session.get(self.base_url + f"samples/{sample_id}/events")
+
+        if self.report_type == "overview" or self.report_type == "complete":
+            final_report["overview"] = self.get_overview_report(sample_id)
+
+        if self.report_type == "complete":
+            final_report["static_report"] = self.get_static_report(sample_id)
+
+            final_report["task_report"] = {}
+            for task in final_report["overview"]["tasks"].keys():
+                status_code, task_report_json = self.get_task_report(sample_id, task)
+                if status_code == 200:
+                    final_report["task_report"][f"{task}"] = task_report_json
+
+        return final_report
+
+    def get_overview_report(self, sample_id):
+        overview = self.session.get(
+            self.base_url + f"samples/{sample_id}/overview.json"
+        )
+        return overview.json()
+
+    def get_static_report(self, sample_id):
+        static = self.session.get(self.base_url + f"samples/{sample_id}/reports/static")
+        return static.json()
+
+    def get_task_report(self, sample_id, task):
+        task_report = self.session.get(
+            self.base_url + f"samples/{sample_id}/{task}/report_triage.json"
+        )
+        return (task_report.status_code, task_report.json())

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -994,6 +994,24 @@
     "python_module": "tor.Tor",
     "soft_time_limit": 30
   },
+  "Triage_Search": {
+    "type": "observable",
+    "observable_supported": [
+      "url",
+      "hash"
+    ],
+    "description": "analyze a url sample using triage sandbox environment",
+    "python_module": "triage_search.TriageSearch",
+    "requires_configuration": true,
+    "external_service": true,
+    "additional_config_params": {
+      "api_key_name": "TRIAGE_KEY",
+      "endpoint": "public",
+      "analysis_type": "search",
+      "report_type": "overview"
+    },
+    "soft_time_limit": 300
+  },
   "Triage_Scan": {
     "type": "file",
     "description": "leverage Triage sandbox environment to scan various files",
@@ -1003,9 +1021,9 @@
     "additional_config_params": {
       "api_key_name": "TRIAGE_KEY",
       "endpoint": "public",
-      "report_type": "overview",
-      "soft_time_limit": 300
+      "report_type": "overview"
     },
+    "soft_time_limit": 300,
     "queue": "long"
   },
   "UnpacMe_EXE_Unpacker": {

--- a/docs/source/Advanced-Usage.md
+++ b/docs/source/Advanced-Usage.md
@@ -94,7 +94,12 @@ List of some of the analyzers with optional configuration:
   * `query`: Follow according to [docs](https://www.zoomeye.org/doc#host-search), but omit `ip`, `hostname`. Eg: `"query": "city:biejing port:21"`
   * `facets`(default: Empty string): A comma-separated list of properties to get summary information on query. Eg: `"facets:app,os"`
   * `page`(default 1): The page number to paging
-  * `history`(default True):  	To query the history data. 
+  * `history`(default True):  	To query the history data.
+* `Triage_Scan` and `Triage_Search`:
+  * `endpoint` (default public): choose whether to query on the public or the private endpoint of triage.
+  * `report_type` (default overview): determines how detailed the final report will be. (overview/complete)
+* `Triage_Search`:
+  * `analysis_type` (default search): choose whether to search for existing observable reports or upload for scanning via URL. (search/submit)
 
 There are two ways to do this:
 

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -94,6 +94,7 @@ Optional variables needed to enable specific analyzers:
 * `UNPAC_ME_API_KEY`: UnpacMe API ([docs](https://api.unpac.me/))
 * `IPINFO_KEY`: ipinfo API key
 * `ZOOMEYE_KEY`: ZoomEye API Key([docs](https://www.zoomeye.org/doc))
+* `TRIAGE_KEY`: tria.ge API key([docs](https://tria.ge/docs/))
 
 Advanced additional configuration:
 * `OLD_JOBS_RETENTION_DAYS`: Database retention, default 3 days. Change this if you want to keep your old analysis longer in the database.

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -137,6 +137,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * `DNStwist`: Scan a url/domain to find potentially malicious permutations via dns fuzzing. [dnstwist repo](https://github.com/elceef/dnstwist) 
 * `IPInfo`: Location Information about an IP
 * `Zoomeye`: [Zoomeye](https://www.zoomeye.org) Cyberspace Search Engine recording information of devices, websites, services and components etc..
+* `Triage_Search`: Search for reports of observables or upload from URL on triage cloud
 
 #### Generic analyzers (email, phone number, ...)
 * `EmailRep`: search an email address on emailrep.io

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -38,6 +38,7 @@ from api_app.script_analyzers.observable_analyzers import (
     dnstwist,
     zoomeye,
     emailrep,
+    triage_search,
 )
 from api_app.models import Job
 from .mock_utils import (
@@ -80,6 +81,14 @@ def mocked_dnsdb_v2_request(*args, **kwargs):
         '"rdata":"0.0.0.0"}}\n'
         '{"cond":"limited","msg":"Result limit reached"}\n',
     )
+
+
+def mocked_triage_get(*args, **kwargs):
+    return MockResponse({"tasks": {"task_1": {}, "task_2": {}}, "data": []}, 200)
+
+
+def mocked_triage_post(*args, **kwargs):
+    return MockResponse({"id": "sample_id", "status": "pending"}, 200)
 
 
 @mock_connections(patch("requests.get", side_effect=mocked_requests))
@@ -519,6 +528,30 @@ class URLAnalyzersTests(
         ).start()
         self.assertEqual(report.get("success", False), True)
 
+    @mock_connections(patch("requests.Session.get", side_effect=mocked_triage_get))
+    @mock_connections(patch("requests.Session.post", side_effect=mocked_triage_post))
+    def test_triage_search(self, *args):
+        report = triage_search.TriageSearch(
+            "Triage_Search",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    @mock_connections(patch("requests.Session.get", side_effect=mocked_triage_get))
+    @mock_connections(patch("requests.Session.post", side_effect=mocked_triage_post))
+    def test_triage_submit(self, *args):
+        report = triage_search.TriageSearch(
+            "Triage_Search",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {"analysis_type": "submit"},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
 
 @mock_connections(patch("requests.get", side_effect=mocked_requests))
 @mock_connections(patch("requests.post", side_effect=mocked_requests))
@@ -551,6 +584,18 @@ class HashAnalyzersTests(
     def test_cymru_get(self, mock_get=None, mock_post=None):
         report = cymru.Cymru(
             "Cymru_Hash_Registry_Get_Observable",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    @mock_connections(patch("requests.Session.get", side_effect=mocked_triage_get))
+    @mock_connections(patch("requests.Session.post", side_effect=mocked_triage_post))
+    def test_triage_search(self, *args):
+        report = triage_search.TriageSearch(
+            "Triage_Search",
             self.job_id,
             self.observable_name,
             self.observable_classification,


### PR DESCRIPTION
# Description

Added triage analyzer for scanning observables - searching through existing reports via URL or Hash query; or submitting a sample for analysis via a URL. Also added documentation for both triage observable and file analyzers.

## Fixes
closes #142 

## Type of change
- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] The pull request is for the branch develop
- [x] I changed the file [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) and [ReadMe](https://github.com/intelowlproject/IntelOwl/blob/master/README.md) if I added a new analyzer. 
- [x] I have added tests in the [Tests](https://github.com/intelowlproject/IntelOwl/blob/master/tests) folder. 
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.

# Real World Example
1. `submit` config paramenter - submitting file via url (similar report generated as triage file analyzer)
![image](https://user-images.githubusercontent.com/17424778/101536522-214b0200-39c0-11eb-9234-c1d75282777d.png)

2. `search` config parameter - searching for reports via hash.
![image](https://user-images.githubusercontent.com/17424778/101537670-e944be80-39c1-11eb-98f1-16b2a9f17e06.png)
50 results (default) (max 200) in same format as above followed by a `next` key. I haven't implemented pagination using `next` as of now. A bit confused on how to go about it since next contains a date-time stamp of sorts. 
![image](https://user-images.githubusercontent.com/17424778/101537783-142f1280-39c2-11eb-8686-d761e1f3517f.png)

3. `search` config parameter - searching for reports via URL.
I couldn't find a good example of this (a malicious url) but report should be similar to the hash case.