### PR TITLE
adding missing migration

### DIFF
--- a/docker/entrypoint_uwsgi.sh
+++ b/docker/entrypoint_uwsgi.sh
@@ -7,6 +7,9 @@ done
 
 # Apply database migrations
 echo "Waiting for db to be ready..."
+# makemigrations is needed only for the durin package.
+# The customization of the parameters is not applied until the migration is done
+python manage.py makemigrations durin
 python manage.py migrate
 
 # Collect static files


### PR DESCRIPTION
added makemigrations for durin package only to allow customization of its parameters.

@Eshaan7 do you think there is a cleanest way to do this? maybe directly in the durin package?

In this way the durin migration would be applied each time the IntelOwl project is brought up. Not of a big problem but still unecessary