### PR TITLE
added Greynoise community API analyzer and disabled old Greynoise Alp…

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/greynoise.py
+++ b/api_app/script_analyzers/observable_analyzers/greynoise.py
@@ -9,7 +9,7 @@ class GreyNoise(classes.ObservableAnalyzer):
     base_url: str = "https://api.greynoise.io"
 
     def set_config(self, additional_config_params):
-        self.api_version = additional_config_params.get("greynoise_api_version", "v1")
+        self.api_version = additional_config_params.get("greynoise_api_version", "v3")
         self.api_key_name = additional_config_params.get(
             "api_key_name", "GREYNOISE_API_KEY"
         )
@@ -22,21 +22,33 @@ class GreyNoise(classes.ObservableAnalyzer):
             url = f"{self.base_url}/v1/query/ip"
             headers = {"Content-Type": "application/x-www-form-urlencoded"}
             data = {"ip": self.observable_name}
-
             response = requests.post(url, data=data, headers=headers)
             response.raise_for_status()
+
         elif self.api_version == "v2":
             url = f"{self.base_url}/v2/noise/context/{self.observable_name}"
-
             api_key = secrets.get_secret(self.api_key_name)
             if not api_key:
                 raise AnalyzerRunException(f"{self.api_key_name} not specified.")
             headers = {"Accept": "application/json", "key": api_key}
             response = requests.get(url, headers=headers)
             response.raise_for_status()
+
+        elif self.api_version == "v3":
+            url = f"{self.base_url}/v3/community/{self.observable_name}"
+            headers = {"Accept": "application/json"}
+            # optional usage of API key
+            api_key = secrets.get_secret(self.api_key_name)
+            if api_key:
+                headers["key"] = api_key
+            response = requests.get(url, headers=headers)
+            if response.status_code != 404:
+                response.raise_for_status()
+
         else:
             raise AnalyzerRunException(
-                "Invalid API Version. Supported are: v1 (free) & v2 (paid)."
+                "Invalid API Version. "
+                "Supported are: v1 (alpha), v2 (paid), v3 (community)"
             )
 
         result = response.json()

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -338,12 +338,26 @@
     },
     "soft_time_limit": 30
   },
+  "GreyNoiseCommunity": {
+    "type": "observable",
+    "observable_supported": [
+      "ip"
+    ],
+    "external_service": true,
+    "description": "scan an IP against the Community Greynoise API",
+    "python_module": "greynoise.GreyNoise",
+    "additional_config_params": {
+      "greynoise_api_version": "v3"
+    },
+    "soft_time_limit": 30
+  },
   "GreyNoiseAlpha": {
     "type": "observable",
     "observable_supported": [
       "ip"
     ],
     "external_service": true,
+    "disabled": true,
     "description": "scan an IP against the Alpha Greynoise API (no API key required)",
     "python_module": "greynoise.GreyNoise",
     "additional_config_params": {

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -92,7 +92,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * `Robtex_IP_Query`: get IP info from Robtex
 * `GoogleSafebrowsing`: Scan an observable against GoogleSafeBrowsing DB
 * `GoogleWebRisk`: Scan an observable against WebRisk API (Commercial version of Google Safe Browsing). Check the [docs]((https://intelowl.readthedocs.io/en/develop/Advanced-Usage.html#analyzers-with-special-configuration)) to enable this properly
-* `GreyNoiseAlpha`: scan an IP against the Alpha Greynoise API (no API key required)
+* `GreyNoiseCommunity`: scan an IP against the Community Greynoise API (no API key required)
 * `GreyNoise`: scan an IP against the Greynoise API (requires API key)
 * `CIRCLPassiveDNS`: scan an observable against the CIRCL Passive DNS DB
 * `CIRCLPassiveSSL`: scan an observable against the CIRCL Passive SSL DB

--- a/tests/test_api.py
+++ b/tests/test_api.py
@@ -155,7 +155,7 @@ class ApiViewTests(TestCase):
             "Shodan_Honeyscore",
             "MaxMindGeoIP",
             "CIRCLPassiveSSL",
-            "GreyNoiseAlpha",
+            "GreyNoiseCommunity",
             "GreyNoise",
             "GoogleSafebrowsing",
             "Robtex_IP_Query",

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -230,13 +230,23 @@ class IPAnalyzersTests(
         ).start()
         self.assertEqual(report.get("success", False), True)
 
-    def test_greynoisealpha(self, mock_get=None, mock_post=None):
+    def test_greynoise_alpha(self, mock_get=None, mock_post=None):
         report = greynoise.GreyNoise(
             "GreyNoiseAlpha",
             self.job_id,
             self.observable_name,
             self.observable_classification,
-            {},
+            {"greynoise_api_version": "v1"},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    def test_greynoise_community(self, mock_get=None, mock_post=None):
+        report = greynoise.GreyNoise(
+            "GreyNoiseCommunity",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {"greynoise_api_version": "v3"},
         ).start()
         self.assertEqual(report.get("success", False), True)
 
@@ -246,7 +256,7 @@ class IPAnalyzersTests(
             self.job_id,
             self.observable_name,
             self.observable_classification,
-            {},
+            {"greynoise_api_version": "v2"},
         ).start()
         self.assertEqual(report.get("success", False), True)
 


### PR DESCRIPTION
# Description

added Greynoise community API analyzer and disabled old Greynoise Alpha analyzer

## Related issues
closes #380 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] The pull request is for the branch develop
- [x] If I added a new analyzer, I updated the file [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md). If the analyzer provides additional optional configuration, I added the available options here: [Advanced-Usage](./Advanced-Usage.md)
- [x] If I added external libraries/packages that use restrictive licenses, please add them in the [ReadMe - Legal Notice](https://github.com/certego/IntelOwl/blob/master/README.md) section
- [x] I added new secrets in the files [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/env_file_app_travis) and in the docs: [Installation](./Installation.md)
- [x] I have added tests in the [Tests](https://github.com/intelowlproject/IntelOwl/blob/master/tests) folder. 
- [ ] The tests gave 0 errors.
- [ ] `Black` gave 0 errors.
- [ ] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one.
  
### please follow these rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review

# Real World Example

Please delete if the PR is for bug fixing.
Otherwise, please provide the resulting raw JSON of a finished analysis (and, if you like, a screenshot of the results). This is to allow the maintainers to understand how the analyzer works.
