### PR TITLE
[Fixes #348] Add ThreatFox analyzer

### DIFF
--- a/api_app/script_analyzers/observable_analyzers/threatfox.py
+++ b/api_app/script_analyzers/observable_analyzers/threatfox.py
@@ -1,0 +1,24 @@
+import requests
+import json
+
+from api_app.exceptions import AnalyzerRunException
+from api_app.script_analyzers import classes
+
+
+class ThreatFox(classes.ObservableAnalyzer):
+    base_url: str = "https://threatfox-api.abuse.ch/api/v1/"
+
+    def run(self):
+        payload = {
+            "query": "search_ioc",
+        }
+
+        try:
+            payload["search_term"] = self.observable_name
+            response = requests.post(self.base_url, data=json.dumps(payload))
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AnalyzerRunException(e)
+
+        result = response.json()
+        return result

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1089,6 +1089,14 @@
     "python_module": "talos.Talos",
     "soft_time_limit": 30
   },
+  "ThreatFox": {
+    "type": "observable",
+    "observable_supported": ["ip", "url", "domain", "hash", "generic"],
+    "external_service": true,
+    "description": "search for an IOC in ThreatFox's database",
+    "python_module": "threatfox.ThreatFox",
+    "soft_time_limit": 30
+  },
   "Threatminer_PDNS": {
     "type": "observable",
     "observable_supported": [

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -149,6 +149,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * `Renderton`: get screenshot of a web page using rendertron (puppeteer) [renderton repo](https://github.com/GoogleChrome/rendertron)
 * `SSAPINet`: get a screenshot of a web page using [screenshotapi.net](https://screenshotapi.net/) (external source); additional config options can be added to `extra_api_params` [in the config](https://github.com/intelowlproject/IntelOwl/blob/master/configuration/analyzer_config.json).
 * `FireHol_IPList`: check if an IP is in [FireHol's IPList](https://iplists.firehol.org/)
+* `ThreatFox`: search for an IOC in [ThreatFox](https://threatfox.abuse.ch/api/)'s database
 
 #### Generic analyzers (email, phone number, ...)
 Some Analyzers require details other than just IP, URL, Domain etc... We classified them as Generic Analyzers. Since the type of field is not known, there is a format for strings to be followed.

--- a/tests/test_observables.py
+++ b/tests/test_observables.py
@@ -45,6 +45,7 @@ from api_app.script_analyzers.observable_analyzers import (
     rendertron,
     ss_api_net,
     firehol_iplist,
+    threatfox,
 )
 from api_app.models import Job
 from .mock_utils import (
@@ -734,6 +735,16 @@ class GenericAnalyzersTest(TestCase):
             self.observable_name,
             self.observable_classification,
             {"inquest_analysis": "dfi_search"},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    def test_threatfox(self, mock_get=None, mock_post=None):
+        report = threatfox.ThreatFox(
+            "ThreatFox",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {},
         ).start()
         self.assertEqual(report.get("success", False), True)
 

--- a/tests/utils.py
+++ b/tests/utils.py
@@ -19,6 +19,7 @@ from api_app.script_analyzers.observable_analyzers import (
     mb_google,
     inquest,
     xforce,
+    threatfox,
 )
 
 from api_app.script_analyzers.observable_analyzers.dns.dns_resolvers import (
@@ -163,6 +164,16 @@ class CommonTestCases_observables(metaclass=ABCMeta):
             self.observable_name,
             self.observable_classification,
             {"api_key_name": "FIRST_MISP_API", "url_key_name": "FIRST_MISP_URL"},
+        ).start()
+        self.assertEqual(report.get("success", False), True)
+
+    def test_threatfox(self, mock_get=None, mock_post=None):
+        report = threatfox.ThreatFox(
+            "ThreatFox",
+            self.job_id,
+            self.observable_name,
+            self.observable_classification,
+            {},
         ).start()
         self.assertEqual(report.get("success", False), True)
 


### PR DESCRIPTION
# Description

This adds [ThreatFox](https://threatfox.abuse.ch/api/) analyzer.

## Related issues
Fixes #348

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] The pull request is for the branch develop
- [x] If I added a new analyzer, I updated the file [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md).
- [x] I have added tests in the [Tests](https://github.com/intelowlproject/IntelOwl/blob/master/tests) folder. 
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] I squashed the commits into a single one.
  
# Real World Example
```json
{"id":470,"tags":[],"source":"admin","is_sample":false,"md5":"8fe2e6655a85d5006cb33f743d75dc30","observable_name":"139.180.203.104","observable_classification":"ip","file_name":"","file_mimetype":"","status":"reported_without_fails","analyzers_requested":["ThreatFox"],"run_all_available_analyzers":false,"analyzers_to_execute":["ThreatFox"],"analysis_reports":[{"name":"ThreatFox","errors":[],"report":{"data":[{"id":"1337","ioc":"139.180.203.104:443","tags":["CobaltStrike"],"malware":"win.cobalt_strike","ioc_type":"ip:port","reporter":"d4rksystem","last_seen":null,"reference":null,"first_seen":"2021-01-04 15:22:41 UTC","threat_type":"payload_delivery","ioc_type_desc":"ip:port combination that delivery a malware payload","malware_alias":"Agentemis,BEACON,CobaltStrike","malware_samples":[],"confidence_level":50,"malware_malpedia":"https://malpedia.caad.fkie.fraunhofer.de/details/win.cobalt_strike","threat_type_desc":"Indicator that identifies a malware distribution server (payload delivery)","malware_printable":"Cobalt Strike"}],"query_status":"ok"},"success":true,"process_time":1.2841122150421143,"started_time":1618400735.38396,"started_time_str":"2021-04-14 11:45:35"}],"received_request_time":"2021-04-14T11:45:35.209328Z","finished_analysis_time":"2021-04-14T11:45:36.696161Z","force_privacy":false,"disable_external_analyzers":false,"errors":[],"runtime_configuration":{}}
```
