### PR TITLE
Fixes #401: Opencti analyzer

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,7 @@ license terms.
 [Manalyze](https://github.com/JusticeRage/Manalyze),
 [Qiling](https://github.com/qilingframework/qiling),
 [Renderton](https://github.com/GoogleChrome/rendertron/blob/main/LICENSE)
+[PyCTI](https://github.com/OpenCTI-Platform/client-python/blob/master/LICENSE)
 
 ## Acknowledgments
 

--- a/api_app/analyzers_manager/observable_analyzers/opencti.py
+++ b/api_app/analyzers_manager/observable_analyzers/opencti.py
@@ -83,14 +83,14 @@ class OpenCTI(classes.ObservableAnalyzer):
 
     @classmethod
     def _monkeypatch(cls):
-        mock_obs = [{"id": 1, "observable_value": "8.8.8.8"}]
-        mock_result = [{"id": 1, "observable_value": "8.8.8.8"}]
+        mock_obs = [{"id": 1, "observable_value": "8.8.8.8", "objectMarkingIds": []}]
+        mock_report = [{"id": 1, "observable_value": "8.8.8.8", "objects": []}]
 
         patches = [
             if_mock_connections(
                 patch("pycti.OpenCTIApiClient", return_value=None),
                 patch("pycti.StixCyberObservable.list", return_value=mock_obs),
-                patch("pycti.Report.list", return_value=mock_result),
+                patch("pycti.Report.list", return_value=mock_report),
             )
         ]
         return super()._monkeypatch(patches=patches)

--- a/api_app/analyzers_manager/observable_analyzers/opencti.py
+++ b/api_app/analyzers_manager/observable_analyzers/opencti.py
@@ -83,12 +83,13 @@ class OpenCTI(classes.ObservableAnalyzer):
 
     @classmethod
     def _monkeypatch(cls):
+        mock_obs = [{"id": 1, "observable_value": "8.8.8.8"}]
         mock_result = [{"id": 1, "observable_value": "8.8.8.8"}]
 
         patches = [
             if_mock_connections(
                 patch("pycti.OpenCTIApiClient", return_value=None),
-                patch("pycti.StixCyberObservable.list", return_value=mock_result),
+                patch("pycti.StixCyberObservable.list", return_value=mock_obs),
                 patch("pycti.Report.list", return_value=mock_result),
             )
         ]

--- a/api_app/analyzers_manager/observable_analyzers/opencti.py
+++ b/api_app/analyzers_manager/observable_analyzers/opencti.py
@@ -1,0 +1,95 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from pycti.api.opencti_api_client import File
+import pycti
+
+from tests.mock_utils import patch, if_mock_connections
+from ..classes import ObservableAnalyzer
+
+
+# for lighter output (credits: Cortex-Analyzers/opencti)
+RESULT_TRIM_MAP = {
+    "observable": [
+        "objectMarkingIds",
+        "objectLabelIds",
+        "externalReferencesIds",
+        "indicatorsIds",
+        "parent_types",
+    ],
+    "report": {
+        "objects",
+        "objectMarkingIds",
+        "externalReferencesIds",
+        "objectLabelIds",
+        "parent_types",
+        "objectsIds",
+        "x_opencti_graph_data",
+    },
+}
+
+
+class OpenCTI(ObservableAnalyzer):
+    def set_params(self, params):
+        self.ssl_verify = params.get("ssl_verify", True)
+        self.proxies = params.get("proxies", {})
+        self.exact_search = params.get("exact_search", False)
+        self.__url_name = self._secrets["url_key_name"]
+        self.__api_key = self._secrets["api_key_name"]
+
+    def run(self):
+        # set up client
+        opencti_instance = pycti.OpenCTIApiClient(
+            url=self.__url_name,
+            token=self.__api_key,
+            ssl_verify=self.ssl_verify,
+            proxies=self.proxies,
+        )
+
+        # search for observables
+        observables = pycti.StixCyberObservable(opencti_instance, File).list(
+            search=self._job.observable_name
+        )
+
+        # Filter exact matches if exact_search is set
+        if self.exact_search:
+            observables = [
+                obs
+                for obs in observables
+                if obs["observable_value"] == self._job.observable_name
+            ]
+
+        for observable in observables:
+            # get reports linked to this observable
+            reports = pycti.Report(opencti_instance).list(
+                filters=[
+                    {
+                        "key": "objectContains",
+                        "values": [observable["id"]],
+                    }
+                ]
+            )
+            # trim observable data
+            for key in RESULT_TRIM_MAP["observable"]:
+                observable.pop(key)
+            for report in reports:
+                # trim report data
+                for key in RESULT_TRIM_MAP["report"]:
+                    report.pop(key)
+
+            observable["reports"] = reports
+
+        return observables
+
+    @classmethod
+    def _monkeypatch(cls):
+        mock_result = [{"id": 1, "observable_value": "8.8.8.8"}]
+
+        patches = [
+            if_mock_connections(
+                patch("pycti.OpenCTIApiClient", return_value=None),
+                patch("pycti.StixCyberObservable.list", return_value=mock_result),
+                patch("pycti.Report.list", return_value=mock_result),
+            )
+        ]
+        return super()._monkeypatch(patches=patches)

--- a/api_app/analyzers_manager/observable_analyzers/opencti.py
+++ b/api_app/analyzers_manager/observable_analyzers/opencti.py
@@ -5,7 +5,7 @@ from pycti.api.opencti_api_client import File
 import pycti
 
 from tests.mock_utils import patch, if_mock_connections
-from ..classes import ObservableAnalyzer
+from api_app.analyzers_manager import classes
 
 
 # for lighter output (credits: Cortex-Analyzers/opencti)
@@ -29,7 +29,7 @@ RESULT_TRIM_MAP = {
 }
 
 
-class OpenCTI(ObservableAnalyzer):
+class OpenCTI(classes.ObservableAnalyzer):
     def set_params(self, params):
         self.ssl_verify = params.get("ssl_verify", True)
         self.proxies = params.get("proxies", {})
@@ -71,11 +71,11 @@ class OpenCTI(ObservableAnalyzer):
             )
             # trim observable data
             for key in RESULT_TRIM_MAP["observable"]:
-                observable.pop(key)
+                observable.pop(key, None)
             for report in reports:
                 # trim report data
                 for key in RESULT_TRIM_MAP["report"]:
-                    report.pop(key)
+                    report.pop(key, None)
 
             observable["reports"] = reports
 

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1299,6 +1299,46 @@
       }
     }
   },
+  "OpenCTI": {
+    "type": "observable",
+    "python_module": "opencti.OpenCTI",
+    "description": "scan an observable on a custom OpenCTI instance",
+    "disabled": false,
+    "external_service": true,
+    "leaks_info": false,
+    "observable_supported": [
+      "ip",
+      "domain",
+      "url",
+      "hash"
+    ],
+    "config": {
+      "soft_time_limit": 30,
+      "queue": "default",
+      "ssl_verify": true,
+      "proxies": {
+        "http": "",
+        "https": ""
+      },
+      "exact_search": false
+    },
+    "secrets": {
+      "api_key_name": {
+        "env_var_key": "OPENCTI_KEY",
+        "type": "string",
+        "required": true,
+        "default": null,
+        "description": "API key for your OpenCTI instance"
+      },
+      "url_key_name": {
+        "env_var_key": "OPENCTI_URL",
+        "type": "string",
+        "required": true,
+        "default": null,
+        "description": "URL of your OpenCTI instance"
+      }
+    }
+  },
   "OTXQuery": {
     "type": "observable",
     "python_module": "otx.OTX",

--- a/docker/env_file_app_ci
+++ b/docker/env_file_app_ci
@@ -55,6 +55,7 @@ SSAPINET_KEY=test
 GOOGLE_APPLICATION_CREDENTIALS=/opt/deploy/intel_owl/configuration/service_account_keyfile_example.json
 MALPEDIA_KEY=test
 DEHASHED_AUTH_KEY=email@example.com:verysecureapikey
+OPENCTI_KEY=test
 
 # Test tokens
 TEST_JOB_ID=1
@@ -69,6 +70,7 @@ CUCKOO_URL=http://fake_url.com
 MISP_URL=http://fake_url.com
 FIRST_MISP_URL=http://fake_url.com
 VT_NOTIFY_URL=http://fake_url.com
+OPENCTI_URL=http://fake_url.com
 
 # other variables
 DEBUG=True

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -62,6 +62,7 @@ GOOGLE_APPLICATION_CREDENTIALS=/opt/deploy/intel_owl/configuration/service_accou
 MALPEDIA_KEY=
 # DEHASHED_AUTH_KEY format is `email:api-key`
 DEHASHED_AUTH_KEY=
+OPENCTI_KEY=
 
 # Test tokens
 TEST_JOB_ID=1
@@ -75,6 +76,7 @@ CUCKOO_URL=
 MISP_URL=
 FIRST_MISP_URL=
 VT_NOTIFY_URL=
+OPENCTI_URL=
 
 # other variables
 DEBUG=False

--- a/docs/source/Advanced-Usage.md
+++ b/docs/source/Advanced-Usage.md
@@ -167,6 +167,10 @@ List of some of the analyzers with optional configuration:
 * `Dehashed_Search`
   * `size` and `pages` can be configured. It's recommended to make `size` a high value but keep `page` to 1 only to save on credits.
   * Refer to the "Sizing & Pagination" section in [dehashed docs](https://www.dehashed.com/docs)
+* `OpenCTI`:
+  * `ssl_verify`: (default `true`), enable SSL certificate server verification. Change this if your OpenCTI instance has not SSL enabled.
+  * `proxies`: (`http` and `https`, default `""`) use these options to pass your request through a proxy server.
+  * `exact_search`: (default `false`) use this if you want exact matches only for the observables returned.
 
 There are two ways to do this:
 

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -151,6 +151,7 @@ The following is the list of the available analyzers you can run out-of-the-box:
 * `SSAPINet`: get a screenshot of a web page using [screenshotapi.net](https://screenshotapi.net/) (external source); additional config options can be added to `extra_api_params` [in the config](https://github.com/intelowlproject/IntelOwl/blob/master/configuration/analyzer_config.json).
 * `FireHol_IPList`: check if an IP is in [FireHol's IPList](https://iplists.firehol.org/)
 * `ThreatFox`: search for an IOC in [ThreatFox](https://threatfox.abuse.ch/api/)'s database
+* `OpenCTI`: scan an observable on an OpenCTI instance
 
 #### Generic analyzers (email, phone number, etc.; anything really)
 Some Analyzers require details other than just IP, URL, Domain etc... We classified them as Generic Analyzers. Since the type of field is not known, there is a format for strings to be followed.

--- a/requirements.txt
+++ b/requirements.txt
@@ -33,11 +33,12 @@ pysafebrowsing==0.1.1
 PySocks==1.7.1
 python-magic==0.4.22
 quark-engine==21.7.2
-requests==2.26.0
+requests==2.25.1
 speakeasy-emulator==1.5.3
 uWSGI==2.0.19.1
 yara-python==4.1.0
 darksearch==2.1.2
+pycti==4.5.5
 
 git+https://github.com/DissectMalware/xlrd2.git@a666cd8fb4dba4e2898f4f33ee4da515ba91d9b2
 git+https://github.com/DissectMalware/pyxlsb2.git@8cc2ee6c7176a6808f9058fda9b235d10a7b7a47


### PR DESCRIPTION
# Description
This adds an observable analyzer that searches for observables on a connected OpenCTI instance and returns all linked reports.

Notes
- `requests` was downgraded to `2.25.1` for `pycti==4.5.5`

## Related issues
#401 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] The pull request is for the branch develop
- [x] If I added a new analyzer, I updated the file [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md). If the analyzer provides additional optional configuration, I added the available options here: [Advanced-Usage](./Advanced-Usage.md)
- [x] If I added external libraries/packages that use restrictive licenses, please add them in the [ReadMe - Legal Notice](https://github.com/certego/IntelOwl/blob/master/README.md) section
- [x] I added new secrets in the files [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the docs: [Installation](./Installation.md)
- [x] I have added tests
- [ ] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [ ] I squashed the commits into a single one. (optional, they will be squashed anyway by the maintainer)
 
# Real World Example
![image](https://user-images.githubusercontent.com/51958314/127820644-d9498fae-ad11-4935-a0f4-0554139119d4.png)
