### PR TITLE
fix for correctly handling AWS Secrets

### DIFF
--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -53,6 +53,7 @@ SLACK_TOKEN=
 DEFAULT_SLACK_CHANNEL=
 
 # Elastic Search Configuration
+ELASTIC_DSL_ENABLED=False
 ELASTIC_HOST=
 ELASTIC_PASSWORD=
 # consult to: https://django-elasticsearch-dsl.readthedocs.io/en/latest/settings.html

--- a/intel_owl/celery.py
+++ b/intel_owl/celery.py
@@ -38,6 +38,8 @@ def get_queue_name(queue: str) -> str:
     return f"{queue}.fifo"
 
 
+print(dir(settings))
+
 if settings.AWS_SQS:
     PREDEFINED_QUEUES = {
         get_queue_name(queue): {

--- a/intel_owl/celery.py
+++ b/intel_owl/celery.py
@@ -38,8 +38,6 @@ def get_queue_name(queue: str) -> str:
     return f"{queue}.fifo"
 
 
-print(dir(settings))
-
 if settings.AWS_SQS:
     PREDEFINED_QUEUES = {
         get_queue_name(queue): {

--- a/intel_owl/secrets.py
+++ b/intel_owl/secrets.py
@@ -34,28 +34,31 @@ def aws_get_secret(secret_name):
     try:
         get_secret_value_response = client.get_secret_value(SecretId=secret_name)
     except ClientError as e:
-        if e.response["Error"]["Code"] == "DecryptionFailureException":
-            # Secrets Manager can't decrypt the protected secret text..
-            # ... using the provided KMS key.
-            # Deal with the exception here, and/or rethrow at your discretion.
-            raise RetrieveSecretException(e)
-        if e.response["Error"]["Code"] == "InternalServiceErrorException":
-            # An error occurred on the server side.
-            # Deal with the exception here, and/or rethrow at your discretion.
-            raise RetrieveSecretException(e)
-        if e.response["Error"]["Code"] == "InvalidParameterException":
-            # You provided an invalid value for a parameter.
-            # Deal with the exception here, and/or rethrow at your discretion.
-            raise RetrieveSecretException(e)
-        if e.response["Error"]["Code"] == "InvalidRequestException":
-            # You provided a parameter value that is not valid for the..
-            # ... current state of the resource.
-            # Deal with the exception here, and/or rethrow at your discretion.
-            raise RetrieveSecretException(e)
-        if e.response["Error"]["Code"] == "ResourceNotFoundException":
-            # We can't find the resource that you asked for.
-            # Deal with the exception here, and/or rethrow at your discretion.
-            raise RetrieveSecretException(e)
+        match e.response["Error"]["Code"]:
+            case "DecryptionFailureException" | "DecryptionFailure":
+                # Secrets Manager can't decrypt the protected secret text..
+                # ... using the provided KMS key.
+                # Deal with the exception here, and/or rethrow at your discretion.
+                raise RetrieveSecretException(e)
+            case "InternalServiceErrorException" | "InternalServiceError":
+                # An error occurred on the server side.
+                # Deal with the exception here, and/or rethrow at your discretion.
+                raise RetrieveSecretException(e)
+            case "InvalidParameterException":
+                # You provided an invalid value for a parameter.
+                # Deal with the exception here, and/or rethrow at your discretion.
+                raise RetrieveSecretException(e)
+            case "InvalidRequestException":
+                # You provided a parameter value that is not valid for the..
+                # ... current state of the resource.
+                # Deal with the exception here, and/or rethrow at your discretion.
+                raise RetrieveSecretException(e)
+            case "ResourceNotFoundException":
+                # We can't find the resource that you asked for.
+                # Deal with the exception here, and/or rethrow at your discretion.
+                raise RetrieveSecretException(e)
+            case _:
+                raise RetrieveSecretException(e)
     else:
         # Decrypts secret using the associated KMS CMK.
         # Depending on whether the secret is a string or binary,..
@@ -86,5 +89,8 @@ def get_secret(secret_name, default=""):
             logging.error(
                 f"Error: {e}. Secret: {secret_name}"
             )  # lgtm [py/clear-text-logging-sensitive-data]
-
+        except Exception as e:
+            logging.exception(
+                f"Error: {e}. Secret: {secret_name}"
+            )  # lgtm [py/clear-text-logging-sensitive-data]
     return secret

--- a/intel_owl/settings/aws.py
+++ b/intel_owl/settings/aws.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import sys
+
 from intel_owl import secrets
 
 # AWS settings
@@ -10,6 +12,10 @@ if not AWS_IAM_ACCESS:
     AWS_SECRET_ACCESS_KEY = secrets.get_secret("AWS_SECRET_ACCESS_KEY")
 AWS_SECRETS = secrets.get_secret("AWS_SECRETS", False) == "True"
 AWS_SQS = secrets.get_secret("AWS_SQS", False) == "True"
-AWS_USER_NUMBER = secrets.get_secret("AWS_USER_NUMBER")
+if AWS_SQS:
+    AWS_USER_NUMBER = secrets.get_secret("AWS_USER_NUMBER")
+    if not AWS_USER_NUMBER:
+        print("you must specify the USER NUMBER")
+        sys.exit(4)
 
 AWS_RDS_IAM_ROLE = secrets.get_secret("AWS_RDS_IAM_ROLE", False) == "True"

--- a/intel_owl/settings/celery.py
+++ b/intel_owl/settings/celery.py
@@ -2,10 +2,9 @@
 # See the file 'LICENSE' for copying permission.
 
 # this module must run before the others
-import sys
 
 from ._util import get_secret
-from .aws import AWS_SQS, AWS_USER_NUMBER
+from .aws import AWS_SQS
 
 RESULT_BACKEND = "django-db"
 BROKER_URL = get_secret("BROKER_URL", None)
@@ -23,7 +22,3 @@ CELERY_QUEUES = get_secret("CELERY_QUEUES", DEFAULT_QUEUE).split(",")
 for queue in [DEFAULT_QUEUE, CONFIG_QUEUE]:
     if queue not in CELERY_QUEUES:
         CELERY_QUEUES.append(queue)
-
-if AWS_SQS and not AWS_USER_NUMBER:
-    print("you must specify the USER NUMBER")
-    sys.exit(4)

--- a/intel_owl/settings/elasticsearch.py
+++ b/intel_owl/settings/elasticsearch.py
@@ -28,28 +28,36 @@ if ELASTICSEARCH_BI_ENABLED:
                 f"ELASTICSEARCH BI client configuration did not connect correctly: {ELASTICSEARCH_BI_CLIENT.info()}"
             )
 
-ELASTIC_HOST = secrets.get_secret("ELASTIC_HOST")
-if ELASTIC_HOST:
-    elastic_client_settings = {"hosts": ELASTIC_HOST}
+ELASTIC_DSL_ENABLED = secrets.get_secret("ELASTIC_DSL_ENABLED", False) == "True"
+if ELASTIC_DSL_ENABLED:
+    ELASTIC_HOST = secrets.get_secret("ELASTIC_HOST")
+    if ELASTIC_HOST:
+        elastic_client_settings = {"hosts": ELASTIC_HOST}
 
-    ELASTIC_PASSWORD = secrets.get_secret("ELASTIC_PASSWORD")
-    if ELASTIC_PASSWORD:
-        elastic_client_settings["basic_auth"] = ("elastic", ELASTIC_PASSWORD)
-    ca_path = "/opt/deploy/intel_owl/certs/elastic_ca/ca.crt"
-    cert_path = "/opt/deploy/intel_owl/certs/elastic_instance/elasticsearch.crt"
-    if "elasticsearch:9200" in ELASTIC_HOST:
-        # in case we use Elastic as container we need the generated
-        # in case we use Elastic as external service it should have a valid cert
-        elastic_client_settings["verify_certs"] = cert_path
-        elastic_client_settings["ca_certs"] = ca_path
-    ELASTICSEARCH_DSL = {"default": elastic_client_settings}
+        ELASTIC_PASSWORD = secrets.get_secret("ELASTIC_PASSWORD")
+        if ELASTIC_PASSWORD:
+            elastic_client_settings["basic_auth"] = ("elastic", ELASTIC_PASSWORD)
+        ca_path = "/opt/deploy/intel_owl/certs/elastic_ca/ca.crt"
+        cert_path = "/opt/deploy/intel_owl/certs/elastic_instance/elasticsearch.crt"
+        if "elasticsearch:9200" in ELASTIC_HOST:
+            # in case we use Elastic as container we need the generated
+            # in case we use Elastic as external service it should have a valid cert
+            elastic_client_settings["verify_certs"] = cert_path
+            elastic_client_settings["ca_certs"] = ca_path
+        ELASTICSEARCH_DSL = {"default": elastic_client_settings}
 
-    ELASTICSEARCH_DSL_INDEX_SETTINGS = {
-        "number_of_shards": int(secrets.get_secret("ELASTICSEARCH_DSL_NO_OF_SHARDS")),
-        "number_of_replicas": int(
-            secrets.get_secret("ELASTICSEARCH_DSL_NO_OF_REPLICAS")
-        ),
-    }
+        ELASTICSEARCH_DSL_INDEX_SETTINGS = {
+            "number_of_shards": int(
+                secrets.get_secret("ELASTICSEARCH_DSL_NO_OF_SHARDS")
+            ),
+            "number_of_replicas": int(
+                secrets.get_secret("ELASTICSEARCH_DSL_NO_OF_REPLICAS")
+            ),
+        }
+    else:
+        print(
+            "you have to configure ELASTIC_HOST with the URL of your ElasticSearch instance"
+        )
 else:
     ELASTICSEARCH_DSL_AUTOSYNC = False
     ELASTICSEARCH_DSL = {


### PR DESCRIPTION
for @drosetti : I added a boolean environment variable for the integration with Elastic to avoid to have empty ("None") environment variables. This would have created problems in case the _AWS_SECRETS_ variable was enabled.

More generally, it would also make more sense to have that boolean flag to enable/disable the feature instead of leveraging an URL-based variable. In this way you don't have to configure the URL multiple times in case of changes but you have to configure a more easily understandable boolean flag.

I updated the doc too: https://github.com/intelowlproject/docs/commit/ecb7c721158eb26a22ad7d1a50329cc4b154c49d