### PR TITLE
Capa V3 Update

### DIFF
--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -249,7 +249,9 @@
     "leaks_info": false,
     "docker_based": true,
     "supported_filetypes": [
-      "application/x-dosexec"
+      "application/x-dosexec",
+      "application/x-sharedlib",
+      "application/x-executable"
     ],
     "config": {
       "soft_time_limit": 500,

--- a/integrations/static_analyzers/Dockerfile
+++ b/integrations/static_analyzers/Dockerfile
@@ -15,8 +15,9 @@ RUN useradd -ms /bin/bash static_analyzers-user
 
 # Install capa
 WORKDIR ${PROJECT_PATH}
-# flare-capa package is in requirements.txt
-RUN git clone --depth 1 https://github.com/fireeye/capa-rules.git
+RUN git clone --depth 1 https://github.com/mandiant/capa.git \
+    && pip install -e capa --no-cache-dir
+RUN git clone --depth 1 https://github.com/mandiant/capa-rules.git
 
 # Install FLOSS nightly binary
 RUN wget -q -O floss-linux https://s3.amazonaws.com/build-artifacts.floss.flare.fireeye.com/travis/linux/dist/floss \

--- a/integrations/static_analyzers/requirements.txt
+++ b/integrations/static_analyzers/requirements.txt
@@ -1,4 +1,3 @@
 Flask-Shell2HTTP~=1.8.0
 gunicorn~=20.1.0
-flare-capa~=2.0.0
 stringsifter~=2.20201202


### PR DESCRIPTION
Updated package and allow ELF files

# Description

IntelOwl currently uses capa v2.0.0. This PR updates it to use the latest version 3.1.0
The capa repository is cloned and capa is installed from the local source.
Also allowed the analyzer to be used on ELF files.

## Related issues
closes #708 

## Type of change
- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)

# Real World Example
![capav3](https://user-images.githubusercontent.com/57103973/153644773-770b4600-eea5-46ba-9617-24ebe8c6705d.png)


