### PR TITLE
fix initialize.sh docker condition

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -92,7 +92,7 @@ if  [ "$(docker --help | grep -q 'compose')" == 0 ] && ! [ -x "$(command -v dock
     exit 1
   fi
 else
-  if  [ "$(docker --help | grep -q 'compose')" == 0 ]; then
+  if  docker --help | grep -q 'compose'; then
     docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
   else
     IFS=',' read -ra temp <<< "$(docker-compose --version)"


### PR DESCRIPTION
# Description

In a bash shell the first type of docker compose version parser in the `if...else...fi` condition was not reachable even if the exit code of the command in the condition was 0:

![image](https://user-images.githubusercontent.com/60733449/222349576-c8f0f14d-58e0-4f7d-803f-c7ca65c1ed3a.png)

The second type of condition check is used in the fixed `initialize.sh` to run correctly. If the command exits with a successful code, the condition is true, else it's false and it goes on with the `else` branch. There is no need to compare the exit code to 0.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector or playbook) was added or changed, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the plugin provides additional optional configuration).
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] If a File analyzer was added, its name was explicitly defined in [test_file_scripts.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_file_scripts.py) (not required for Observable Analyzers).
    - [ ] If you created a new analyzer and it is free (does not require API keys), please add it in the `FREE_TO_USE_ANALYZERS` playbook in `playbook_config.json`
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](./Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.