### PR TITLE
chore: change url format for kill job to jobs/{job_id}/kill

### DIFF
--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -7,7 +7,6 @@ from .api import (
     ask_analysis_result,
     get_analyzer_configs,
     download_sample,
-    kill_running_job,
     TagViewSet,
     JobViewSet,
 )
@@ -31,7 +30,6 @@ urlpatterns = [
     path("ask_analysis_result", ask_analysis_result),
     path("get_analyzer_configs", get_analyzer_configs),
     path("download_sample", download_sample),
-    path("kill_analysis", kill_running_job),
     # Viewsets
     path(r"", include(router.urls)),
 ]


### PR DESCRIPTION
# Description
This modifies the `kill api view` to use `@action` decorator under `JobViewSet`.
The URL would change to ` /api/jobs/{job_id}/kill`  from `/api/kill_running_analysis?job_id`.
Asked by @Eshaan7 

## Related issues
#225

# Checklist

- [x] The pull request is for the branch develop.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.
