### PR TITLE
fixed cape sandbox analyzer task status

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/cape_sandbox.py
+++ b/api_app/analyzers_manager/file_analyzers/cape_sandbox.py
@@ -251,6 +251,16 @@ class CAPEsandbox(FileAnalyzer):
                     except requests.RequestException as e:
                         raise AnalyzerRunException(e)
 
+                    results = final_request.json()
+
+                    # the task was being processed
+                    if (
+                        "error" in results
+                        and results["error"]
+                        and results["error_value"] == "Task is still being analyzed"
+                    ):
+                        raise self.ContinuePolling("Task still processing")
+
                     logger.info(
                         f" Job: {self.job_id} ->"
                         f"Poll number #{attempt}/{self.max_tries} fetched"
@@ -258,7 +268,6 @@ class CAPEsandbox(FileAnalyzer):
                         " stopping polling.."
                     )
 
-                    results = final_request.json()
                     break
 
                 else:


### PR DESCRIPTION
status "processing" is no longer available

# Description

when the analysis is being processed by the processor the status “completed“ is set, intelowl if it queries at this moment the endpoint gets an error "Task is still being analyzed".

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [X] A new plugin (analyzer, connector, visualizer, playbook or ingestor) was added or changed, in which case:
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](./Advanced-Usage.md) was updated (in case the plugin provides additional optional configuration).
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require API keys), please add it in the `FREE_TO_USE_ANALYZERS` playbook in `playbook_config.json`.
    - [ ] Check if it could make sense to add that analyzer/connector to other freely available playbooks.
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](./Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.