### PR TITLE
Fixes #438: Phishstats analyzer

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -15,8 +15,7 @@ class PhishStats(ObservableAnalyzer):
     def __build_phishstats_url(self) -> str:
         if self.observable_classification == self.ObservableTypes.IP:
             return self.base_url.format(input=self.observable_name)
-        else:
-            raise AnalyzerRunException("PhishStats only works with IP addresses")
+        raise AnalyzerRunException("PhishStats only works with IP addresses")
 
     def run(self):
         api_uri = self.__build_phishstats_url()

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -1,0 +1,42 @@
+import requests
+
+from api_app.analyzers_manager.classes import ObservableAnalyzer
+from api_app.exceptions import AnalyzerRunException
+from tests.mock_utils import MockResponse, if_mock_connections, patch
+
+
+class PhishStats(ObservableAnalyzer):
+    """
+    Analyzer that uses PhishStats API to check if the observable is a phishing site.
+    """
+
+    base_url: str = "https://phishstats.info:2096/api/phishing?_where=(ip,eq,{input})"
+
+    def __build_phishstats_url(self) -> str:
+        if self.observable_classification == self.ObservableTypes.IP:
+            return self.base_url.format(input=self.observable_name)
+        else:
+            raise AnalyzerRunException("PhishStats only works with IP addresses")
+
+    def run(self):
+        api_uri = self.__build_phishstats_url()
+        try:
+            response = requests.get(api_uri)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AnalyzerRunException(e)
+
+        result = response.json()
+        return result
+
+    @classmethod
+    def _monkeypatch(cls):
+        patches = [
+            if_mock_connections(
+                patch(
+                    "requests.get",
+                    return_value=MockResponse({}, 200),
+                ),
+            )
+        ]
+        return super()._monkeypatch(patches=patches)

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -17,14 +17,13 @@ class PhishStats(ObservableAnalyzer):
 
     def __build_phishstats_url(self) -> str:
         if self.observable_classification == self.ObservableTypes.IP:
-            endpoint = "phishing?_where=(ip,eq,{input})"
+            endpoint = "phishing?_where=(ip,eq,{input})&_sort=-date"
             name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.URL:
-            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
-            domain = self.observable_name.split("/")[2]
-            name = domain.split(".")[0]
+            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-date"
+            name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.DOMAIN:
-            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
+            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-date"
             name = self.observable_name.split(".")[0]
         else:
             raise AnalyzerRunException(

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -18,21 +18,17 @@ class PhishStats(ObservableAnalyzer):
     def __build_phishstats_url(self) -> str:
         if self.observable_classification == self.ObservableTypes.IP:
             endpoint = "phishing?_where=(ip,eq,{input})&_sort=-date"
-            name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.URL:
             endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-date"
-            name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.DOMAIN:
             endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-date"
-            name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.GENERIC:
             endpoint = "phishing?_where=(title,like,~{input}~)&_sort=-date"
-            name = self.observable_name
         else:
             raise AnalyzerRunException(
-                "PhishStats only works with IP, Domain and Gennric"
+                "Phishstats require either of IP, URL, Domain or Generic"
             )
-        return f"{self.base_url}/{endpoint.format(input=name)}"
+        return f"{self.base_url}/{endpoint.format(input=self.observable_name)}"
 
     def run(self):
         api_uri = self.__build_phishstats_url()

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -18,17 +18,19 @@ class PhishStats(ObservableAnalyzer):
     def __build_phishstats_url(self) -> str:
         if self.observable_classification == self.ObservableTypes.IP:
             endpoint = "phishing?_where=(ip,eq,{input})"
-            return f"{self.base_url}/{endpoint.format(input=self.observable_name)}"
+            name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.URL:
             endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
             domain = self.observable_name.split("/")[2]
             name = domain.split(".")[0]
-            return f"{self.base_url}/{endpoint.format(input=name)}"
         elif self.observable_classification == self.ObservableTypes.DOMAIN:
             endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
-            domain = self.observable_name.split(".")[0]
-            return f"{self.base_url}/{endpoint.format(input=domain)}"
-        raise AnalyzerRunException("PhishStats only works with IP, Domain and Gennric")
+            name = self.observable_name.split(".")[0]
+        else:
+            raise AnalyzerRunException(
+                "PhishStats only works with IP, Domain and Gennric"
+            )
+        return f"{self.base_url}/{endpoint.format(input=name)}"
 
     def run(self):
         api_uri = self.__build_phishstats_url()

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -1,3 +1,6 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
 import requests
 
 from api_app.analyzers_manager.classes import ObservableAnalyzer

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -13,12 +13,22 @@ class PhishStats(ObservableAnalyzer):
     Analyzer that uses PhishStats API to check if the observable is a phishing site.
     """
 
-    base_url: str = "https://phishstats.info:2096/api/phishing?_where=(ip,eq,{input})"
+    base_url: str = "https://phishstats.info:2096/api/"
 
     def __build_phishstats_url(self) -> str:
         if self.observable_classification == self.ObservableTypes.IP:
-            return self.base_url.format(input=self.observable_name)
-        raise AnalyzerRunException("PhishStats only works with IP addresses")
+            endpoint = "phishing?_where=(ip,eq,{input})"
+            return f"{self.base_url}/{endpoint.format(input=self.observable_name)}"
+        elif self.observable_classification == self.ObservableTypes.URL:
+            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
+            domain = self.observable_name.split("/")[2]
+            name = domain.split(".")[0]
+            return f"{self.base_url}/{endpoint.format(input=name)}"
+        elif self.observable_classification == self.ObservableTypes.DOMAIN:
+            endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-id"
+            domain = self.observable_name.split(".")[0]
+            return f"{self.base_url}/{endpoint.format(input=domain)}"
+        raise AnalyzerRunException("PhishStats only works with IP, Domain and Gennric")
 
     def run(self):
         api_uri = self.__build_phishstats_url()

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -24,7 +24,10 @@ class PhishStats(ObservableAnalyzer):
             name = self.observable_name
         elif self.observable_classification == self.ObservableTypes.DOMAIN:
             endpoint = "phishing?_where=(url,like,~{input}~)&_sort=-date"
-            name = self.observable_name.split(".")[0]
+            name = self.observable_name
+        elif self.observable_classification == self.ObservableTypes.GENERIC:
+            endpoint = "phishing?_where=(title,like,~{input}~)&_sort=-date"
+            name = self.observable_name
         else:
             raise AnalyzerRunException(
                 "PhishStats only works with IP, Domain and Gennric"

--- a/api_app/analyzers_manager/observable_analyzers/whoisripe.py
+++ b/api_app/analyzers_manager/observable_analyzers/whoisripe.py
@@ -1,0 +1,31 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import requests
+
+from api_app.analyzers_manager import classes
+from tests.mock_utils import MockResponse, if_mock_connections, patch
+
+
+class WhoIsRipeAPI(classes.ObservableAnalyzer):
+    url: str = "https://rest.db.ripe.net/search.json"
+
+    def run(self):
+        params = {"query-string": self.observable_name}
+
+        response = requests.get(self.url, params=params)
+        response.raise_for_status()
+
+        return response.json()
+
+    @classmethod
+    def _monkeypatch(cls):
+        patches = [
+            if_mock_connections(
+                patch(
+                    "requests.get",
+                    return_value=MockResponse({}, 200),
+                ),
+            )
+        ]
+        return super()._monkeypatch(patches=patches)

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1881,7 +1881,7 @@
   "Phishstats": {
     "type": "observable",
     "python_module": "phishstats.PhishStats",
-    "description": "check if the observable is a phishing site",
+    "description": "Search PhishStats API to determine if an IP/URL/domain is malicious.",
     "disabled": false,
     "external_service": true,
     "leaks_info": true,
@@ -1892,15 +1892,7 @@
       "soft_time_limit": 100,
       "queue": "long"
     },
-    "secrets": {
-      "api_key_name": {
-        "env_var_key": "PHISTATS_API_KEY",
-        "type": "string",
-        "default": null,
-        "description": "Optional API key for Phishstats.",
-        "required": false
-      }
-    },
+    "secrets": {},
     "params": {}
   },
   "Phishtank": {

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1886,7 +1886,7 @@
     "external_service": true,
     "leaks_info": true,
     "observable_supported": [
-      "ip"
+      "ip", "url", "domain"
     ],
     "config": {
       "soft_time_limit": 30,

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1886,10 +1886,10 @@
     "external_service": true,
     "leaks_info": true,
     "observable_supported": [
-      "ip", "url", "domain"
+      "ip", "url", "domain", "generic"
     ],
     "config": {
-      "soft_time_limit": 30,
+      "soft_time_limit": 100,
       "queue": "long"
     },
     "secrets": {},

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -3298,6 +3298,23 @@
     },
     "params": {}
   },
+ "WhoIs_RipeDB_Search" : {
+    "type": "observable",
+    "python_module" : "whoisripe.WhoIsRipeAPI",
+    "description" : "Fetch whois record data of an IP address from Ripe DB using their [search API](https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API-search)",
+    "disabled" : false,
+    "external_service" : true,
+    "leaks_info" : false,
+    "observable_supported" : [
+      "ip"
+    ],
+    "config" : {
+      "soft_time_limit" : 30,
+      "queue" : "default"
+    },
+    "secrets" : {},
+    "params" : {}
+  },
   "WiGLE": {
     "type": "observable",
     "python_module": "wigle.WiGLE",

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1860,6 +1860,31 @@
     "secrets": {},
     "params": {}
   },
+  "Phishstats": {
+    "type": "observable",
+    "python_module": "phishstats.PhishStats",
+    "description": "check if the observable is a phishing site",
+    "disabled": false,
+    "external_service": true,
+    "leaks_info": true,
+    "observable_supported": [
+      "ip"
+    ],
+    "config": {
+      "soft_time_limit": 100,
+      "queue": "long"
+    },
+    "secrets": {
+      "api_key_name": {
+        "env_var_key": "PHISTATS_API_KEY",
+        "type": "string",
+        "default": null,
+        "description": "Optional API key for Phishstats.",
+        "required": false
+      }
+    },
+    "params": {}
+  },
   "Phishtank": {
     "type": "observable",
     "python_module": "phishtank.Phishtank",

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1889,7 +1889,7 @@
       "ip"
     ],
     "config": {
-      "soft_time_limit": 100,
+      "soft_time_limit": 30,
       "queue": "long"
     },
     "secrets": {},

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -231,6 +231,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
+* `Phishstats`: Search an url against [Phishstats](https://phishstats.info/) API
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)
 * `Quad9_Malicious_Detector`: Leverages Quad9 DoH to check if a domain is related to malware
 * `DNStwist`: Scan a url/domain to find potentially malicious permutations via dns fuzzing. [dnstwist repo](https://github.com/elceef/dnstwist) 

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -227,6 +227,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `Pulsedive_Active_IOC`: Scan indicators and retrieve results from [Pulsedive's API](https://pulsedive.com/api/).
 * `CheckDMARC`: An SPF and DMARC DNS records validator for domains.
 * `Whoisxmlapi`: Fetch WHOIS record data, of a domain name, an IP address, or an email address.
+* `WhoIs_RipeDB_Search` : Fetch whois record data of an IP address from Ripe DB using their [search API](https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API-search) (no API key required)
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -231,7 +231,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
-* `Phishstats`: Search an url against [Phishstats](https://phishstats.info/) API
+* `Phishstats`: Search [PhishStats API](https://phishstats.info/) to determine if an IP/URL/domain is malicious.
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)
 * `Quad9_Malicious_Detector`: Leverages Quad9 DoH to check if a domain is related to malware
 * `DNStwist`: Scan a url/domain to find potentially malicious permutations via dns fuzzing. [dnstwist repo](https://github.com/elceef/dnstwist) 


### PR DESCRIPTION
# Description

Added [Phishstats](https://phishstats.info/https://phishstats.info/) Analyzer 
API Call - https://phishstats.info:2096/api/phishing?_where=(ip,eq,148.228.16.3)

## Related issues
#438 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).


# Checklist

- [X] The pull request is for the branch develop
- [X] A new analyzer or connector was added, in which case:
    - [X] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [X] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
    - [ ] If a File analyzer was added, it's name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] The tests gave 0 errors.
- [X] `Black` gave 0 errors.
- [X] `Flake` gave 0 errors.
- [ ] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  

# Screenshots

![Screenshot from 2021-11-18 23-12-21](https://user-images.githubusercontent.com/72073401/142469191-57bcba9d-f0c7-43dc-9de9-6b55f36d9354.png)

-------------

![Screenshot from 2021-11-18 23-12-04](https://user-images.githubusercontent.com/72073401/142469168-c030419c-3ef1-4366-ba82-e00b26c3b052.png)



