### PR TITLE
Add new api to kill ongoing job

### DIFF
--- a/api_app/api.py
+++ b/api_app/api.py
@@ -459,7 +459,7 @@ def kill_running_job(request):
             )
         # close celery tasks
         task_ids = cache.get(data_received["job_id"])
-        if isinstance(task_ids, list) and len(task_ids):
+        if isinstance(task_ids, list):
             celery_app.control.revoke(task_ids)
             cache.delete((data_received["job_id"]))
         # set job status

--- a/api_app/api.py
+++ b/api_app/api.py
@@ -3,13 +3,11 @@ import logging
 from api_app import models, serializers, helpers
 from api_app.permissions import ExtendedObjectPermissions
 from .script_analyzers import general
-from intel_owl.celery import app as celery_app
 
 from wsgiref.util import FileWrapper
 
 from django.http import HttpResponse
 from django.db.models import Q
-from django.core.cache import cache
 from rest_framework.response import Response
 from rest_framework import status, viewsets, mixins
 from rest_framework.decorators import api_view
@@ -458,10 +456,7 @@ def kill_running_job(request):
                 status=status.HTTP_400_BAD_REQUEST,
             )
         # close celery tasks
-        task_ids = cache.get(data_received["job_id"])
-        if isinstance(task_ids, list):
-            celery_app.control.revoke(task_ids)
-            cache.delete((data_received["job_id"]))
+        general.kill_running_analysis(data_received["job_id"])
         # set job status
         job.status = "killed"
         job.save()

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -16,6 +16,7 @@ STATUS = [
     ("reported_without_fails", "reported_without_fails"),
     ("reported_with_fails", "reported_with_fails"),
     ("failed", "failed"),
+    ("killed", "killed"),
 ]
 
 

--- a/api_app/script_analyzers/general.py
+++ b/api_app/script_analyzers/general.py
@@ -4,7 +4,6 @@ from django.core.cache import cache
 
 
 from intel_owl.celery import app as celery_app
-from intel_owl import tasks
 from api_app.exceptions import (
     AnalyzerConfigurationException,
     AnalyzerRunException,
@@ -109,8 +108,12 @@ def start_analyzers(
             # run analyzer with a celery task asynchronously
             stl = ac.get("soft_time_limit", 300)
             t_id = uuid()
-            tasks.run_analyzer.apply_async(
-                args=args, queue=queue, soft_time_limit=stl, task_id=t_id
+            celery_app.send_task(
+                "run_analyzer",
+                args=args,
+                queue=queue,
+                soft_time_limit=stl,
+                task_id=t_id,
             )
             # to track task_id by job_id
             task_ids = cache.get(job_id)

--- a/api_app/signal_handlers.py
+++ b/api_app/signal_handlers.py
@@ -17,9 +17,10 @@ def save_profile(sender, instance, created, **kwargs):
     if created:
         grp, grp_created = Group.objects.get_or_create(name="DefaultGlobal")
         if grp_created:
-            # view/add/delete permissions for Job model
+            # view/add/change/delete permissions for Job model
             assign_perm("api_app.view_job", grp)
             assign_perm("api_app.add_job", grp)
+            assign_perm("api_app.change_job", grp)
             assign_perm("api_app.delete_job", grp)
             # view/add/change permissions for Tag model
             assign_perm("api_app.view_tag", grp)

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -31,7 +31,7 @@ urlpatterns = [
     path("ask_analysis_result", ask_analysis_result),
     path("get_analyzer_configs", get_analyzer_configs),
     path("download_sample", download_sample),
-    path("job/kill/", kill_running_job),
+    path("kill_analysis", kill_running_job),
     # Viewsets
     path(r"", include(router.urls)),
 ]

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -7,6 +7,7 @@ from .api import (
     ask_analysis_result,
     get_analyzer_configs,
     download_sample,
+    kill_running_job,
     TagViewSet,
     JobViewSet,
 )
@@ -30,6 +31,7 @@ urlpatterns = [
     path("ask_analysis_result", ask_analysis_result),
     path("get_analyzer_configs", get_analyzer_configs),
     path("download_sample", download_sample),
+    path("job/kill/", kill_running_job),
     # Viewsets
     path(r"", include(router.urls)),
 ]


### PR DESCRIPTION
Signed-off-by: Shubham Pandey <shubhampcpandey13@gmail.com>
Fixes #225 by @Eshaan7 

# Description
This PR adds a new API `kill_running_job` which would receive job_id as a parameter and revoke the running celery tasks associated with it. Once this is done, the job's status is set `killed`.

Note: The task ids are stored in cache once the task is set, in `start_analyzers` function.

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] The pull request is for the branch develop
- [ ] I have added tests in the [Tests](https://github.com/intelowlproject/IntelOwl/blob/master/tests) folder. 
- [ ] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one.
  
# Real World Example
![image](https://user-images.githubusercontent.com/51958314/107865550-a4d81200-6e8d-11eb-8257-9f69b9ca30ad.png)
Here the job was killed before all the tasks could run.