### PR TITLE
adjusted plugin config tests

### DIFF
--- a/tests/api_app/test_views.py
+++ b/tests/api_app/test_views.py
@@ -595,7 +595,6 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
 
     def setUp(self):
         super().setUp()
-        PluginConfig.objects.all().delete()
 
     def test_plugin_config(self):
         org = Organization.create("test_org", self.user)
@@ -818,7 +817,7 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             if obj["attribute"] == pc0.attribute:
                 needle = obj
             # the owner cannot see configs of other orgs (pc1)
-            if "organization" in obj.keys():
+            if "organization" in obj.keys() and obj["organization"] is not None:
                 self.assertEqual(obj["organization"], "testorg0")
         self.assertIsNotNone(needle)
         self.assertIn("type", needle)
@@ -845,7 +844,7 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             if obj["attribute"] == pc0.attribute:
                 needle = obj
             # an admin cannot see configs of other orgs (pc1)
-            if "organization" in obj.keys():
+            if "organization" in obj.keys() and obj["organization"] is not None:
                 self.assertEqual(obj["organization"], "testorg0")
         self.assertIsNotNone(needle)
         self.assertIn("type", needle)
@@ -872,7 +871,7 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             if obj["attribute"] == pc1.attribute:
                 needle = obj
             # a user cannot see configs of other orgs (pc0)
-            if "organization" in obj.keys():
+            if "organization" in obj.keys() and obj["organization"] is not None:
                 self.assertEqual(obj["organization"], "testorg1")
         self.assertIsNotNone(needle)
         self.assertIn("type", needle)
@@ -1242,11 +1241,11 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             user=self.user, organization=org, is_owner=False, is_admin=False
         )
         ac = AnalyzerConfig.objects.get(name="AbuseIPDB")
-        uri = "/api/plugin-config/1"
+        uri = "/api/plugin-config"
 
         # logged out
         self.client.logout()
-        response = self.client.delete(uri, {}, format="json")
+        response = self.client.delete(f"{uri}/1", {}, format="json")
         self.assertEqual(response.status_code, 401)
 
         param = Parameter.objects.create(
@@ -1256,60 +1255,51 @@ class PluginConfigViewSetTestCase(CustomViewSetTestCase):
             required=True,
             type="str",
         )
-        pc = PluginConfig(
+        pc, _ = PluginConfig.objects.get_or_create(
             value="supersecret",
             for_organization=True,
             owner=self.superuser,
             parameter=param,
             analyzer_config=ac,
-            id=1,
         )
-        pc.full_clean()
-        pc.save()
         self.assertEqual(pc.owner, org.owner)
 
         # user can not delete org secret
         self.client.force_authenticate(user=self.user)
-        response = self.client.delete(uri, {}, format="json")
+        response = self.client.delete(f"{uri}/{pc.id}", {}, format="json")
         self.assertEqual(response.status_code, 403)
 
         # owner can delete org secret
         self.client.force_authenticate(user=self.superuser)
-        response = self.client.delete(uri, format="json")
+        response = self.client.delete(f"{uri}/{pc.id}", format="json")
         self.assertEqual(response.status_code, 204)
 
-        pc = PluginConfig(
+        pc, _ = PluginConfig.objects.get_or_create(
             value="supersecret",
             for_organization=True,
             owner=self.superuser,
             parameter=param,
             analyzer_config=ac,
-            id=1,
         )
-        pc.full_clean()
-        pc.save()
         self.assertEqual(pc.owner, org.owner)
 
         # admin can delete org secret
         self.client.force_authenticate(user=self.admin)
-        response = self.client.delete(uri, {}, format="json")
+        response = self.client.delete(f"{uri}/{pc.id}", {}, format="json")
         self.assertEqual(response.status_code, 204)
 
-        pc = PluginConfig(
+        pc, _ = PluginConfig.objects.get_or_create(
             value="supersecret",
             for_organization=False,
             owner=self.user,
             parameter=param,
             analyzer_config=ac,
-            id=1,
         )
-        pc.full_clean()
-        pc.save()
         self.assertEqual(pc.owner, self.user)
 
         # user can delete own personal secret
         self.client.force_authenticate(user=self.user)
-        response = self.client.delete(uri, {}, format="json")
+        response = self.client.delete(f"{uri}/{pc.id}", {}, format="json")
         self.assertEqual(response.status_code, 204)
 
     def test_get_403(self):


### PR DESCRIPTION
(Please add to the PR name the issue/s that this PR would close if merged by using a [Github](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) keyword. Example: `<feature name>. Closes #999`. If your PR is made by a single commit, please add that clause in the commit too. This is all required to automate the closure of related issues.)

# Description

Please include a summary of the change and link to the related issue.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review. After being reviewed and received a "change request", you should explicitly ask for a review again once you have made the requested changes.