### PR TITLE
Fix form action extraction print

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/phishing/phishing_form_compiler.py
+++ b/api_app/analyzers_manager/file_analyzers/phishing/phishing_form_compiler.py
@@ -160,7 +160,7 @@ class PhishingFormCompiler(FileAnalyzer):
         ):  # found a domain (relative file names such as "login.php" should start with /)
             logger.info(f"Found a domain in form action {form_action=}")
         elif "://" in form_action:
-            logger.info(f"Found a whole new url {form_action=}")
+            logger.info(f"Form is sending data to a whole new url {form_action=}")
         else:
             base_site = target_site
 

--- a/integrations/phishing_analyzers/Dockerfile
+++ b/integrations/phishing_analyzers/Dockerfile
@@ -11,7 +11,7 @@ RUN useradd -ms /bin/bash ${USER}
 # Install Google Chrome and Chromium
 RUN DEBIAN_FRONTEND=noninteractive apt-get update -qq \
     && apt-get install -y --no-install-recommends \
-    libvulkan1 libu2f-udev fonts-liberation chromium sudo \
+    libvulkan1 libu2f-udev fonts-liberation sudo \
     && pip3 install --no-cache-dir --upgrade pip \
     # Cleanup
     && apt-get remove --purge -y gcc \

--- a/integrations/phishing_analyzers/analyzers/extract_phishing_site.py
+++ b/integrations/phishing_analyzers/analyzers/extract_phishing_site.py
@@ -65,6 +65,8 @@ def analyze_target(
 
         result: str = json.dumps(extract_driver_result(driver_wrapper), default=str)
         logger.debug(f"JSON dump of driver {result=}")
+
+        # this print returns the result of the analysis, do not remove
         print(result)
     except Exception as e:
         logger.exception(

--- a/integrations/phishing_analyzers/requirements.txt
+++ b/integrations/phishing_analyzers/requirements.txt
@@ -2,7 +2,7 @@
 # So, if you want reproducible builds, you must explicitly state the flask version you want to install
 Flask-Shell2HTTP-fork==1.9.2
 # Flask most recent versions require most recent versions of blinker
-flask==2.3.3
+flask==3.0.3
 gunicorn==23.0.0
 selenium==4.25.0
 selenium-wire==5.1.0

--- a/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
+++ b/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
@@ -1,0 +1,137 @@
+from unittest import TestCase
+
+from api_app.analyzers_manager.file_analyzers.phishing.phishing_form_compiler import (
+    PhishingFormCompiler,
+)
+
+
+class PhishingFormCompilerTestCase(TestCase):
+
+    def test_extract_action_attribute_url(self):
+        # for this test we'll treat "form" parameter as a dict
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": "https://test2.com"}
+            ),
+            "https://test2.com",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": "https://test2.com/"}
+            ),
+            "https://test2.com/",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/", {"action": "/test.php"}
+            ),
+            "https://test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": "/test.php"}
+            ),
+            "https://test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/", {"action": "test.php"}
+            ),
+            "test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": "test.php"}
+            ),
+            "test.php",
+        )
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/", {"action": "test"}
+            ),
+            "https://test.com/test",
+        )
+
+    def test_extract_action_attribute_domain(self):
+        # for this test we'll treat "form" parameter as a dict
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com", {"action": "https://test2.com"}
+            ),
+            "https://test2.com",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com", {"action": "https://test2.com/"}
+            ),
+            "https://test2.com/",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/", {"action": "/test.php"}
+            ),
+            "test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com", {"action": "/test.php"}
+            ),
+            "test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/", {"action": "test.php"}
+            ),
+            "test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com", {"action": "test.php"}
+            ),
+            "test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/", {"action": "/test"}
+            ),
+            "test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com", {"action": "/test"}
+            ),
+            "test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/", {"action": "test"}
+            ),
+            "test.com/test",
+        )

--- a/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
+++ b/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
@@ -11,6 +11,13 @@ class PhishingFormCompilerTestCase(TestCase):
         # for this test we'll treat "form" parameter as a dict
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
+                "https://test.com", {"action": ""}
+            ),
+            "https://test.com",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
                 "https://test.com", {"action": "https://test2.com"}
             ),
             "https://test2.com",
@@ -41,14 +48,14 @@ class PhishingFormCompilerTestCase(TestCase):
             PhishingFormCompiler.extract_action_attribute(
                 "https://test.com/", {"action": "test.php"}
             ),
-            "test.php",
+            "https://test.com/test.php",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "https://test.com", {"action": "test.php"}
             ),
-            "test.php",
+            "https://test.com/test.php",
         )
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
@@ -71,8 +78,83 @@ class PhishingFormCompilerTestCase(TestCase):
             "https://test.com/test",
         )
 
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/another", {"action": "https://test2.com"}
+            ),
+            "https://test2.com",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/another.php?test=y", {"action": "https://test2.com/"}
+            ),
+            "https://test2.com/",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/another.php?test=y", {"action": "/test2"}
+            ),
+            "https://test.com/test2",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php/", {"action": "/test2.php"}
+            ),
+            "https://test.com/test2.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php", {"action": "/test2.php"}
+            ),
+            "https://test.com/test2.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php", {"action": "test.php"}
+            ),
+            "https://test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php/", {"action": "test.php"}
+            ),
+            "https://test.com/test.php/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php/", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com/test.php", {"action": "test"}
+            ),
+            "https://test.com/test",
+        )
+
     def test_extract_action_attribute_domain(self):
         # for this test we'll treat "form" parameter as a dict
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute("test.com", {"action": ""}),
+            "test.com",
+        )
+
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com", {"action": "https://test2.com"}
@@ -91,47 +173,117 @@ class PhishingFormCompilerTestCase(TestCase):
             PhishingFormCompiler.extract_action_attribute(
                 "test.com/", {"action": "/test.php"}
             ),
-            "test.com/test.php",
+            "https://test.com/test.php",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com", {"action": "/test.php"}
             ),
-            "test.com/test.php",
+            "https://test.com/test.php",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com/", {"action": "test.php"}
             ),
-            "test.php",
+            "https://test.com/test.php",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com", {"action": "test.php"}
             ),
-            "test.php",
+            "https://test.com/test.php",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com/", {"action": "/test"}
             ),
-            "test.com/test",
+            "https://test.com/test",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com", {"action": "/test"}
             ),
-            "test.com/test",
+            "https://test.com/test",
         )
 
         self.assertEqual(
             PhishingFormCompiler.extract_action_attribute(
                 "test.com/", {"action": "test"}
             ),
-            "test.com/test",
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/another", {"action": "https://test2.com"}
+            ),
+            "https://test2.com",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/another.php?test=y", {"action": "https://test2.com/"}
+            ),
+            "https://test2.com/",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/another.php?test=y", {"action": "/test2"}
+            ),
+            "https://test.com/test2",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php/", {"action": "/test2.php"}
+            ),
+            "https://test.com/test2.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php", {"action": "/test2.php"}
+            ),
+            "https://test.com/test2.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php", {"action": "test.php"}
+            ),
+            "https://test.com/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php/", {"action": "test.php"}
+            ),
+            "https://test.com/test.php/test.php",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php/", {"action": "/test"}
+            ),
+            "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com/test.php", {"action": "test"}
+            ),
+            "https://test.com/test",
         )

--- a/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
+++ b/tests/api_app/analyzers_manager/file_analyzers/phishing/test_phishing_form_compiler.py
@@ -148,6 +148,13 @@ class PhishingFormCompilerTestCase(TestCase):
             "https://test.com/test",
         )
 
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "https://test.com:11111/test.php", {"action": "test"}
+            ),
+            "https://test.com:11111/test",
+        )
+
     def test_extract_action_attribute_domain(self):
         # for this test we'll treat "form" parameter as a dict
         self.assertEqual(
@@ -286,4 +293,11 @@ class PhishingFormCompilerTestCase(TestCase):
                 "test.com/test.php", {"action": "test"}
             ),
             "https://test.com/test",
+        )
+
+        self.assertEqual(
+            PhishingFormCompiler.extract_action_attribute(
+                "test.com:11111/test.php", {"action": "test"}
+            ),
+            "https://test.com:11111/test",
         )


### PR DESCRIPTION
# Description
Fixed an issue with Phishing Form Compiler that caused extraction of 'action' attribute from form to be wrong.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).