### PR TITLE
Fixes #428: Add `Mnemonic_PassiveDNS` analyzer

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/mnemonic_pdns.py
+++ b/api_app/analyzers_manager/observable_analyzers/mnemonic_pdns.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import json
+
 import requests
 
 from api_app.analyzers_manager import classes
@@ -28,9 +29,8 @@ class MnemonicPassiveDNS(classes.ObservableAnalyzer):
             raise AnalyzerRunException(e)
 
         if self._cofformat:
-            result = []
-            for i in response.text.splitlines():
-                result.append(json.loads(i))
+            result = [json.loads(line) for line in response.text.splitlines()]
+
         else:
             result = response.json()
 

--- a/api_app/analyzers_manager/observable_analyzers/mnemonic_pdns.py
+++ b/api_app/analyzers_manager/observable_analyzers/mnemonic_pdns.py
@@ -2,7 +2,6 @@
 # See the file 'LICENSE' for copying permission.
 
 import json
-
 import requests
 
 from api_app.analyzers_manager import classes
@@ -10,11 +9,11 @@ from api_app.exceptions import AnalyzerRunException
 from tests.mock_utils import MockResponse, if_mock_connections, patch
 
 
-class passiveDNS(classes.ObservableAnalyzer):
+class MnemonicPassiveDNS(classes.ObservableAnalyzer):
     base_url: str = "https://api.mnemonic.no/pdns/v3/"
 
     def set_params(self, params):
-        self._cofformat = params.get("cofformat", True)
+        self._cofformat = params.get("cof_format", True)
         self._limit = params.get("limit", 100)
 
     def run(self):

--- a/api_app/analyzers_manager/observable_analyzers/passivedns.py
+++ b/api_app/analyzers_manager/observable_analyzers/passivedns.py
@@ -1,0 +1,34 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import requests
+
+from api_app.analyzers_manager import classes
+from api_app.exceptions import AnalyzerRunException
+from tests.mock_utils import MockResponse, if_mock_connections, patch
+
+
+class passiveDNS(classes.ObservableAnalyzer):
+    base_url: str = "https://api.mnemonic.no/pdns/v3/"
+
+    def run(self):
+        try:
+            response = requests.get(self.base_url + self.observable_name)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AnalyzerRunException(e)
+
+        result = response.json()
+        return result
+
+    @classmethod
+    def _monkeypatch(cls):
+        patches = [
+            if_mock_connections(
+                patch(
+                    "requests.get",
+                    return_value=MockResponse({}, 200),
+                ),
+            )
+        ]
+        return super()._monkeypatch(patches=patches)

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1826,6 +1826,23 @@
       }
     }
   },
+  "PassiveDNS" : {
+    "type" : "observable",
+    "python_module" : "passivedns.passiveDNS",
+    "description" : "Look up the PDNS information of a domain using the PassiveDNS API.",
+    "disabled" : false,
+    "external_service" : true,
+    "leaks_info" : false,
+    "observable_supported": [
+      "domain"
+    ],
+    "config" : {
+      "soft_time_limit" : 30,
+      "queue" : "default"
+    },
+    "secrets" : {},
+    "params" : {}
+  },
   "PDF_Info": {
     "type": "file",
     "python_module": "pdf_info.PDFInfo",

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1842,8 +1842,8 @@
   },
   "Mnemonic_PassiveDNS" : {
     "type" : "observable",
-    "python_module" : "mnemonic_pdns.passiveDNS",
-    "description" : "Look up the PDNS information of a domain or IP address using the PassiveDNS API.",
+    "python_module" : "mnemonic_pdns.MnemonicPassiveDNS",
+    "description" : "Look up a domain or IP using the [Mnemonic PassiveDNS public API](https://docs.mnemonic.no/display/public/API/Passive+DNS+Overview).",
     "disabled" : false,
     "external_service" : true,
     "leaks_info" : false,
@@ -1852,20 +1852,20 @@
       "ip"
     ],
     "config" : {
-      "soft_time_limit" : 30,
-      "queue" : "default"
+      "soft_time_limit" : 60,
+      "queue" : "long"
     },
     "secrets" : {},
     "params" : {
-      "cofformat" : {
+      "cof_format" : {
         "value" : true,
         "type" : "bool",
-        "description" : "Use the cof format endpoint."
+        "description" : "Return result in the PassiveDNS [Common Output Format](https://datatracker.ietf.org/doc/draft-dulaunoy-dnsop-passive-dns-cof/)."
       },
       "limit" : {
-        "value" : 100,
+        "value" : 1000,
         "type" : "int",
-        "description" : ""
+        "description" : "Number of records to fetch."
       }
     }
   },

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1840,22 +1840,34 @@
       }
     }
   },
-  "PassiveDNS" : {
+  "Mnemonic_PassiveDNS" : {
     "type" : "observable",
-    "python_module" : "passivedns.passiveDNS",
-    "description" : "Look up the PDNS information of a domain using the PassiveDNS API.",
+    "python_module" : "mnemonic_pdns.passiveDNS",
+    "description" : "Look up the PDNS information of a domain or IP address using the PassiveDNS API.",
     "disabled" : false,
     "external_service" : true,
     "leaks_info" : false,
     "observable_supported": [
-      "domain"
+      "domain",
+      "ip"
     ],
     "config" : {
       "soft_time_limit" : 30,
       "queue" : "default"
     },
     "secrets" : {},
-    "params" : {}
+    "params" : {
+      "cofformat" : {
+        "value" : true,
+        "type" : "bool",
+        "description" : "Use the cof format endpoint."
+      },
+      "limit" : {
+        "value" : 100,
+        "type" : "int",
+        "description" : ""
+      }
+    }
   },
   "PDF_Info": {
     "type": "file",

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -230,7 +230,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `WhoIs_RipeDB_Search` : Fetch whois record data of an IP address from Ripe DB using their [search API](https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API-search) (no API key required)
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
-* `PassiveDNS` : Look up the DNS information of a domain using the [PassiveDNS](https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide) API.
+* `Mnemonic_PassiveDNS` : Look up the PDNS information of a domain or IP address using the [PassiveDNS](https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide) API.
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
 * `Phishstats`: Search [PhishStats API](https://phishstats.info/) to determine if an IP/URL/domain is malicious.
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -230,6 +230,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `WhoIs_RipeDB_Search` : Fetch whois record data of an IP address from Ripe DB using their [search API](https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API-search) (no API key required)
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
+* `PassiveDNS` : Look up the DNS information of a domain using the [PassiveDNS](https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide) API.
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
 * `Phishstats`: Search [PhishStats API](https://phishstats.info/) to determine if an IP/URL/domain is malicious.
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -230,7 +230,7 @@ The following is the list of the available analyzers you can run out-of-the-box.
 * `WhoIs_RipeDB_Search` : Fetch whois record data of an IP address from Ripe DB using their [search API](https://github.com/RIPE-NCC/whois/wiki/WHOIS-REST-API-search) (no API key required)
 * `UrlScan_Search`: Search an IP/domain/url/hash against [URLScan](https://urlscan.io) API
 * `UrlScan_Submit_Result`: Submit & retrieve result of an URL against [URLScan](https://urlscan.io) API
-* `Mnemonic_PassiveDNS` : Look up the PDNS information of a domain or IP address using the [PassiveDNS](https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide) API.
+* `Mnemonic_PassiveDNS` : Look up a domain or IP using the [Mnemonic PassiveDNS public API](https://docs.mnemonic.no/display/public/API/Passive+DNS+Overview).
 * `Phishtank`: Search an url against [Phishtank](https://phishtank.org/api_info.php) API
 * `Phishstats`: Search [PhishStats API](https://phishstats.info/) to determine if an IP/URL/domain is malicious.
 * `Quad9_DNS`: Retrieve current domain resolution with Quad9 DoH (DNS over HTTPS)


### PR DESCRIPTION
# Description

Added the <a href = "https://docs.mnemonic.no/display/public/API/PassiveDNS+Integration+Guide">PassiveDNS</a> analyzer.

## Related issues

#428

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] The pull request is for the branch develop
- [x] A new analyzer or connector was added, in which case:
    - [x] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [x] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
- [x] The tests gave 0 errors.
- [x] `Black` gave 0 errors.
- [x] `Flake` gave 0 errors.
- [x] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)


# Real World Example

Here is the screenshot:
![Screenshot 2021-12-07 at 4 21 11 AM](https://user-images.githubusercontent.com/60684641/144936386-9e3da20d-93f8-489a-9338-68a677950652.png)


