### PR TITLE
fix duplicated ingestor users

### DIFF
--- a/api_app/ingestors_manager/migrations/0022_ingestor_fix_duplicated_users.py
+++ b/api_app/ingestors_manager/migrations/0022_ingestor_fix_duplicated_users.py
@@ -1,0 +1,45 @@
+from django.conf import settings
+from django.db import migrations
+
+
+def migrate(apps, schema_editor):
+    User = apps.get_model(*settings.AUTH_USER_MODEL.split("."))
+    UserProfile = apps.get_model("authentication", "UserProfile")
+    IngestorConfig = apps.get_model("ingestors_manager", "IngestorConfig")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+
+    users = User.objects.filter(username__endswith="Ingestor")
+    for u in users:
+        username = u.username.removesuffix("Ingestor")
+        if username != username.title():
+            correct_user = User.objects.get_or_create(
+                username=f"{username.title()}Ingestor"
+            )[0]
+            correct_user.profile = UserProfile()
+            correct_user.profile.task_priority = 7
+            correct_user.profile.is_robot = True
+            correct_user.profile.save()
+
+            related_ingestor = IngestorConfig.objects.get(name__iexact=username)
+            related_ingestor.user = correct_user
+            related_ingestor.save()
+
+            for pc in PluginConfig.objects.filter(owner=u):
+                pc.owner = correct_user
+                pc.save()
+
+            u.delete()
+
+
+def reverse_migrate(apps, schema_editor):
+    pass
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("api_app", "0062_alter_parameter_python_module"),
+        ("ingestors_manager", "0021_ingestor_fix_malwarebazaar_threatfox"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]

--- a/api_app/ingestors_manager/signals.py
+++ b/api_app/ingestors_manager/signals.py
@@ -21,9 +21,9 @@ def pre_save_ingestor_config(sender, instance: IngestorConfig, *args, **kwargs):
     from intel_owl.tasks import execute_ingestor
 
     user = User.objects.get_or_create(
-        username__iexact=f"{instance.name.title()}Ingestor",
+        username__iexact=f"{instance.name}Ingestor",
         defaults={
-            "username": f"{instance.name.title()}Ingestor",
+            "username": f"{instance.name}Ingestor",
         },
     )[0]
 
@@ -37,10 +37,10 @@ def pre_save_ingestor_config(sender, instance: IngestorConfig, *args, **kwargs):
     instance.user = user
 
     periodic_task = PeriodicTask.objects.update_or_create(
-        name__iexact=f"{instance.name.title()}Ingestor",
+        name__iexact=f"{instance.name}Ingestor",
         task=f"{execute_ingestor.__module__}.{execute_ingestor.__name__}",
         defaults={
-            "name": f"{instance.name.title()}Ingestor",
+            "name": f"{instance.name}Ingestor",
             "crontab": instance.schedule,
             "queue": instance.queue,
             "kwargs": json.dumps({"config_name": instance.name}),

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -1260,7 +1260,7 @@ class PythonConfig(AbstractConfig):
             and self.python_module.health_check_schedule
         ):
             periodic_task = PeriodicTask.objects.update_or_create(
-                name=f"{self.name.title()}HealthCheck{self.__class__.__name__}",
+                name__iexact=f"{self.name.title()}HealthCheck{self.__class__.__name__}",
                 task=f"{health_check.__module__}.{health_check.__name__}",
                 defaults={
                     "crontab": self.python_module.health_check_schedule,

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -1260,7 +1260,7 @@ class PythonConfig(AbstractConfig):
             and self.python_module.health_check_schedule
         ):
             periodic_task = PeriodicTask.objects.update_or_create(
-                name__iexact=f"{self.name.title()}HealthCheck{self.__class__.__name__}",
+                name__iexact=f"{self.name}HealthCheck{self.__class__.__name__}",
                 task=f"{health_check.__module__}.{health_check.__name__}",
                 defaults={
                     "name": f"{self.name}HealthCheck{self.__class__.__name__}",

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -1263,6 +1263,7 @@ class PythonConfig(AbstractConfig):
                 name__iexact=f"{self.name.title()}HealthCheck{self.__class__.__name__}",
                 task=f"{health_check.__module__}.{health_check.__name__}",
                 defaults={
+                    "name": f"{self.name}HealthCheck{self.__class__.__name__}",
                     "crontab": self.python_module.health_check_schedule,
                     "queue": self.queue,
                     "enabled": not self.disabled,

--- a/tests/api_app/ingestors_manager/test_signals.py
+++ b/tests/api_app/ingestors_manager/test_signals.py
@@ -25,7 +25,7 @@ class IngestorConfigSignalsTestCase(CustomTestCase):
             playbook_to_execute=PlaybookConfig.objects.first(),
         )
         self.assertIsNotNone(ic.periodic_task)
-        self.assertEqual(ic.periodic_task.name, "TestIngestor")
+        self.assertEqual(ic.periodic_task.name, "testIngestor")
         self.assertEqual(ic.periodic_task.task, "intel_owl.tasks.execute_ingestor")
         self.assertFalse(ic.periodic_task.enabled)
         self.assertEqual(ic.periodic_task.crontab, crontab)

--- a/tests/api_app/ingestors_manager/test_signals.py
+++ b/tests/api_app/ingestors_manager/test_signals.py
@@ -32,7 +32,7 @@ class IngestorConfigSignalsTestCase(CustomTestCase):
         self.assertEqual(ic.periodic_task.queue, "default")
         self.assertEqual(json.loads(ic.periodic_task.kwargs)["config_name"], ic.name)
         self.assertIsNotNone(ic.user)
-        self.assertEqual(ic.user.username, "TestIngestor")
+        self.assertEqual(ic.user.username, "testIngestor")
         ic.delete()
         if created:
             crontab.delete()


### PR DESCRIPTION
# Description
Added user creation also in the migration where the incorrect users will be deleted (not only in the relative signal) because if the project has just been started the signal will not cover this case.

## Type of change
- [X] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [X] I have read and understood the rules about [how to Contribute](https://intelowl.readthedocs.io/en/latest/Contribute.html) to this project
- [X] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Usage.md) file was updated.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Advanced-Usage.md) was updated (in case the plugin provides additional optional configuration).
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowl.readthedocs.io/en/develop/Usage.html#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowl.readthedocs.io/en/latest/Contribute.html#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (check [CONTRIBUTE.md](https://github.com/intelowlproject/IntelOwl/blob/master/docs/source/Contribute.md)).
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.