### PR TITLE
Updated Installation.md

### DIFF
--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -21,7 +21,7 @@ cd ..
 python start.py prod up
 
 # create a super user 
-docker exec -ti intelowl_uwsgi python3 manage.py createsuperuser
+docker exec -ti intel_owl_uwsgi python3 manage.py createsuperuser
 
 # now the app is running on http://localhost:80
 ```


### PR DESCRIPTION
# Description

Should be `intel_owl_uwsgi` instead of `intelowl_uwsgi` according to the name of the containers that start up.

## Related issues
NA

## Type of change

- [x] Updating documentation
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] The pull request is for the branch develop 
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.
 
# Real World Example

`intel_owl_uwsgi` container is created when starting the application.
![image](https://user-images.githubusercontent.com/17424778/110640619-06627680-81d7-11eb-86ef-f65d9c945636.png)

Following the steps of the current documentation, a superuser is created with the command:
```
docker exec -ti intelowl_uwsgi python3 manage.py createsuperuser
```
which yields the error
![image](https://user-images.githubusercontent.com/17424778/110640987-77a22980-81d7-11eb-9368-630aa3f7e04b.png)

Performing the suggested change fixes it
![image](https://user-images.githubusercontent.com/17424778/110641119-9ef8f680-81d7-11eb-92c2-1898568ece96.png)


