### PR TITLE
docker: bump intelowl_ng tag to v3.0.0

### DIFF
--- a/docker/.env
+++ b/docker/.env
@@ -1,4 +1,4 @@
 ### DO NOT CHANGE THIS VALUE !!
 ### It should be updated only when you pull latest changes off from the 'master' branch of IntelOwl.
 INTELOWL_TAG_VERSION=v2.5.0
-INTELOWL_NG_TAG_VERSION=v2.1.1
+INTELOWL_NG_TAG_VERSION=v3.0.0

--- a/docker/Dockerfile_nginx
+++ b/docker/Dockerfile_nginx
@@ -1,5 +1,5 @@
 # Stage 1: Get build artifacts from intelowl-ng
-ARG INTELOWL_NG_TAG_VERSION="v2.1.1"
+ARG INTELOWL_NG_TAG_VERSION="v3.0.0"
 FROM intelowlproject/intelowl_ng:${INTELOWL_NG_TAG_VERSION} AS angular-prod-build
 
 # Stage 2: Inject the build artifacts into nginx container


### PR DESCRIPTION
Waiting for it to finish building https://hub.docker.com/repository/docker/intelowlproject/intelowl_ng/builds