### PR TITLE
add nerd observable analyzer

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/nerd.py
+++ b/api_app/analyzers_manager/observable_analyzers/nerd.py
@@ -1,0 +1,60 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import requests
+
+from api_app.analyzers_manager.classes import ObservableAnalyzer
+from tests.mock_utils import MockUpResponse, if_mock_connections, patch
+from api_app.analyzers_manager.exceptions import (
+    AnalyzerConfigurationException,
+    AnalyzerRunException,
+)
+
+class NERD(ObservableAnalyzer):
+    url: str = "https://nerd.cesnet.cz/nerd/api/v1"
+
+    _api_key_name: str
+    nerd_analysis: str
+
+    def run(self):
+        if self.nerd_analysis == "basic":
+            headers = {"Authorization": self._api_key_name, "Accept": "application/json"}
+            uri = f"/ip/{self.observable_name}"
+        elif self.nerd_analysis == "full":
+            headers = {"Authorization": self._api_key_name, "Accept": "application/json"}
+            uri = f"/ip/{self.observable_name}/full"
+        elif self.nerd_analysis == "rep":
+            headers = {"Authorization": self._api_key_name, "Accept": "application/json"}
+            uri = f"/ip/{self.observable_name}/rep"
+        elif self.nerd_analysis == "fmp":
+            headers = {"Authorization": self._api_key_name, "Accept": "application/json"}
+            uri = f"/ip/{self.observable_name}/fmp"
+        else:
+            raise AnalyzerConfigurationException(
+                f"analysis type: '{self.nerd_analysis}' not supported."
+                "Supported are: 'basic', 'full', 'rep', 'fmp'."
+            )
+
+        try:
+            response = requests.get(self.url + uri, headers=headers)
+            response.raise_for_status()
+        except requests.RequestException as e:
+            raise AnalyzerRunException(e)
+
+        result = response.json()
+
+        return result
+
+
+    @classmethod
+    def _monkeypatch(cls):
+
+        patches = [
+            if_mock_connections(
+                patch(
+                    "requests.get",
+                    return_value=MockUpResponse({}, 200),
+                ),
+            )
+        ]
+        return super()._monkeypatch(patches=patches)


### PR DESCRIPTION
(Please add to the PR name the issue/s that this PR would close if merged by using a [Github](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) keyword. Example: `<feature name>. Closes #999`. If your PR is made by a single commit, please add that clause in the commit too. This is all required to automate the closure of related issues.)

# Description

New observable analyzer for https://nerd.cesnet.cz/ service.

## Type of change

Please delete options that are not relevant.

- [ ] New feature (non-breaking change which adds functionality).

# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Advanced-Usage.md) was updated (in case the plugin provides additional optional configuration).
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowl.readthedocs.io/en/develop/Usage.html#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.