### PR TITLE
Added project name to start.py

### DIFF
--- a/start.py
+++ b/start.py
@@ -119,7 +119,7 @@ def start(
                 for analyzer in path_mapping["all_analyzers" + test_appendix]
             ]
         )
-
+    command += " -p intel_owl"
     command += " " + docker_command
 
     try:


### PR DESCRIPTION
# Description

The name of the project during the docker build is the base directory. Since we moved the docker files inside /docker, now the project name is wrong.

Please include a summary of the change.

## Fixes
Please add related issues.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] The pull request is for the branch develop
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.
