### PR TITLE
Used NewJsonRenderer instead of CustomJsonInput

### DIFF
--- a/docker/Dockerfile
+++ b/docker/Dockerfile
@@ -1,4 +1,5 @@
-# Stage 1: Frontend 
+# Stage 1: Frontend
+# Remove this part if it is conflicting with the frontend you are currently testing
 FROM node:lts-alpine3.14 as frontend-build
 
 WORKDIR /

--- a/docs/source/Contribute.md
+++ b/docs/source/Contribute.md
@@ -90,6 +90,7 @@ python3 start.py prod up
 <ul>
 <li>Running `prod` would be faster because you would leverage the official images and you won't need to build the backend locally. In case you would need to test backend changes too at the same time, please use `test` and refer to the previous section of the documentation.</li>
 <li>This works thanks to the directive `proxy` in the `frontend/package.json` configuration</li>
+<li>It may happen that the backend build does not work due to incompatibility between the frontend version you are testing with the current complete IntelOwl version you are running. In those cases, considering that you don't need to build the frontend together with the backend because you are already testing it separately, we suggest to remove the first build step (the frontend part) from the main Dockerfile temporarily and build IntelOwl with only the backend. In this way there won't be conflict issues.</li>
 </ul>
 </div>
 

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -4,7 +4,7 @@
   "private": true,
   "proxy": "http://localhost:80/",
   "dependencies": {
-    "@certego/certego-ui": "^0.1.0",
+    "@certego/certego-ui": "^0.1.1",
     "axios": "^0.27.2",
     "axios-hooks": "^3.0.4",
     "bootstrap": "^5.1.3",

--- a/frontend/src/components/jobs/result/utils/tables.jsx
+++ b/frontend/src/components/jobs/result/utils/tables.jsx
@@ -108,6 +108,7 @@ const tableProps = {
   },
   SubComponent: ({ row }) => (
     <NewJsonRenderer
+      collapsed={2}
       onEdit={() => null}
       key={row.id}
       id={`jobreport-jsoninput-${row.id}`}

--- a/frontend/src/components/jobs/result/utils/tables.jsx
+++ b/frontend/src/components/jobs/result/utils/tables.jsx
@@ -4,7 +4,7 @@ import PropTypes from "prop-types";
 import { MdOutlineRefresh, MdPauseCircleOutline } from "react-icons/md";
 
 import {
-  CustomJsonInput,
+  NewJsonRenderer,
   DataTable,
   DefaultColumnFilter,
   IconButton,
@@ -107,19 +107,16 @@ const tableProps = {
     ],
   },
   SubComponent: ({ row }) => (
-    <CustomJsonInput
-      viewOnly
-      confirmGood={false}
-      onChange={() => null}
+    <NewJsonRenderer
+      onEdit={() => null}
       key={row.id}
       id={`jobreport-jsoninput-${row.id}`}
-      placeholder={{
+      jsonData={{
         report: row.original?.report,
         errors: row.original?.errors,
         runtime_configuration: row.original?.runtime_configuration,
       }}
-      height="50vh"
-      width="90vw"
+      style={{ height: "50vh", width: "90vw", overflow: "scroll" }}
     />
   ),
 };


### PR DESCRIPTION
# Description

Used NewJsonRenderer instead of CustomJsonInput

## Related issues

closes #959 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] If a File analyzer was added, its name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [x] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)