### PR TITLE
Fixes: #11 Add OpenCTI connector

### DIFF
--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -64,6 +64,7 @@ class MISP(Connector):
             value = self._job.observable_name
             if type == "hash":
                 matched_type = helpers.get_hash_type(value)
+                matched_type.replace("-", "")  # convert sha-x to shax
                 type = matched_type if matched_type is not None else "text"
             else:
                 type = INTELOWL_MISP_TYPE_MAP[type]

--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -70,7 +70,7 @@ class MISP(Connector):
                 type = INTELOWL_MISP_TYPE_MAP[type]
 
         obj = self._get_attr_obj(type, value)
-        obj.comment = f"Analyzers Executed: {self._job.analyzers_to_execute}"
+        obj.comment = f"Analyzers Executed: {', '.join(self._job.analyzers_to_execute)}"
         return obj
 
     @property

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -1,0 +1,146 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.conf import settings
+
+from pycti import OpenCTIApiClient
+
+from api_app import helpers
+from ..classes import Connector
+
+
+INTELOWL_OPENCTI_TYPE_MAP = {
+    "ip": {
+        "v4": "ipv4-addr",
+        "v6": "ipv6-addr",
+    },
+    "domain": "domain-name",
+    "url": "url",
+    # type hash is combined with file
+    "generic": "x-opencti-text",  # misc field, so keeping text
+    "file": "file",  # hashes: md5, sha-1, sha-256
+}
+
+
+class OpenCTI(Connector):
+    def set_params(self, params):
+        self.ssl_verify = params.get("ssl_verify", True)
+        self.tlp = params.get(
+            "tlp", {"type": "white", "color": "#FFFFFF", "x_opencti_order": 0}
+        )
+        self.proxies = params.get("proxies", {})
+        self.__url_name = self._secrets["url_key_name"]
+        self.__api_key = self._secrets["api_key_name"]
+
+    def get_observable_type(self):
+        if self._job.is_sample:
+            type = INTELOWL_OPENCTI_TYPE_MAP["file"]
+        elif self._job.observable_classification == "hash":
+            matched_hash_type = helpers.get_hash_type(self._job.observable_name)
+            if matched_hash_type in [
+                "md5",
+                "sha-1",
+                "sha-256",
+            ]:  # sha-512 not supported
+                type = INTELOWL_OPENCTI_TYPE_MAP["file"]
+            else:
+                type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
+        elif self._job.observable_classification == "ip":
+            ip_version = helpers.get_ip_version(self._job.observable_name)
+            if ip_version == 4 or ip_version == 6:
+                type = INTELOWL_OPENCTI_TYPE_MAP["ip"][f"v{ip_version}"]  # v4/v6
+            else:
+                type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
+        else:
+            type = INTELOWL_OPENCTI_TYPE_MAP[self._job.observable_classification]
+
+        return type
+
+    def create_observable(self):
+        observable_data = {"type": self.get_observable_type()}
+        if self._job.is_sample:
+            observable_data["name"] = self._job.file_name
+            observable_data["hashes"] = helpers.generate_hashes(self.job_id)
+        elif (
+            self._job.observable_classification == "hash"
+            and observable_data["type"] == "file"
+        ):
+            # add hash instead of value
+            matched_type = helpers.get_hash_type(self._job.observable_name)
+            observable_data["hashes"] = {matched_type: self._job.observable_name}
+        else:
+            observable_data["value"] = self._job.observable_name
+
+        observable = self.opencti_api_client.stix_cyber_observable.create(
+            observableData=observable_data,
+            createdBy=self.organization["id"],
+            objectMarking=self.marking_definition["id"],
+        )
+        return observable
+
+    def run(self):
+        # set up client
+        self.opencti_api_client = OpenCTIApiClient(
+            url=self.__url_name,
+            token=self.__api_key,
+            ssl_verify=self.ssl_verify,
+            proxies=self.proxies,
+        )
+
+        # Create author (if it doesn't exist)
+        self.organization = self.opencti_api_client.identity.create(
+            type="Organization",
+            name="IntelOwl",
+            description=(
+                "Intel Owl is an Open Source Intelligence, or OSINT solution"
+                " to get threat intelligence data about a specific file, an IP"
+                " or a domain from a single API at scale.[Visit the project on GitHub]"
+                "(https://github.com/intelowlproject/IntelOwl/)"
+            ),
+        )
+        # Create the marking definition
+        self.marking_definition = self.opencti_api_client.marking_definition.create(
+            definition_type="TLP",
+            definition="TLP:%s" % self.tlp["type"].upper(),
+            x_opencti_color=self.tlp["color"].upper(),
+            x_opencti_order=self.tlp["x_opencti_order"],
+        )
+
+        # Create the observable
+        observable = self.create_observable()
+
+        # Create the report
+        report = self.opencti_api_client.report.create(
+            name=f"IntelOwl Job-{self.job_id}",
+            description=(
+                f"This is IntelOwl's analysis report for Job: {self.job_id}."
+                f" Analyzers Executed: {self._job.analyzers_to_execute}"
+            ),
+            published=self._job.received_request_time.strftime("%Y-%m-%dT%H:%M:%SZ"),
+            report_types=["internal-report"],
+            createdBy=self.organization["id"],
+            objectMarking=self.marking_definition["id"],
+            x_opencti_report_status=2,  # Analyzed
+        )
+        # Create the external reference
+        external_reference = self.opencti_api_client.external_reference.create(
+            source_name="IntelOwl Analysis",
+            description="View analysis report on the IntelOwl instance",
+            url=f"{settings.WEB_CLIENT_URL}/pages/scan/result/{self.job_id}",
+        )
+        # Add the external reference to the report
+        self.opencti_api_client.stix_domain_object.add_external_reference(
+            id=report["id"], external_reference_id=external_reference["id"]
+        )
+
+        # Link Observable and Report
+        self.opencti_api_client.report.add_stix_object_or_stix_relationship(
+            id=report["id"], stixObjectOrStixRelationshipId=observable["id"]
+        )
+
+        return {
+            "observable": self.opencti_api_client.stix_cyber_observable.read(
+                id=observable["id"]
+            ),
+            "report": self.opencti_api_client.report.read(id=report["id"]),
+        }

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -8,7 +8,7 @@ import pycti
 
 from tests.mock_utils import patch, if_mock_connections
 from api_app import helpers
-from ..classes import Connector
+from api_app.connectors_manager import classes
 
 
 INTELOWL_OPENCTI_TYPE_MAP = {
@@ -24,7 +24,7 @@ INTELOWL_OPENCTI_TYPE_MAP = {
 }
 
 
-class OpenCTI(Connector):
+class OpenCTI(classes.Connector):
     def set_params(self, params):
         self.ssl_verify = params.get("ssl_verify", True)
         self.tlp = params.get(

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -36,7 +36,7 @@ class OpenCTI(classes.Connector):
 
     def get_observable_type(self) -> str:
         if self._job.is_sample:
-            type = INTELOWL_OPENCTI_TYPE_MAP["file"]
+            obs_type = INTELOWL_OPENCTI_TYPE_MAP["file"]
         elif self._job.observable_classification == "hash":
             matched_hash_type = helpers.get_hash_type(self._job.observable_name)
             if matched_hash_type in [
@@ -44,19 +44,19 @@ class OpenCTI(classes.Connector):
                 "sha-1",
                 "sha-256",
             ]:  # sha-512 not supported
-                type = INTELOWL_OPENCTI_TYPE_MAP["file"]
+                obs_type = INTELOWL_OPENCTI_TYPE_MAP["file"]
             else:
-                type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
+                obs_type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
         elif self._job.observable_classification == "ip":
             ip_version = helpers.get_ip_version(self._job.observable_name)
             if ip_version == 4 or ip_version == 6:
-                type = INTELOWL_OPENCTI_TYPE_MAP["ip"][f"v{ip_version}"]  # v4/v6
+                obs_type = INTELOWL_OPENCTI_TYPE_MAP["ip"][f"v{ip_version}"]  # v4/v6
             else:
-                type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
+                obs_type = INTELOWL_OPENCTI_TYPE_MAP["generic"]  # text
         else:
-            type = INTELOWL_OPENCTI_TYPE_MAP[self._job.observable_classification]
+            obs_type = INTELOWL_OPENCTI_TYPE_MAP[self._job.observable_classification]
 
-        return type
+        return obs_type
 
     def generate_observable_data(self) -> dict:
         observable_data = {"type": self.get_observable_type()}

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -1,11 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import sys
-
 from django.conf import settings
 
-from cache_memoize import cache_memoize
 from pycti.api.opencti_api_client import File
 import pycti
 
@@ -79,9 +76,8 @@ class OpenCTI(classes.Connector):
         return observable_data
 
     @property
-    @cache_memoize(timeout=sys.maxsize)
-    def organization_id(self) -> str:  # called only once (cached indefinitely)
-        # Create author (if not exists)
+    def organization_id(self) -> str:
+        # Create author (if not exists); else update
         org = pycti.Identity(self.opencti_instance).create(
             type="Organization",
             name="IntelOwl",
@@ -91,17 +87,17 @@ class OpenCTI(classes.Connector):
                 " domain from a single API at scale. [Visit the project on GitHub]"
                 "(https://github.com/intelowlproject/IntelOwl/)"
             ),
+            update=True,  # just in case the description is updated in future
         )
         return org["id"]
 
     @property
-    @cache_memoize(timeout=sys.maxsize)
-    def marking_definition_id(self) -> str:  # called only once (cached indefinitely)
+    def marking_definition_id(self) -> str:
         # Create the marking definition (if not exists)
         md = pycti.MarkingDefinition(self.opencti_instance).create(
             definition_type="TLP",
             definition=f"TLP:{self.tlp['type'].upper()}",
-            x_opencti_color=self.tlp["color"].upper(),
+            x_opencti_color=self.tlp["color"].lower(),
             x_opencti_order=self.tlp["x_opencti_order"],
         )
         return md["id"]

--- a/api_app/helpers.py
+++ b/api_app/helpers.py
@@ -5,6 +5,7 @@
 
 import json
 import logging
+import ipaddress
 import hashlib
 import re
 from magic import from_buffer as magic_from_buffer
@@ -67,6 +68,33 @@ def generate_sha256(job_id):
     return hashlib.sha256(binary).hexdigest()
 
 
+def generate_hashes(job_id):
+    """
+    Returns hashes of job sample
+    Formats: md5, sha1, sha256
+    """
+    binary = get_binary(job_id)
+    return {
+        "md5": hashlib.md5(binary).hexdigest(),
+        "sha-1": hashlib.sha1(binary).hexdigest(),
+        "sha-256": hashlib.sha256(binary).hexdigest(),
+    }
+
+
+def get_ip_version(ip_value):
+    """
+    Returns ip version
+    Supports IPv4 and IPv6
+    """
+    ip_type = None
+    try:
+        ip = ipaddress.ip_address(ip_value)
+        ip_type = ip.version
+    except ValueError as e:
+        logger.error(e)
+    return ip_type
+
+
 def get_hash_type(hash_value):
     """
     Returns hash type
@@ -74,9 +102,9 @@ def get_hash_type(hash_value):
     """
     RE_HASH_MAP = {
         "md5": re.compile(r"^[a-f\d]{32}$", re.IGNORECASE | re.ASCII),
-        "sha1": re.compile(r"^[a-f\d]{40}$", re.IGNORECASE | re.ASCII),
-        "sha256": re.compile(r"^[a-f\d]{64}$", re.IGNORECASE | re.ASCII),
-        "sha512": re.compile(r"^[a-f\d]{128}$", re.IGNORECASE | re.ASCII),
+        "sha-1": re.compile(r"^[a-f\d]{40}$", re.IGNORECASE | re.ASCII),
+        "sha-256": re.compile(r"^[a-f\d]{64}$", re.IGNORECASE | re.ASCII),
+        "sha-512": re.compile(r"^[a-f\d]{128}$", re.IGNORECASE | re.ASCII),
     }
 
     detected_hash_type = None

--- a/configuration/connector_config.json
+++ b/configuration/connector_config.json
@@ -25,5 +25,39 @@
         "description": "URL of your MISP instance"
       }
     }
+  },
+  "OpenCTI": {
+    "disabled": false,
+    "description": "OpenCTI Connector",
+    "python_module": "opencti.OpenCTI",
+    "config": {
+      "soft_time_limit": 30,
+      "ssl_verify": true,
+      "proxies": {
+        "http": "",
+        "https": ""
+      },
+      "tlp": {
+        "type": "white",
+        "color": "#FFFFFF",
+        "x_opencti_order": 0
+      }
+    },
+    "secrets": {
+      "api_key_name": {
+        "env_var_key": "OPENCTI_KEY",
+        "type": "string",
+        "required": true,
+        "default": null,
+        "description": "API key for your OpenCTI instance"
+      },
+      "url_key_name": {
+        "env_var_key": "OPENCTI_URL",
+        "type": "string",
+        "required": true,
+        "default": null,
+        "description": "URL of your OpenCTI instance"
+      }
+    }
   }
 }

--- a/configuration/connector_config.json
+++ b/configuration/connector_config.json
@@ -39,8 +39,8 @@
       },
       "tlp": {
         "type": "white",
-        "color": "#FFFFFF",
-        "x_opencti_order": 0
+        "color": "#ffffff",
+        "x_opencti_order": 1
       }
     },
     "secrets": {

--- a/docs/source/Installation.md
+++ b/docs/source/Installation.md
@@ -120,6 +120,8 @@ In the `env_file_app`, configure different variables as explained below.
 * `MWDB_KEY`: API key for [MWDB](https://mwdb.cert.pl/)
 * `SSAPINET_KEY`: screenshotapi.net ([docs](https://screenshotapi.net/documentation))
 * `MALPEDIA_KEY`: MALPEDIA API KEY ([docs](https://malpedia.caad.fkie.fraunhofer.de/usage/api))
+* `OPENCTI_KEY`: your own OpenCTI instance key
+* `OPENCTI_URL`: your own OpenCTI instance URL
 
 **Advanced** additional configuration:
 * `OLD_JOBS_RETENTION_DAYS`: Database retention for analysis results (default: 3 days). Change this if you want to keep your old analysis longer in the database.


### PR DESCRIPTION
# Description
This adds a connector for OpenCTI. It creates a report and an observable from the job data on a connected OpenCTI instance.

- [ ] Docs work to be handled in #562 

Notes
- `requests` was downgraded to `2.25.1` for `pycti==4.5.5`
- IP validation on GUI doesn't allow `IPv6` addresses. 

## Related issues
#11 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] The pull request is for the branch develop
- [x] If I added external libraries/packages that use restrictive licenses, please add them in the [ReadMe - Legal Notice](https://github.com/certego/IntelOwl/blob/master/README.md) section
- [x] I added new secrets in the files [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the docs: [Installation](./Installation.md)
- [x] I have added tests 
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one. (optional, they will be squashed anyway by the maintainer)


# Real World Example
<details>
      <summary>Click to expand</summary>
<img src="https://user-images.githubusercontent.com/51958314/127753401-ad10cee3-b16c-4616-84b1-7c7573881328.png" />
<img src="https://user-images.githubusercontent.com/51958314/127753404-f998e90d-56db-4353-9cf2-eb16fa70e249.png" />
<img src="https://user-images.githubusercontent.com/51958314/128049987-f63abbd6-c629-4338-bf52-8abde7efd241.png" />
</details>