### PR TITLE
Fixed a bug in PR #848

### DIFF
--- a/start.py
+++ b/start.py
@@ -155,7 +155,7 @@ def start():
         compose_files.extend(list(path_mapping[f"all_analyzers{test_appendix}"]))
 
     # load relevant .env file
-    load_dotenv("docker/.env" + test_appendix)
+    load_dotenv("docker/.env.start" + test_appendix)
     # construct final command
     base_command = [
         "docker-compose",


### PR DESCRIPTION
# Description

Fixed a filename typo in PR #848 

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
    - [ ] If a File analyzer was added, it's name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [X] The tests gave 0 errors.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [X] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  