### PR TITLE
Removed analyzer error when hash is not present in the mwdb

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/mwdb_scan.py
+++ b/api_app/analyzers_manager/file_analyzers/mwdb_scan.py
@@ -6,6 +6,8 @@ import time
 import mwdblib
 import logging
 
+from requests import HTTPError
+
 from api_app.exceptions import AnalyzerRunException
 from api_app.analyzers_manager.classes import FileAnalyzer
 
@@ -86,16 +88,11 @@ class MWDB_Scan(FileAnalyzer):
         else:
             try:
                 file_info = self.mwdb.query_file(query)
-            except Exception as exc:
-                err_msg = (
-                    "Error: File not found in the MWDB. Set 'upload_file=true' "
-                    "if you want to upload and poll results. "
-                )
-                logger.error((str(exc), err_msg))
-                self.report.errors.append(str(exc))
-                self.report.errors.append(err_msg)
+            except HTTPError:
                 result["not_found"] = True
                 return result
+            else:
+                result["not_found"] = False
         # adding information about the children and parents
         self.adjust_relations(file_info.data, "parents", True)
         self.adjust_relations(file_info.data, "children", True)


### PR DESCRIPTION
# Description

Mwdb analyzer would fail if the hash requested isn't present in the db. 


## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] The pull request is for the branch develop
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (incase the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
    - [ ] If a File analyzer was added, it's name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [ReadMe - Legal Notice](https://github.com/certego/IntelOwl/blob/master/README.md) section.
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [ ] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  