### PR TITLE
Shell script change

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -99,11 +99,16 @@ if  [ "$(docker --help | grep -q 'compose')" == 0 ] && ! [ -x "$(command -v dock
   fi
 else
   if  docker --help | grep -q 'compose'; then
-    docker_compose_version="$(docker compose version | awk '{print $4}' | cut -d '-' -f1)"
+    docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
   else
     IFS=',' read -ra temp <<< "$(docker-compose --version)"
     docker_compose_version=$(echo "${temp[0]}"| awk '{print $NF}')
   fi
+
+  if [[ -z "$docker_compose_version" ]]; then
+    docker_compose_version="$(docker compose version | awk '{print $4}' | cut -d '-' -f1)"
+  fi
+
   if [[ $(semantic_version_comp "$docker_compose_version" "$MINIMUM_DOCKER_COMPOSE_VERSION") == "lessThan" ]]; then
     echo "Error: Docker-compose version is too old. Please upgrade to at least $MINIMUM_DOCKER_COMPOSE_VERSION." >&2
     exit 1

--- a/initialize.sh
+++ b/initialize.sh
@@ -99,7 +99,7 @@ if  [ "$(docker --help | grep -q 'compose')" == 0 ] && ! [ -x "$(command -v dock
   fi
 else
   if  docker --help | grep -q 'compose'; then
-    docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
+    docker_compose_version="$(docker compose version | awk '{print $4}' | cut -d '-' -f1)"
   else
     IFS=',' read -ra temp <<< "$(docker-compose --version)"
     docker_compose_version=$(echo "${temp[0]}"| awk '{print $NF}')


### PR DESCRIPTION
Closes #2037 

# Description

Shell script not parsing docker compose version correctly so pre requisites not getting installed properly.
So the solution I came up with was adding an if condition to check if docker_compose_version variable was empty or not.
![image](https://github.com/intelowlproject/IntelOwl/assets/141546762/8310b0f4-41cf-4872-8909-057c36923623)


## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [x] I have a provided a screenshot of the result in the PR.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.