### PR TITLE
force xlrd2 as dependency for xlmmacrodeobfuscator

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -46,5 +46,6 @@ uWSGI==2.0.19.1
 yara-python==4.1.0
 pydragonfly==0.0.3
 XLMMacroDeobfuscator==0.2.3
-# this is required because XLMMacroDeobfuscator does not pin xlrd2
+# this is required because XLMMacroDeobfuscator does not pin xlrd2 and pyxlsb2 packages
+pyxlsb2==0.0.8
 xlrd2==1.3.4 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,3 +46,4 @@ uWSGI==2.0.19.1
 yara-python==4.1.0
 pydragonfly==0.0.3
 XLMMacroDeobfuscator==0.2.3
+xlrd2==1.3.4 

--- a/requirements.txt
+++ b/requirements.txt
@@ -46,4 +46,5 @@ uWSGI==2.0.19.1
 yara-python==4.1.0
 pydragonfly==0.0.3
 XLMMacroDeobfuscator==0.2.3
+# this is required because XLMMacroDeobfuscator does not pin xlrd2
 xlrd2==1.3.4 


### PR DESCRIPTION
XlmMacroDeobfuscator does not pin a version, meaning that its package is not updated correctly.
This package is required for new malware that are sent, like cbecd8f82cf81f569c16b3ac533a850b0f6163a71b8b772b9f219e184dca21b1

