### PR TITLE
Solve #569. Added new hashes to `PE_Info` analyzer

### DIFF
--- a/.github/legal_notice.md
+++ b/.github/legal_notice.md
@@ -12,6 +12,8 @@ license terms.
 [stringsifter](https://github.com/fireeye/stringsifter),
 [peepdf](https://github.com/jesparza/peepdf),
 [pefile](https://github.com/erocarrera/pefile),
+[impfuzzy](https://github.com/JPCERTCC/impfuzzy),
+[Dhashicon - SuperPeHasher](https://github.com/fr0gger/SuperPeHasher),
 [oletools](https://github.com/decalage2/oletools),
 [XLMMacroDeobfuscator](https://github.com/DissectMalware/XLMMacroDeobfuscator),
 [MaxMind-DB-Reader-python](https://github.com/maxmind/MaxMind-DB-Reader-python),

--- a/api_app/analyzers_manager/file_analyzers/pe_info.py
+++ b/api_app/analyzers_manager/file_analyzers/pe_info.py
@@ -7,9 +7,13 @@
 # forked repository: https://github.com/mlodic/pefile
 
 import logging
+import os
 from datetime import datetime
 
+import lief
 import pefile
+import pyimpfuzzy
+from PIL import Image
 
 from api_app.analyzers_manager.classes import FileAnalyzer
 from api_app.exceptions import AnalyzerRunException
@@ -31,11 +35,9 @@ class WinPEhasher:
         Return Dhashicon of the exe
         """
         try:
-            import os
-
-            import lief
-            from PIL import Image
-
+            # this code was implemented from
+            # https://github.com/fr0gger/SuperPeHasher/commit/e9b753bf52d4e48dda2da0b7801075be4037a161#diff-2bb2d2d4d25fef20a893a4e93e96c9b8c0b0c6d5791fc14594cc9dd5cbf40b41
+            #
             # config
             hash_size = 8
             # extract icon
@@ -65,8 +67,6 @@ class WinPEhasher:
                     decimal_value = 0
             os.remove(icon_path)
             return "".join(icon_hash)
-        except ImportError:
-            raise ImportError("please run pip -r requirements.txt")
         except Exception as e:
             raise AnalyzerRunException(f"pe_info:winpe_hasher gave errors. {str(e)}")
 
@@ -75,12 +75,11 @@ class WinPEhasher:
         Calculate impfuzzy hash and return
         """
         try:
-            import pyimpfuzzy
-
+            # this code was implemented from
+            # https://github.com/JPCERTCC/impfuzzy
+            #
             impfuzzyhash = pyimpfuzzy.get_impfuzzy(self.file_path)
             return str(impfuzzyhash)
-        except ImportError:
-            raise ImportError("please run pip -r requirements.txt")
         except Exception as e:
             raise AnalyzerRunException(f"pe_info:winpe_hasher gave errors. {str(e)}")
 

--- a/requirements/requirements.txt
+++ b/requirements/requirements.txt
@@ -23,6 +23,7 @@ GitPython==3.1.18
 google>=3.0.0
 google-cloud-webrisk==1.6.0
 intezer-sdk==1.6
+lief==0.11.5
 maxminddb==2.2.0
 mwdblib==4.0.0
 oletools==0.60
@@ -30,11 +31,13 @@ OTXv2==1.5.12
 peepdf-fork==0.4.3
 pdfid==1.0.4
 pefile-fork==2020.12.16
+Pillow==9.0.0
 psycopg2-binary==2.9.1
 pycti==5.1.4
 pydeep==0.4
 PyExifTool==0.4.9
 pyhashlookup==1.1.1
+pyimpfuzzy==0.5
 pymisp==2.4.144
 pypdns==1.5.2
 pypssl==2.2


### PR DESCRIPTION
# Description

Added new [Dhashicon](https://github.com/fr0gger/SuperPeHasher/commit/e9b753bf52d4e48dda2da0b7801075be4037a161#diff-2bb2d2d4d25fef20a893a4e93e96c9b8c0b0c6d5791fc14594cc9dd5cbf40b41) and [ImpFuzzy](https://github.com/JPCERTCC/impfuzzy) hashes to `PE_Info` analyzer. Results now include `dhashicon_hash` and `impfuzzy_hash` values as `string` types.

This PR is still a draft

## Related issues
#569

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [x] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  
### Important Rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review

# Real World Example

![image](https://user-images.githubusercontent.com/66906402/149163996-aee2e42d-ea69-4570-bc4e-1503b734fe96.png)

