### PR TITLE
Add shellcode option to floss, speakeasy and capa

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/capa_info.py
+++ b/api_app/analyzers_manager/file_analyzers/capa_info.py
@@ -15,12 +15,22 @@ class CapaInfo(FileAnalyzer, DockerBasedAnalyzer):
     timeout: int = 60 * 9
     # whereas subprocess timeout is kept as 60 * 9 = 9 minutes
 
+    def set_params(self, params):
+        self.args = []
+        arch = params.get("arch", "64")
+        if arch != "64":
+            arch = "32"
+        shellcode = params.get("shellcode", False)
+        if shellcode:
+            self.args.append("-f")
+            self.args.append("sc" + arch)
+
     def run(self):
         # get binary
         binary = self.read_file_bytes()
         # make request data
         fname = str(self.filename).replace("/", "_").replace(" ", "_")
-        args = [f"@{fname}", "-j"]
+        args = [f"@{fname}", "-j", *self.args]
         req_data = {"args": args, "timeout": self.timeout}
         req_files = {fname: binary}
 

--- a/api_app/analyzers_manager/file_analyzers/speakeasy_emulation.py
+++ b/api_app/analyzers_manager/file_analyzers/speakeasy_emulation.py
@@ -4,6 +4,7 @@
 import logging
 
 import speakeasy
+import speakeasy.winenv.arch as e_arch
 
 from api_app.analyzers_manager.classes import FileAnalyzer
 
@@ -11,11 +12,24 @@ logger = logging.getLogger(__name__)
 
 
 class SpeakEasy(FileAnalyzer):
+
+    def set_params(self, params):
+        self.raw_offset = params.get("raw_offset", 0x0)
+        self.arch = params.get("arch", "x64")
+        self.shellcode = params.get("shellcode", False)
+
     def run(self):
         results = {}
         s = speakeasy.Speakeasy()
-        m = s.load_module(self.filepath)
-        s.run_module(m)
+        if self.shellcode:
+            arch = e_arch.ARCH_AMD64
+            if self.arch == 'x86':
+                arch = e_arch.ARCH_X86
+            sc_addr = s.load_shellcode(self.filepath, arch)
+            s.run_shellcode(sc_addr, offset=self.raw_offset or 0)
+        else:
+            m = s.load_module(self.filepath)
+            s.run_module(m)
         results = s.get_report()
 
         return results

--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -259,6 +259,34 @@
     "secrets": {},
     "params": {}
   },
+  "Capa_Info_Shellcode": {
+    "type": "file",
+    "python_module": "capa_info.CapaInfo",
+    "description": "capa detects capabilities in shellcode files",
+    "disabled": false,
+    "external_service": false,
+    "leaks_info": false,
+    "supported_filetypes": [
+      "application/octet-stream"
+    ],
+    "config": {
+      "soft_time_limit": 500,
+      "queue": "long"
+    },
+    "secrets": {},
+    "params": {
+      "arch": {
+        "value": "64",
+        "type": "str",
+        "description": "Change system architecture for the shellcode (32 or 64)."
+      },
+      "shellcode": {
+        "value": true,
+        "type": "bool",
+        "description": "true if the file is a shellcode."
+      }
+    }
+  },
   "CapeSandbox": {
     "type": "file",
     "python_module": "cape_sandbox.CAPEsandbox",
@@ -869,7 +897,8 @@
     "leaks_info": false,
     "docker_based": true,
     "supported_filetypes": [
-      "application/x-dosexec"
+      "application/x-dosexec",
+      "application/octet-stream"
     ],
     "config": {
       "soft_time_limit": 500,
@@ -2679,6 +2708,39 @@
     },
     "secrets": {},
     "params": {}
+  },
+  "SpeakEasy_Shellcode": {
+    "type": "file",
+    "python_module": "speakeasy_emulation.SpeakEasy",
+    "description": "speakeasy emulation shellcode report",
+    "disabled": false,
+    "external_service": false,
+    "leaks_info": false,
+    "supported_filetypes": [
+      "application/octet-stream"
+    ],
+    "config": {
+      "soft_time_limit": 120,
+      "queue": "long"
+    },
+    "secrets": {},
+    "params": {
+      "arch": {
+        "value": "x64",
+        "type": "str",
+        "description": "Change system architecture for the shellcode (x86 or x64)."
+      },
+      "shellcode": {
+        "value": true,
+        "type": "bool",
+        "description": "true if the file is a shellcode."
+      },
+      "raw_offset": {
+        "value": 0,
+        "type": "int",
+        "description": "Offset to start emulating."
+      }
+    }
   },
   "Spyse": {
     "type": "observable",


### PR DESCRIPTION
# Description
Add option to analyze shellcode in analyzer: floss, capa and speakeasy

## Related issues
issue #898 (https://github.com/intelowlproject/IntelOwl/issues/898)

## Type of change

- [X] New feature (non-breaking change which adds functionality).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project

