### PR TITLE
fix: use django-celery-results as result backend

### DIFF
--- a/docker/env_file_app_ci
+++ b/docker/env_file_app_ci
@@ -91,5 +91,5 @@ AWS_REGION=eu-central-1
 DJANGO_SETTINGS_MODULE=intel_owl.settings
 COVERAGE_PROCESS_START=.coveragerc
 
+# broker configuration
 BROKER_URL=amqp://guest:guest@rabbitmq:5672
-BACKEND_URL=rpc://guest:guest@rabbitmq:5672

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -99,7 +99,6 @@ AWS_REGION=eu-central-1
 
 # broker configuration
 BROKER_URL=amqp://guest:guest@rabbitmq:5672
-BACKEND_URL=rpc://guest:guest@rabbitmq:5672
 RABBITMQ_DEFAULT_USER=guest
 RABBITMQ_DEFAULT_PASS=guest
 FLOWER_USER=flower

--- a/intel_owl/celery.py
+++ b/intel_owl/celery.py
@@ -2,18 +2,19 @@
 # See the file 'LICENSE' for copying permission.
 
 from __future__ import absolute_import, unicode_literals
-from intel_owl.settings import (
-    CELERY_QUEUES,
-    BROKER_URL,
-    BACKEND_URL,
-    AWS_SQS,
-    TEST_MODE,
-)
 import os
-
 from celery import Celery
 from celery.schedules import crontab
 from kombu import Exchange, Queue
+
+from .settings import (
+    CELERY_QUEUES,
+    BROKER_URL,
+    RESULT_BACKEND,
+    AWS_SQS,
+    TEST_MODE,
+)
+
 
 os.environ.setdefault("DJANGO_SETTINGS_MODULE", "intel_owl.settings")
 
@@ -34,7 +35,7 @@ app.conf.update(
     ],
     task_time_limit=1800,
     broker_url=BROKER_URL,
-    result_backend=BACKEND_URL,
+    result_backend=RESULT_BACKEND,
     accept_content=["application/json"],
     task_serializer="json",
     result_serializer="json",

--- a/intel_owl/settings.py
+++ b/intel_owl/settings.py
@@ -52,15 +52,18 @@ INSTALLED_APPS = [
     "django.contrib.messages",
     "django.contrib.staticfiles",
     "django.contrib.postgres",
+    # celery, elasticsearch
+    "django_celery_results",
+    "django_elasticsearch_dsl",
     # DRF
     "rest_framework",
     "durin",
     "guardian",
+    "drf_spectacular",
+    # intelowl apps
     "api_app.apps.ApiAppConfig",
     "api_app.analyzers_manager.apps.AnalyzersManagerConfig",
     "api_app.connectors_manager.apps.ConnectorsManagerConfig",
-    "django_elasticsearch_dsl",
-    "drf_spectacular",
 ]
 
 MIDDLEWARE = [
@@ -157,7 +160,7 @@ else:
     }
 
 BROKER_URL = secrets.get_secret("BROKER_URL", "amqp://guest:guest@rabbitmq:5672")
-BACKEND_URL = secrets.get_secret("BACKEND_URL", "rpc://guest:guest@rabbitmq:5672")
+RESULT_BACKEND = "django-db"
 CELERY_QUEUES = os.environ.get("CELERY_QUEUES", "default").split(",")
 
 # AWS

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,5 +1,6 @@
 boto3==1.18.7
 celery==5.1.2
+django-celery-results
 checkdmarc==4.4.1
 darksearch==2.1.2
 dataclasses==0.6

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,6 +1,6 @@
 boto3==1.18.7
 celery==5.1.2
-django-celery-results
+django-celery-results==2.2.0
 checkdmarc==4.4.1
 darksearch==2.1.2
 dataclasses==0.6


### PR DESCRIPTION
We can't use the `rpc` result backend because it does not work w/ chords.

Error:
> raised unexpected: NotImplementedError('The "rpc" result backend does not support chords!\n\nNote that a group chained with a task is also upgraded to be a chord,\nas this pattern requires synchronization.\n\nResult backends that supports chords: Redis, Database, Memcached, and more.')

So, I try here to use the postgreSQL database as backend using the [django-celery-results](https://github.com/celery/django-celery-results) backend library.