### PR TITLE
package installations moved from dockerfile to requirements.txt for dependabot

### DIFF
--- a/integrations/static_analyzers/Dockerfile
+++ b/integrations/static_analyzers/Dockerfile
@@ -15,8 +15,8 @@ RUN useradd -ms /bin/bash static_analyzers-user
 
 # Install capa
 WORKDIR ${PROJECT_PATH}
-RUN pip3 install --no-cache-dir flare-capa==2.0.0 \
-    && git clone --depth 1 https://github.com/fireeye/capa-rules.git
+# flare-capa package is in requirements.txt
+RUN git clone --depth 1 https://github.com/fireeye/capa-rules.git
 
 # Install FLOSS nightly binary
 RUN wget -q -O floss-linux https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/linux/dist/floss \
@@ -29,9 +29,6 @@ RUN git clone --depth 1 https://github.com/guelfoweb/peframe.git
 RUN cd peframe && rm -rf .git && pip3 install -r requirements.txt --no-cache-dir \
     && python3 setup.py install \
     && rm -rf ./peframe
-
-# Install stringsifter
-RUN pip3 install --no-cache-dir stringsifter==2.20201202
 
 # Install and build Manalyze
 RUN git clone https://github.com/JusticeRage/Manalyze.git \

--- a/integrations/static_analyzers/requirements.txt
+++ b/integrations/static_analyzers/requirements.txt
@@ -1,2 +1,4 @@
 Flask-Shell2HTTP~=1.8.0
 gunicorn~=20.1.0
+flare-capa~=2.0.0
+stringsifter~=2.20201202


### PR DESCRIPTION
# Description
suitable package installations moved from dockerfile to requirements.txt so that they can be managed by dependabot.

## Related issues
#882 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)

