### PR TITLE
"Docker compose version too old" bug

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -104,6 +104,10 @@ else
     IFS=',' read -ra temp <<< "$(docker-compose --version)"
     docker_compose_version=$(echo "${temp[0]}"| awk '{print $NF}')
   fi
+  if [[ -z "$docker_compose_version" ]]; then
+    IFS=' ' read -ra temp <<< "$(docker-compose --version)"
+    docker_compose_version=$(echo "${temp[2]}"| cut -d ',' -f1)
+  fi
   if [[ $(semantic_version_comp "$docker_compose_version" "$MINIMUM_DOCKER_COMPOSE_VERSION") == "lessThan" ]]; then
     echo "Error: Docker-compose version is too old. Please upgrade to at least $MINIMUM_DOCKER_COMPOSE_VERSION." >&2
     exit 1


### PR DESCRIPTION
closes #2037 

# Description

initialize.sh related error!

Docker compose version was not being parsed correctly and the variable was having null as the content inside it so i added an if condition to account for such a situation and parse it differently.
image for reference:
![image](https://github.com/intelowlproject/IntelOwl/assets/141546762/f01ef8ca-190a-46cd-a657-72721b3e0747)

## Type of change

Please delete options that are not relevant.

- [X] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- If your changes decrease the overall tests coverage (you will know after the Codecov CI job is done), you should add the required tests to fix the problem
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.