### PR TITLE
Fix log directory with docker integrations

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -8,9 +8,8 @@ ENV ELASTICSEARCH_DSL_VERSION 7.1.4
 ENV watch_logs_cmd "watch -n1 tail -n10 /var/log/intel_owl/django/api_app.log"
 
 RUN mkdir -p ${LOG_PATH} \
-    ${LOG_PATH}/django ${LOG_PATH}/uwsgi \
-    ${LOG_PATH}/thug ${LOG_PATH}/static_analyzers ${LOG_PATH}/box-js \
-    ${LOG_PATH}/apk_analyzers \
+    ${LOG_PATH}/django \
+    ${LOG_PATH}/uwsgi \
     /opt/deploy/files_required /opt/deploy/yara /opt/deploy/configuration
 
 RUN apt-get update \

--- a/integrations/apk_analyzers/entrypoint.sh
+++ b/integrations/apk_analyzers/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+mkdir -p ${LOG_PATH}
 touch ${LOG_PATH}/gunicorn_access.log ${LOG_PATH}/gunicorn_errors.log
 chown -R apk-user:apk-user ${LOG_PATH}
 su apk-user -s /bin/bash

--- a/integrations/box-js/entrypoint.sh
+++ b/integrations/box-js/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+mkdir -p ${LOG_PATH}
 touch ${LOG_PATH}/gunicorn_access.log ${LOG_PATH}/gunicorn_errors.log
 chown -R boxjs-user:boxjs-user ${LOG_PATH}
 su boxjs-user -s /bin/sh

--- a/integrations/static_analyzers/entrypoint.sh
+++ b/integrations/static_analyzers/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+mkdir -p ${LOG_PATH}
 touch ${LOG_PATH}/gunicorn_access.log ${LOG_PATH}/gunicorn_errors.log
 chown -R static_analyzers-user:static_analyzers-user ${LOG_PATH}
 su static_analyzers-user -s /bin/bash

--- a/integrations/thug/entrypoint.sh
+++ b/integrations/thug/entrypoint.sh
@@ -1,5 +1,5 @@
 #!/bin/sh
-
+mkdir -p ${LOG_PATH}
 touch ${LOG_PATH}/gunicorn_access.log ${LOG_PATH}/gunicorn_errors.log
 chown -R thug:thug ${LOG_PATH}
 su thug -s /bin/bash


### PR DESCRIPTION
# Description
I can't wrap my head around on why it happens but creating the log directories for the analyzers_integration inside the Dockerfile it is not effective. I think that this happens because we are attaching there a volume in the docker-compose file, but I'm not sure about the motivation. Nevertheless, we had `No such file or directory` happening. The solution that I provide is to force the creation of the log directory *inside* each entrypoint of each integration. Moreover, I think is cleaner to remove the creation of directories that the user may not use from the main Dockerfile.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

## Steps to reproduce
- Run IntelOwl
- Delete directory /var/log/intel_owl/static_analyzer
- Build and run again intelowl
-  ![image](https://user-images.githubusercontent.com/30528879/102498328-1b1ceb80-407a-11eb-9f8c-fe4b6f0f2e9a.png)
 

## Checklist

- [x] The pull request is for the branch develop
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.

