### PR TITLE
Adds elasticsearch container for development. Fixes #808

### DIFF
--- a/docker/elasticsearch.override.yml
+++ b/docker/elasticsearch.override.yml
@@ -1,0 +1,21 @@
+version: '3.8'
+
+services:
+  uwsgi:
+    depends_on:
+      - elasticsearch
+
+  elasticsearch:
+    image: docker.elastic.co/elasticsearch/elasticsearch:7.17.0
+    environment:
+      - "discovery.type=single-node"
+
+  kibana:
+    image: docker.elastic.co/kibana/kibana:7.17.0
+    environment:
+      ELASTICSEARCH_HOSTS: '["http://elasticsearch:9200"]'
+    ports:
+      - '5601:5601'
+    depends_on:
+      - elasticsearch
+

--- a/docs/source/Advanced-Usage.md
+++ b/docs/source/Advanced-Usage.md
@@ -159,8 +159,9 @@ In the `env_file_app_template`, you'd see various elasticsearch related environm
 Intel Owl provides a Kibana's "Saved Object" configuration (with example dashboard and visualizations). It can be downloaded from [here](https://github.com/intelowlproject/IntelOwl/blob/develop/configuration/Kibana-Saved-Conf.ndjson) and can be imported into Kibana by going to the "Saved Objects" panel (http://localhost:5601/app/management/kibana/objects).
 
 #### Example Configuration
-1. Setup [Elastic Search and Kibana](https://hub.docker.com/r/nshou/elasticsearch-kibana/) and say it is running in a docker service with name `elk` on port `9200` which is exposed to the shared docker network.
-2. In the `env_file_app`, we set `ELASTICSEARCH_ENABLED` to `True` and `ELASTICSEARCH_HOST` to `elk:9200`.
+1. Setup [Elastic Search and Kibana](https://hub.docker.com/r/nshou/elasticsearch-kibana/) and say it is running in a docker service with name `elasticsearch` on port `9200` which is exposed to the shared docker network.
+   (Alternatively, you can spin up a local Elastic Search instance, by appending ```--elastic``` to the ```python3 start.py ...``` command. Note that the local Elastic Search instance consumes large amount of memory, and hence having >=16GB is recommended.))
+2. In the `env_file_app`, we set `ELASTICSEARCH_ENABLED` to `True` and `ELASTICSEARCH_HOST` to `elasticsearch:9200`.
 3. In the `Dockerfile`, set the correct version in `ELASTICSEARCH_DSL_VERSION` [depending on the version](https://django-elasticsearch-dsl.readthedocs.io/en/latest/about.html#features) of our elasticsearch server. Default value is `7.1.4`.
 4. Rebuild the docker images with `docker-compose build` (required only if `ELASTICSEARCH_DSL_VERSION` was changed)
 5. Now start the docker containers and execute,
@@ -170,6 +171,7 @@ Intel Owl provides a Kibana's "Saved Object" configuration (with example dashboa
   ```
 
   This will build and populate all existing job objects into the `jobs` index.
+
 
 
 ## Django Groups & Permissions

--- a/start.py
+++ b/start.py
@@ -26,6 +26,7 @@ path_mapping = {
     "test_multi_queue": "docker/test.multi-queue.override.yml",
     "flower": "docker/flower.override.yml",
     "test_flower": "docker/test.flower.override.yml",
+    "elastic": "docker/elasticsearch.override.yml",
 }
 # to fix the box-js folder name
 path_mapping.update(
@@ -114,11 +115,21 @@ def start():
         help="While using 'test' mode, this allows to use the default"
         " Django server instead of Uwsgi",
     )
+    parser.add_argument(
+        "--elastic",
+        required=False,
+        action="store_true",
+        help="This spins up Elasticsearch"
+        "and Kibana on your machine (might need >=16GB of RAM)",
+    )
+
     args, unknown = parser.parse_known_args()
     # logic
     test_appendix = ""
     if args.mode == "test":
         test_appendix = ".test"
+    # load relevant .env file
+    load_dotenv("docker/.env.start" + test_appendix)
     docker_flags = [
         args.__dict__[docker_analyzer] for docker_analyzer in docker_analyzers
     ]
@@ -138,6 +149,8 @@ def start():
             compose_files.append(path_mapping["django_server"])
         else:
             compose_files.append(path_mapping[args.mode])
+    if args.__dict__["elastic"]:
+        compose_files.append(path_mapping["elastic"])
     # upgrades
     for key in ["traefik", "multi_queue", "custom", "flower"]:
         if args.__dict__[key]:
@@ -154,8 +167,6 @@ def start():
     if args.all_analyzers:
         compose_files.extend(list(path_mapping[f"all_analyzers{test_appendix}"]))
 
-    # load relevant .env file
-    load_dotenv("docker/.env.start" + test_appendix)
     # construct final command
     base_command = [
         "docker-compose",


### PR DESCRIPTION
# Description

Added elasticsearch container for development purposes. The container does not run by default but can be triggered by one of two mechanisms as described in the ```Elastic Search``` section of ```Advanced-Usage``` documentation.

## Related issues
#808 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in it's class to apply the necessary decorators.
    - [ ] If a File analyzer was added, it's name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [X] The tests gave 0 errors.
- [X] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [X] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  
### Important Rules
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review
