### PR TITLE
added support admins pluginconfig managemnent #1470

### DIFF
--- a/api_app/models.py
+++ b/api_app/models.py
@@ -593,13 +593,6 @@ class PluginConfig(models.Model):
                 f"You can't create `for_organization` {self.__class__.__name__}"
                 " if you do not have an organization"
             )
-        if self.for_organization and (
-            self.owner.has_membership()
-            and self.owner.membership.organization.owner != self.owner
-        ):
-            raise ValidationError(
-                "Only organization owner can create configuration at the org level"
-            )
 
     def clean_value(self):
         from django.forms.fields import JSONString

--- a/api_app/permissions.py
+++ b/api_app/permissions.py
@@ -14,3 +14,16 @@ class IsObjectRealOwnerPermission(BasePermission):
         if obj_owner := getattr(obj, "owner", None):
             return obj_owner == request.user
         return False
+
+
+class IsObjectAdminPermission(BasePermission):
+    @staticmethod
+    def has_object_permission(request, view, obj):
+        if request.user.has_membership():
+            return request.user.membership.is_admin
+        return False
+
+
+IsObjectRealOwnerOrAdminPermission = (
+    IsObjectRealOwnerPermission | IsObjectAdminPermission  # pylint: disable=E1131
+)

--- a/api_app/permissions.py
+++ b/api_app/permissions.py
@@ -8,14 +8,6 @@ from rest_framework.permissions import BasePermission
 logger = getLogger(__name__)
 
 
-class IsObjectRealOwnerPermission(BasePermission):
-    @staticmethod
-    def has_object_permission(request, view, obj):
-        if obj_owner := getattr(obj, "owner", None):
-            return obj_owner == request.user
-        return False
-
-
 class IsObjectAdminPermission(BasePermission):
     @staticmethod
     def has_object_permission(request, view, obj):

--- a/api_app/queryset.py
+++ b/api_app/queryset.py
@@ -210,17 +210,15 @@ class PluginConfigQuerySet(CleanOnCreateQuerySet):
                 # we don't need to do anything.
                 return self.filter(Q(owner=user) | Q(owner__isnull=True))
             else:
-                if membership.is_admin:
-                    return self.filter(Q(for_organization=True) | Q(owner__isnull=True))
-                else:
-                    return self.filter(
-                        (
-                            Q(for_organization=True)
-                            & Q(owner=membership.organization.owner)
-                        )
-                        | Q(owner=user)
-                        | Q(owner__isnull=True)
+                # If you are member of an organization you should see the configs.
+                return self.filter(
+                    Q(
+                        for_organization=True,
+                        owner__membership__organization=membership.organization,
                     )
+                    | Q(owner=user)
+                    | Q(owner__isnull=True)
+                )
         else:
             return self.filter(owner__isnull=True)
 

--- a/api_app/queryset.py
+++ b/api_app/queryset.py
@@ -210,11 +210,17 @@ class PluginConfigQuerySet(CleanOnCreateQuerySet):
                 # we don't need to do anything.
                 return self.filter(Q(owner=user) | Q(owner__isnull=True))
             else:
-                return self.filter(
-                    (Q(for_organization=True) & Q(owner=membership.organization.owner))
-                    | Q(owner=user)
-                    | Q(owner__isnull=True)
-                )
+                if membership.is_admin:
+                    return self.filter(Q(for_organization=True) | Q(owner__isnull=True))
+                else:
+                    return self.filter(
+                        (
+                            Q(for_organization=True)
+                            & Q(owner=membership.organization.owner)
+                        )
+                        | Q(owner=user)
+                        | Q(owner__isnull=True)
+                    )
         else:
             return self.filter(owner__isnull=True)
 

--- a/api_app/serializers.py
+++ b/api_app/serializers.py
@@ -879,6 +879,12 @@ class PluginConfigSerializer(rfs.ModelSerializer):
                     raise ValidationError({"detail": "Value is not JSON-compliant."})
 
         def get_attribute(self, instance: PluginConfig):
+            # We return `redacted` when
+            # 1) is a secret AND
+            # 2) is a value for the organization AND
+            # (NOR OPERATOR)
+            # 3) we are not its owner OR
+            # 4) we are not an admin of the same organization
             if (
                 instance.is_secret()
                 and instance.for_organization
@@ -930,6 +936,10 @@ class PluginConfigSerializer(rfs.ModelSerializer):
             return attrs
         if "organization" in attrs and attrs["organization"]:
             org = attrs.pop("organization")
+            # we raise ValidationError() when
+            # (NOR OPERATOR)
+            # 1 - we are not owner  OR
+            # 2 - we are not admin of the same org
             if not (
                 org.owner == attrs["owner"]
                 or (

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -43,7 +43,7 @@ from .models import (
     PythonConfig,
     Tag,
 )
-from .permissions import IsObjectRealOwnerOrAdminPermission
+from .permissions import IsObjectAdminPermission
 from .pivots_manager.models import PivotConfig
 from .serializers import (
     CommentSerializer,
@@ -573,7 +573,7 @@ class PluginConfigViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         permissions = super().get_permissions()
         if self.request.method in ["PATCH", "DELETE"]:
-            permissions.append(IsObjectRealOwnerOrAdminPermission())
+            permissions.append(IsObjectAdminPermission())
         elif self.request.method == "PUT":
             raise PermissionDenied()
         return permissions
@@ -761,9 +761,7 @@ class AbstractConfigViewSet(viewsets.ReadOnlyModelViewSet, metaclass=ABCMeta):
         logger.info(f"get disable_in_org from user {request.user}, name {pk}")
         obj: AbstractConfig = self.get_object()
         if request.user.has_membership():
-            if not (
-                request.user.membership.is_owner or request.user.membership.is_admin
-            ):
+            if not request.user.membership.is_admin:
                 raise PermissionDenied()
         else:
             raise PermissionDenied()
@@ -778,9 +776,7 @@ class AbstractConfigViewSet(viewsets.ReadOnlyModelViewSet, metaclass=ABCMeta):
         logger.info(f"get enable_in_org from user {request.user}, name {pk}")
         obj: AbstractConfig = self.get_object()
         if request.user.has_membership():
-            if not (
-                request.user.membership.is_owner or request.user.membership.is_admin
-            ):
+            if not request.user.membership.is_admin:
                 raise PermissionDenied()
         else:
             raise PermissionDenied()

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -760,7 +760,12 @@ class AbstractConfigViewSet(viewsets.ReadOnlyModelViewSet, metaclass=ABCMeta):
     def disable_in_org(self, request, pk=None):
         logger.info(f"get disable_in_org from user {request.user}, name {pk}")
         obj: AbstractConfig = self.get_object()
-        if not request.user.has_membership() or not request.user.membership.is_owner:
+        if request.user.has_membership():
+            if not (
+                request.user.membership.is_owner or request.user.membership.is_admin
+            ):
+                raise PermissionDenied()
+        else:
             raise PermissionDenied()
         organization = request.user.membership.organization
         if obj.disabled_in_organizations.filter(pk=organization.pk).exists():
@@ -772,7 +777,12 @@ class AbstractConfigViewSet(viewsets.ReadOnlyModelViewSet, metaclass=ABCMeta):
     def enable_in_org(self, request, pk=None):
         logger.info(f"get enable_in_org from user {request.user}, name {pk}")
         obj: AbstractConfig = self.get_object()
-        if not request.user.has_membership() or not request.user.membership.is_owner:
+        if request.user.has_membership():
+            if not (
+                request.user.membership.is_owner or request.user.membership.is_admin
+            ):
+                raise PermissionDenied()
+        else:
             raise PermissionDenied()
         organization = request.user.membership.organization
         if not obj.disabled_in_organizations.filter(pk=organization.pk).exists():

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -43,7 +43,7 @@ from .models import (
     PythonConfig,
     Tag,
 )
-from .permissions import IsObjectRealOwnerPermission
+from .permissions import IsObjectRealOwnerOrAdminPermission
 from .pivots_manager.models import PivotConfig
 from .serializers import (
     CommentSerializer,
@@ -573,7 +573,7 @@ class PluginConfigViewSet(viewsets.ModelViewSet):
     def get_permissions(self):
         permissions = super().get_permissions()
         if self.request.method in ["PATCH", "DELETE"]:
-            permissions.append(IsObjectRealOwnerPermission())
+            permissions.append(IsObjectRealOwnerOrAdminPermission())
         elif self.request.method == "PUT":
             raise PermissionDenied()
         return permissions

--- a/requirements/certego-requirements.txt
+++ b/requirements/certego-requirements.txt
@@ -1,4 +1,4 @@
-certego-saas==0.6.0
+certego-saas==0.7.0
 # While developing for certego-saas, comment the previous line.
 # Then, add a line like the one below to your forked repo and your most recent commit
 # In this way you can test your changes directly in IntelOwl with the complete application

--- a/tests/__init__.py
+++ b/tests/__init__.py
@@ -30,10 +30,24 @@ class CustomTestCase(TestCase):
     @classmethod
     def setUpTestData(cls):
         try:
-            cls.user = User.objects.get(is_superuser=False)
+            cls.guest = User.objects.get(is_superuser=False, username="guest")
+        except User.DoesNotExist:
+            cls.guest = User.objects.create(
+                username="guest", email="guest@intelowl.com", password="test"
+            )
+
+        try:
+            cls.user = User.objects.get(is_superuser=False, username="user")
         except User.DoesNotExist:
             cls.user = User.objects.create(
-                username="user", email="test2@intelowl.com", password="test"
+                username="user", email="user@intelowl.com", password="test"
+            )
+
+        try:
+            cls.admin = User.objects.get(is_superuser=False, username="admin")
+        except User.DoesNotExist:
+            cls.admin = User.objects.create(
+                username="admin", email="admin@intelowl.com", password="test"
             )
 
         try:

--- a/tests/api_app/test_plugin_config.py
+++ b/tests/api_app/test_plugin_config.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from django.contrib.auth import get_user_model
 from rest_framework.reverse import reverse
 
 from api_app.analyzers_manager.models import AnalyzerConfig
@@ -11,6 +12,7 @@ from certego_saas.apps.organization.organization import Organization
 from .. import CustomViewSetTestCase
 
 custom_config_uri = reverse("plugin-config-list")
+User = get_user_model()
 
 
 class PluginConfigViewSetTestCase(CustomViewSetTestCase):
@@ -24,8 +26,26 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             type="str",
         )
         self.org = Organization.objects.create(name="testorg")
+        self.admin = User.objects.create_user(
+            username="admin",
+            email="admin@intelowl.com",
+            password="test",
+        )
+        self.admin.save()
+        self.guest = User.objects.create_user(
+            username="guest",
+            email="guest@intelowl.com",
+            password="test",
+        )
+        self.guest.save()
         Membership.objects.create(
             organization=self.org, user=self.superuser, is_owner=True
+        )
+        Membership.objects.create(
+            organization=self.org, user=self.admin, is_owner=False, is_admin=True
+        )
+        Membership.objects.create(
+            organization=self.org, user=self.user, is_owner=False, is_admin=False
         )
         self.pc = PluginConfig.objects.create(
             parameter=self.param,
@@ -45,17 +65,54 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             .filter(pk=self.pc.pk)
             .exists()
         )
+
+        # logged out
+        self.client.logout()
         response = self.client.get(f"{custom_config_uri}/{self.pc.pk}")
-        self.assertEqual(response.status_code, 404)
+        self.assertEqual(response.status_code, 401)
+
+        # the owner can see the config
         self.client.force_authenticate(user=self.superuser)
         response = self.client.get(f"{custom_config_uri}/{self.pc.pk}")
         self.assertEqual(response.status_code, 200)
 
-    def test_list(self):
-        response = self.client.get(f"{custom_config_uri}")
+        # also an admin can see the config
+        self.client.force_authenticate(user=self.admin)
+        self.assertTrue(
+            PluginConfig.objects.visible_for_user(self.admin)
+            .filter(pk=self.pc.pk)
+            .exists()
+        )
+        response = self.client.get(f"{custom_config_uri}/{self.pc.pk}")
         self.assertEqual(response.status_code, 200)
-        result = response.json()
-        self.assertEqual(0, len(result))
+
+        # a user in the org can see the config
+        self.assertTrue(
+            PluginConfig.objects.visible_for_user(self.user)
+            .filter(pk=self.pc.pk)
+            .exists()
+        )
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{custom_config_uri}/{self.pc.pk}")
+        self.assertEqual(response.status_code, 200)
+
+        # a user outside the org can not see the config
+        self.assertFalse(
+            PluginConfig.objects.visible_for_user(self.guest)
+            .filter(pk=self.pc.pk)
+            .exists()
+        )
+        self.client.force_authenticate(user=self.guest)
+        response = self.client.get(f"{custom_config_uri}/{self.pc.pk}")
+        self.assertEqual(response.status_code, 404)
+
+    def test_list(self):
+        # logged out
+        self.client.logout()
+        response = self.client.get(f"{custom_config_uri}")
+        self.assertEqual(response.status_code, 401)
+
+        # the owner can see the config
         self.client.force_authenticate(user=self.superuser)
         response = self.client.get(f"{custom_config_uri}")
         self.assertEqual(response.status_code, 200)
@@ -75,6 +132,58 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
         self.assertEqual(needle["organization"], "testorg")
         self.assertIn("value", needle)
         self.assertEqual(needle["value"], "value")
-
         self.assertIn("attribute", needle)
         self.assertEqual(needle["attribute"], "test")
+
+        # an admin can see the config
+        self.client.force_authenticate(user=self.admin)
+        response = self.client.get(f"{custom_config_uri}")
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        needle = None
+        for obj in result:
+            if obj["id"] == self.pc.pk:
+                needle = obj
+        self.assertIsNotNone(needle)
+        self.assertIn("type", needle)
+        self.assertEqual(needle["type"], "1")
+        self.assertIn("config_type", needle)
+        self.assertEqual(needle["config_type"], "2")
+        self.assertIn("plugin_name", needle)
+        self.assertEqual(needle["plugin_name"], self.param.analyzer_config.name)
+        self.assertIn("organization", needle)
+        self.assertEqual(needle["organization"], "testorg")
+        self.assertIn("value", needle)
+        self.assertEqual(needle["value"], "value")
+        self.assertIn("attribute", needle)
+        self.assertEqual(needle["attribute"], "test")
+
+        # a user in the org can see the config with redacted data
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(f"{custom_config_uri}")
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        needle = None
+        for obj in result:
+            if obj["id"] == self.pc.pk:
+                needle = obj
+        self.assertIsNotNone(needle)
+        self.assertIn("type", needle)
+        self.assertEqual(needle["type"], "1")
+        self.assertIn("config_type", needle)
+        self.assertEqual(needle["config_type"], "2")
+        self.assertIn("plugin_name", needle)
+        self.assertEqual(needle["plugin_name"], self.param.analyzer_config.name)
+        self.assertIn("organization", needle)
+        self.assertEqual(needle["organization"], "testorg")
+        self.assertIn("value", needle)
+        self.assertEqual(needle["value"], "redacted")
+        self.assertIn("attribute", needle)
+        self.assertEqual(needle["attribute"], "test")
+
+        # a user outside the org can not see the config
+        self.client.force_authenticate(user=self.guest)
+        response = self.client.get(f"{custom_config_uri}")
+        self.assertEqual(response.status_code, 200)
+        result = response.json()
+        self.assertEqual(0, len(result))

--- a/tests/api_app/test_queryset.py
+++ b/tests/api_app/test_queryset.py
@@ -348,6 +348,91 @@ class PluginConfigQuerySetTestCase(CustomTestCase):
         org.delete()
         pc.delete()
 
+    def test_admin_visible_for_own_organization(self):
+        org0 = Organization.objects.create(name="test_org_0")
+        org1 = Organization.objects.create(name="test_org_1")
+
+        m0 = Membership.objects.create(
+            user=self.superuser, organization=org0, is_owner=True
+        )
+        m1 = Membership.objects.create(
+            user=self.admin, organization=org1, is_owner=False, is_admin=True
+        )
+        m2 = Membership.objects.create(
+            user=self.user, organization=org1, is_owner=False, is_admin=False
+        )
+
+        pc0 = PluginConfig.objects.create(
+            value="test_admin_visibility_0",
+            for_organization=True,
+            owner=self.superuser,
+            parameter=Parameter.objects.first(),
+        )
+        pc1 = PluginConfig.objects.create(
+            value="test_admin_visibility_1",
+            for_organization=True,
+            owner=self.user,
+            parameter=Parameter.objects.first(),
+        )
+
+        self.assertEqual(
+            1,
+            PluginConfig.objects.filter(value="test_admin_visibility_0")
+            .visible_for_user(self.superuser)
+            .count(),
+        )
+        self.assertEqual(
+            0,
+            PluginConfig.objects.filter(value="test_admin_visibility_0")
+            .visible_for_user(self.admin)
+            .count(),
+        )
+        self.assertEqual(
+            0,
+            PluginConfig.objects.filter(value="test_admin_visibility_0")
+            .visible_for_user(self.user)
+            .count(),
+        )
+        self.assertEqual(
+            0,
+            PluginConfig.objects.filter(value="test_admin_visibility_0")
+            .visible_for_user(self.guest)
+            .count(),
+        )
+
+        self.assertEqual(
+            0,
+            PluginConfig.objects.filter(value="test_admin_visibility_1")
+            .visible_for_user(self.superuser)
+            .count(),
+        )
+        self.assertEqual(
+            1,
+            PluginConfig.objects.filter(value="test_admin_visibility_1")
+            .visible_for_user(self.admin)
+            .count(),
+        )
+        self.assertEqual(
+            1,
+            PluginConfig.objects.filter(value="test_admin_visibility_1")
+            .visible_for_user(self.user)
+            .count(),
+        )
+        self.assertEqual(
+            0,
+            PluginConfig.objects.filter(value="test_admin_visibility_1")
+            .visible_for_user(self.guest)
+            .count(),
+        )
+
+        m0.delete()
+        m1.delete()
+        m2.delete()
+        org0.delete()
+        org1.delete()
+        pc0.delete()
+        pc1.delete()
+
 
 class JobQuerySetTestCase(CustomTestCase):
     def setUp(self) -> None:

--- a/tests/api_app/test_serializers.py
+++ b/tests/api_app/test_serializers.py
@@ -84,18 +84,6 @@ class PluginConfigSerializerTestCase(CustomTestCase):
 
     def test_validate(self):
         org = Organization.objects.create(name="test_org")
-        self.admin = User.objects.create_user(
-            username="admin",
-            email="admin@intelowl.com",
-            password="test",
-        )
-        self.admin.save()
-        self.guest = User.objects.create_user(
-            username="guest",
-            email="guest@intelowl.com",
-            password="test",
-        )
-        self.guest.save()
         m1 = Membership.objects.create(
             user=self.superuser, organization=org, is_owner=True
         )


### PR DESCRIPTION
# Description

Added support to admin permission management plugin config: now you don't need to be an owner but just be an admin of an organization.
NOTE: this update do not cover the frontend.

## Type of change

- [X] New feature (non-breaking change which adds functionality).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook or ingestor) was added or changed, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the plugin provides additional optional configuration).
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require API keys), please add it in the `FREE_TO_USE_ANALYZERS` playbook in `playbook_config.json`.
    - [ ] Check if it could make sense to add that analyzer/connector to other freely available playbooks.
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [X] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [X] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](./Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.