### PR TITLE
Sphinx Build Github Action on Release

### DIFF
--- a/.github/workflows/sphinx_build_on_release.yml
+++ b/.github/workflows/sphinx_build_on_release.yml
@@ -1,6 +1,9 @@
 name: Sphinx Build on Release
 
-on: push
+on:
+  pull_request:
+    branches:
+      - master
 
 jobs:
   build:

--- a/.github/workflows/sphinx_build_on_release.yml
+++ b/.github/workflows/sphinx_build_on_release.yml
@@ -1,6 +1,6 @@
 name: Sphinx Build on Release
 
-on: release
+on: push
 
 jobs:
   build:
@@ -16,11 +16,6 @@ jobs:
       - name: Install docs requirements
         run: |
           pip install -r docs/source/requirements.txt
-
-      # Why do we have to do this?
-      - name: Install additional requirements
-        run: |
-          pip install recommonmark
 
       - name: Build docs
         run: |

--- a/.github/workflows/sphinx_build_on_release.yml
+++ b/.github/workflows/sphinx_build_on_release.yml
@@ -1,0 +1,27 @@
+name: Sphinx Build on Release
+
+on: release
+
+jobs:
+  build:
+
+    runs-on: ubuntu-latest
+
+    steps:
+      - uses: actions/checkout@v2
+      - name: Set up Python
+        uses: actions/setup-python@v2
+        with:
+          python-version: 3.9
+      - name: Install docs requirements
+        run: |
+          pip install -r docs/source/requirements.txt
+
+      # Why do we have to do this?
+      - name: Install additional requirements
+        run: |
+          pip install recommonmark
+
+      - name: Build docs
+        run: |
+          make -C docs html

--- a/docs/source/requirements.txt
+++ b/docs/source/requirements.txt
@@ -3,3 +3,4 @@ sphinxcontrib-openapi==0.7.0
 sphinxcontrib-redoc==1.6.0
 # this is to fix this bug https://github.com/Tribler/tribler/issues/6624
 mistune==0.8.4
+recommonmark==0.7.1


### PR DESCRIPTION
# Description
Added github action to build docs on release

## Related issues

#804 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
    - [ ] If a File analyzer was added, it's name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [X] The tests gave 0 errors.
- [X] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [X] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  
### Important Rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review

