### PR TITLE
Fix strings_info.py

### DIFF
--- a/api_app/script_analyzers/file_analyzers/strings_info.py
+++ b/api_app/script_analyzers/file_analyzers/strings_info.py
@@ -38,7 +38,9 @@ class StringsInfo(FileAnalyzer, DockerBasedAnalyzer):
         }
         req_files = {fname: binary}
         result = self._docker_run(req_data, req_files)
-
+        exceed_max_strings = len(result) > self.max_no_of_strings
+        if exceed_max_strings:
+            result = [s for s in result[: self.max_no_of_strings]]
         if self.rank_strings:
             args = [
                 "rank_strings",
@@ -49,11 +51,8 @@ class StringsInfo(FileAnalyzer, DockerBasedAnalyzer):
             ]
             req_data = {"args": args, "timeout": self.timeout}
             result = self._docker_run(req_data)
-            result = {"data": result, "exceeded_max_number_of_strings": False}
-        elif len(result) > self.max_no_of_strings:
-            result = [s for s in result[: self.max_no_of_strings]]
-            result = {"data": result, "exceeded_max_number_of_strings": True}
-        result["data"] = [
-            row[: self.max_chars_for_string] for row in result.get("data", [])
-        ]
+        result = {
+            "data": [row[: self.max_chars_for_string] for row in result],
+            "exceeded_max_number_of_strings": exceed_max_strings,
+        }
         return result

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -878,6 +878,16 @@
     "soft_time_limit": 30,
     "queue": "local"
   },
+  "SpeakEasy": {
+    "type": "file",
+    "supported_filetypes": [
+      "application/x-dosexec"
+    ],
+    "description": "speakeasy emulation report",
+    "python_module": "speakeasy_emulation.SpeakEasy",
+    "soft_time_limit": 120,
+    "queue": "long"
+  },
   "Strings_Info_Classic": {
     "type": "file",
     "description": "strings extraction",
@@ -888,16 +898,6 @@
     },
     "soft_time_limit": 70,
     "queue": "local"
-  },
-  "SpeakEasy": {
-    "type": "file",
-    "supported_filetypes": [
-      "application/x-dosexec"
-    ],
-    "description": "speakeasy emulation report",
-    "python_module": "speakeasy_emulation.SpeakEasy",
-    "soft_time_limit": 120,
-    "queue": "long"
   },
   "Strings_Info_ML": {
     "type": "file",


### PR DESCRIPTION
# Description
We had two cases that were not checked:
- If too many strings are sent to `Strings_info_ml`, the program crashes. So we check them
- If self.rank_strings==False AND len(result) < self.max_no_of_strings, result is still a list. Meaning that result.get("data", []) will crash the analyzer.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] The pull request is for the branch develop
- [ ] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.

# Real World Example
![image](https://user-images.githubusercontent.com/30528879/102785472-541ccf00-439e-11eb-9dd8-98ae70f33740.png)
![image](https://user-images.githubusercontent.com/30528879/102785490-5e3ecd80-439e-11eb-9da9-a446a43cb2ee.png)
