### PR TITLE
Extends key (closes #752)

### DIFF
--- a/api_app/core/serializers.py
+++ b/api_app/core/serializers.py
@@ -6,6 +6,7 @@ import json
 import logging
 import os
 import sys
+from copy import deepcopy
 from typing import List, Optional, TypedDict
 
 from cache_memoize import cache_memoize
@@ -95,6 +96,7 @@ class AbstractConfigSerializer(rfs.Serializer):
     params = rfs.DictField(child=_ParamSerializer())
     # automatically populated fields
     verification = rfs.SerializerMethodField()
+    extends = rfs.CharField(allow_blank=True, required=False)
 
     def is_valid(self, raise_exception=False):
         ret = super().is_valid(raise_exception=raise_exception)
@@ -164,6 +166,31 @@ class AbstractConfigSerializer(rfs.Serializer):
         return md5hash
 
     @classmethod
+    def _complete_config(
+        cls, config_dict: dict, plugin_name: str, visited: set
+    ) -> dict:
+        """
+        Completes config by parsing extends configs
+        """
+        if plugin_name in visited:
+            raise RuntimeError(f"Circular dependency detected in {cls} config")
+        visited.add(plugin_name)
+        if plugin_name not in config_dict:
+            raise RuntimeError(
+                f"Plugin {plugin_name} not found in {cls} config "
+                "but referenced in extends"
+            )
+        if "extends" in config_dict[plugin_name]:
+            temp = config_dict[plugin_name]
+            parent_plugin = temp.pop("extends")
+            config_dict[plugin_name] = deepcopy(
+                cls._complete_config(config_dict, parent_plugin, visited)
+            )
+            for key in temp:
+                config_dict[plugin_name][key] = temp[key]
+        return config_dict[plugin_name]
+
+    @classmethod
     @cache_memoize(
         timeout=sys.maxsize,
         args_rewrite=lambda cls: f"{cls.__name__}-{cls._md5_config_file()}",
@@ -174,6 +201,8 @@ class AbstractConfigSerializer(rfs.Serializer):
         This function is memoized for the md5sum of the JSON file.
         """
         config_dict = cls._read_config()
+        for plugin in config_dict:
+            cls._complete_config(config_dict, plugin, set())
         serializer_errors = {}
         for key, config in config_dict.items():
             new_config = {"name": key, **config}

--- a/tests/api_app/test_config_parse.py
+++ b/tests/api_app/test_config_parse.py
@@ -1,7 +1,5 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
-import random
-from hashlib import md5
 from unittest.mock import Mock, patch
 
 from django.test import TestCase
@@ -10,9 +8,11 @@ from api_app.core.serializers import AbstractConfigSerializer
 
 
 class ConfigParseTests(TestCase):
-    @patch("api_app.core.serializers.AbstractConfigSerializer._md5_config_file")
+    @patch(
+        "api_app.core.serializers.AbstractConfigSerializer._md5_config_file", new=Mock()
+    )
     @patch("api_app.core.serializers.AbstractConfigSerializer._read_config")
-    def test_extends(self, mock_read_config: Mock, mock_md5_config_file: Mock):
+    def test_extends(self, mock_read_config: Mock):
         sample_analyzer_config = {
             "Shodan_Honeyscore": {
                 "type": "observable",
@@ -52,23 +52,60 @@ class ConfigParseTests(TestCase):
         }
 
         pre_parsed_sample_config = {
-            "Shodan_Honeyscore": sample_analyzer_config["Shodan_Honeyscore"],
+            "Shodan_Honeyscore": {
+                "type": "observable",
+                "python_module": "shodan.Shodan",
+                "description": "scan an IP against Shodan Honeyscore API",
+                "disabled": False,
+                "external_service": True,
+                "leaks_info": False,
+                "observable_supported": ["ip"],
+                "config": {"soft_time_limit": 30, "queue": "default"},
+                "secrets": {
+                    "api_key_name": {
+                        "env_var_key": "SHODAN_KEY",
+                        "description": "",
+                        "required": True,
+                    }
+                },
+                "params": {
+                    "shodan_analysis": {
+                        "value": "honeyscore",
+                        "type": "str",
+                        "description": "",
+                    }
+                },
+            },
             "Shodan_Search": {
-                **sample_analyzer_config["Shodan_Honeyscore"],
-                **sample_analyzer_config["Shodan_Search"],
+                "type": "observable",
+                "python_module": "shodan.Shodan",
+                "disabled": False,
+                "external_service": True,
+                "leaks_info": False,
+                "observable_supported": ["ip"],
+                "config": {"soft_time_limit": 30, "queue": "default"},
+                "secrets": {
+                    "api_key_name": {
+                        "env_var_key": "SHODAN_KEY",
+                        "description": "",
+                        "required": True,
+                    }
+                },
+                "description": "scan an IP against Shodan Search API",
+                "params": {
+                    "shodan_analysis": {
+                        "value": "search",
+                        "type": "str",
+                        "description": "",
+                    }
+                },
             },
         }
-        pre_parsed_sample_config["Shodan_Search"].pop("extends")
 
         mock_read_config.return_value = sample_analyzer_config
-        mock_md5_config_file.return_value = md5(
-            str(random.random()).encode("utf-8")
-        ).hexdigest()
-        parsed_config = AbstractConfigSerializer.read_and_verify_config()
+        # _refresh ensures that cache isn't used, if any
+        parsed_config = AbstractConfigSerializer.read_and_verify_config(_refresh=True)
 
         mock_read_config.return_value = pre_parsed_sample_config
-        mock_md5_config_file.return_value = md5(
-            str(random.random()).encode("utf-8")
-        ).hexdigest()
-        expected_config = AbstractConfigSerializer.read_and_verify_config()
+        expected_config = AbstractConfigSerializer.read_and_verify_config(_refresh=True)
         self.assertDictEqual(parsed_config, expected_config)

--- a/tests/api_app/test_config_parse.py
+++ b/tests/api_app/test_config_parse.py
@@ -1,0 +1,77 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+import random
+from hashlib import md5
+
+from django.test import TestCase
+
+from api_app.core.serializers import AbstractConfigSerializer
+
+
+class ModAbstractConfigSerializer(AbstractConfigSerializer):
+    input_config = None
+
+    @classmethod
+    def _md5_config_file(cls) -> str:
+        return md5(str(random.random()).encode("utf-8")).hexdigest()
+
+    @classmethod
+    def _read_config(cls):
+        return cls.input_config
+
+
+class ConfigParseTests(TestCase):
+    def test_extends(self):
+        sample_analyzer_config = {
+            "Shodan_Honeyscore": {
+                "type": "observable",
+                "python_module": "shodan.Shodan",
+                "description": "scan an IP against Shodan Honeyscore API",
+                "disabled": False,
+                "external_service": True,
+                "leaks_info": False,
+                "observable_supported": ["ip"],
+                "config": {"soft_time_limit": 30, "queue": "default"},
+                "secrets": {
+                    "api_key_name": {
+                        "env_var_key": "SHODAN_KEY",
+                        "description": "",
+                        "required": True,
+                    }
+                },
+                "params": {
+                    "shodan_analysis": {
+                        "value": "honeyscore",
+                        "type": "str",
+                        "description": "",
+                    }
+                },
+            },
+            "Shodan_Search": {
+                "extends": "Shodan_Honeyscore",
+                "description": "scan an IP against Shodan Search API",
+                "params": {
+                    "shodan_analysis": {
+                        "value": "search",
+                        "type": "str",
+                        "description": "",
+                    }
+                },
+            },
+        }
+
+        pre_parsed_sample_config = {
+            "Shodan_Honeyscore": sample_analyzer_config["Shodan_Honeyscore"],
+            "Shodan_Search": {
+                **sample_analyzer_config["Shodan_Honeyscore"],
+                **sample_analyzer_config["Shodan_Search"],
+            },
+        }
+        pre_parsed_sample_config["Shodan_Search"].pop("extends")
+
+        ModAbstractConfigSerializer.input_config = sample_analyzer_config
+        parsed_config = ModAbstractConfigSerializer.read_and_verify_config()
+
+        ModAbstractConfigSerializer.input_config = pre_parsed_sample_config
+        expected_config = ModAbstractConfigSerializer.read_and_verify_config()
+        self.assertDictEqual(parsed_config, expected_config)


### PR DESCRIPTION
# Description

Parsing of `extends` in plugin configuration

## Related issues
#752 

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [X] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new analyzer or connector was added, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the analyzer/connector provides additional optional configuration).
    - [ ] Secrets were added in [env_file_app_template](https://github.com/intelowlproject/IntelOwl/blob/master/docker/env_file_app_template), [env_file_app_ci](https://github.com/certego/IntelOwl/blob/master/docker/env_file_app_ci) and in the [Installation](./Installation.md) docs, if necessary.
    - [ ] If the analyzer/connector requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] If a File analyzer was added, its name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] The tests gave 0 errors.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] The commits were squashed into a single one (optional, they will be squashed anyway by the maintainer)
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check `CONTRIBUTE.md`).
 
