### PR TITLE
Fix docker env multi queue

### DIFF
--- a/docker/multi-queue.override.yml
+++ b/docker/multi-queue.override.yml
@@ -3,7 +3,7 @@ version: '3'
 services:
   uwsgi:
     environment:
-      - CELERY_QUEUES="default,local,long"
+      - CELERY_QUEUES=default,local,long
 
 
   celery_worker_local:


### PR DESCRIPTION
# Description
Bash environ variables does not want double quote

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] The pull request is for the branch develop
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.
