### PR TITLE
MISP Add generic and strict search

### DIFF
--- a/configuration/analyzer_config.json
+++ b/configuration/analyzer_config.json
@@ -1744,7 +1744,8 @@
       "ip",
       "domain",
       "url",
-      "hash"
+      "hash",
+      "generic"
     ],
     "config": {
       "soft_time_limit": 30,
@@ -1792,6 +1793,11 @@
         "value": true,
         "type": "bool",
         "description": "Remove any attributes from the result that would cause a hit on a warninglist entry."
+      },
+      "strict_search": {
+        "value": true,
+        "type": "bool",
+        "description": "Search strictly on the observable value (True) or search on attributes containing observable value (False)"
       }
     }
   },

--- a/docs/source/Usage.md
+++ b/docs/source/Usage.md
@@ -293,6 +293,7 @@ Some analyzers require details other than just IP, URL, Domain, etc. We classifi
 * `Anomali_Threatstream_Confidence`: Give max, average and minimum confidence of maliciousness for an observable. On [Anomali Threatstream](https://www.anomali.com/products/threatstream) Confidence API.
 * `Anomali_Threatstream_Intelligence`: Search for threat intelligence information about an observable. On [Anomali Threatstream](https://www.anomali.com/products/threatstream) Intelligence API. 
 * `VirusTotal_v3_Intelligence_Search`: Perform advanced queries with [VirusTotal Intelligence](https://developers.virustotal.com/reference/intelligence-search) (requires paid plan)
+* `MISP`: scan an observable on a MISP instance
 
 ##### Extra analyzers
 [Additional analyzers](Advanced-Usage.html#optional-analyzers) that can be enabled per your wish.


### PR DESCRIPTION
# Description
Add generic observable but also the capacity to search on attribute containing observable (previously it was only strictly equals to)

## Related issues
#967 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [ ] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
  
# Documentation 
Don't correspond to documentation (searchall should be a boolean) but couldn't be able to do it works in that way...

# Real World Example
## With strict search
No result because in the attribute it is something like "TEMP\tmpe846.tmp"
![image](https://user-images.githubusercontent.com/103488825/166485586-b0dac196-454f-468a-a9bd-1c0922cfd4cb.png)

## Without strict-search
With result because the usage of wildcard
![image](https://user-images.githubusercontent.com/103488825/166484871-3295ef99-fac4-4fbc-97cc-ed22da941ece.png)

