### PR TITLE
Revert "Bump pygraphviz from 1.10 to 1.14 in /integrations/malware_tools_analyzers/requirements"

### DIFF
--- a/integrations/malware_tools_analyzers/requirements/thug-requirements.txt
+++ b/integrations/malware_tools_analyzers/requirements/thug-requirements.txt
@@ -1,6 +1,6 @@
 setuptools==70.0.0
 pytesseract==0.3.10
-pygraphviz==1.14
+pygraphviz==1.10
 # CAREFUL! This is strictly tied to STpy version and Python version
 # DO NOT UPGRADE THIS WITHOUT PROPER MANUAL TESTING
 thug==4.9


### PR DESCRIPTION
Reverts intelowlproject/IntelOwl#2682

reverts cause image is python 3.9 and pygraphviz 1.14 has python requirements >=3.10