### PR TITLE
Frontend - Allow modals to be closed with escape key

### DIFF
--- a/frontend/src/components/auth/utils/registration-alert.jsx
+++ b/frontend/src/components/auth/utils/registration-alert.jsx
@@ -50,6 +50,7 @@ export function AfterRegistrationModalAlert(props) {
       isOpen={isOpen}
       backdrop="static"
       labelledBy="Registration successful modal"
+      toggle={toggle}
     >
       <ModalHeader toggle={toggle}>Registration successful! 🥳</ModalHeader>
       <ModalBody className="px-5">

--- a/frontend/src/components/auth/utils/registration-alert.jsx
+++ b/frontend/src/components/auth/utils/registration-alert.jsx
@@ -48,7 +48,6 @@ export function AfterRegistrationModalAlert(props) {
       zIndex="1050"
       size="lg"
       isOpen={isOpen}
-      keyboard={false}
       backdrop="static"
       labelledBy="Registration successful modal"
     >

--- a/frontend/src/components/plugins/PluginConfigModal.jsx
+++ b/frontend/src/components/plugins/PluginConfigModal.jsx
@@ -105,6 +105,7 @@ export function PluginConfigModal({
       labelledBy="Plugin config modal"
       isOpen={isOpen}
       style={{ minWidth: "70%" }}
+      toggle={() => toggle(false)}
     >
       <ModalHeader className="mx-2" toggle={() => toggle(false)}>
         <small className="text-info">

--- a/frontend/src/components/plugins/PluginConfigModal.jsx
+++ b/frontend/src/components/plugins/PluginConfigModal.jsx
@@ -101,7 +101,6 @@ export function PluginConfigModal({
       centered
       zIndex="1050"
       size="lg"
-      keyboard={false}
       backdrop="static"
       labelledBy="Plugin config modal"
       isOpen={isOpen}

--- a/frontend/src/components/plugins/tables/pluginActionsButtons.jsx
+++ b/frontend/src/components/plugins/tables/pluginActionsButtons.jsx
@@ -221,8 +221,9 @@ export function PluginDeletionButton({ pluginName, pluginType_ }) {
         backdrop="static"
         labelledBy="Plugin deletion modal"
         isOpen={showModal}
+        toggle={() => setShowModal(!showModal)}
       >
-        <ModalHeader className="mx-2" toggle={() => setShowModal(false)}>
+        <ModalHeader className="mx-2" toggle={() => setShowModal(!showModal)}>
           <small className="text-info">Delete plugin</small>
         </ModalHeader>
         <ModalBody className="d-flex justify-content-between my-2 mx-2">
@@ -237,7 +238,7 @@ export function PluginDeletionButton({ pluginName, pluginType_ }) {
             <Button
               className="mx-2"
               size="sm"
-              onClick={() => setShowModal(false)}
+              onClick={() => setShowModal(!showModal)}
             >
               Cancel
             </Button>
@@ -443,13 +444,13 @@ export function PlaybookFlowsButton({ playbook }) {
           centered
           zIndex="1050"
           size="lg"
-          keyboard={false}
           backdrop="static"
           labelledBy="Playbook flows modal"
           isOpen={showModal}
           style={{ minWidth: "90%" }}
+          toggle={() => setShowModal(!showModal)}
         >
-          <ModalHeader className="mx-2" toggle={() => setShowModal(false)}>
+          <ModalHeader className="mx-2" toggle={() => setShowModal(!showModal)}>
             <small className="text-info">Possible playbook flows</small>
           </ModalHeader>
           <ModalBody className="mx-2">
@@ -500,13 +501,13 @@ export function MappingDataModel({ data, type, pythonModule }) {
           centered
           zIndex="1050"
           size="lg"
-          keyboard={false}
           backdrop="static"
           labelledBy="Data model modal"
           isOpen={showModal}
           style={{ minWidth: "50%" }}
+          toggle={() => setShowModal(!showModal)}
         >
-          <ModalHeader className="mx-2" toggle={() => setShowModal(false)}>
+          <ModalHeader className="mx-2" toggle={() => setShowModal(!showModal)}>
             <small className="text-info">
               Data model mapping
               <MdInfoOutline

--- a/frontend/src/components/plugins/tables/pluginActionsButtons.jsx
+++ b/frontend/src/components/plugins/tables/pluginActionsButtons.jsx
@@ -218,7 +218,6 @@ export function PluginDeletionButton({ pluginName, pluginType_ }) {
         centered
         zIndex="1050"
         size="lg"
-        keyboard={false}
         backdrop="static"
         labelledBy="Plugin deletion modal"
         isOpen={showModal}

--- a/frontend/src/components/scan/utils/MultipleObservablesModal.jsx
+++ b/frontend/src/components/scan/utils/MultipleObservablesModal.jsx
@@ -53,7 +53,6 @@ export function MultipleObservablesModal(props) {
       size="xl"
       isOpen={isOpen}
       toggle={toggle}
-      keyboard={false}
       scrollable
       backdrop="static"
       labelledBy="Load Multiple Observables"

--- a/frontend/src/components/scan/utils/RuntimeConfigurationModal.jsx
+++ b/frontend/src/components/scan/utils/RuntimeConfigurationModal.jsx
@@ -52,7 +52,6 @@ export function RuntimeConfigurationModal(props) {
       size="xl"
       isOpen={isOpen}
       toggle={toggle}
-      keyboard={false}
       scrollable
       backdrop="static"
       labelledBy="Edit Runtime Configuration"


### PR DESCRIPTION
(Please add to the PR name the issue/s that this PR would close if merged by using a [Github](https://docs.github.com/en/issues/tracking-your-work-with-issues/linking-a-pull-request-to-an-issue) keyword. Example: `<feature name>. Closes #999`. If your PR is made by a single commit, please add that clause in the commit too. This is all required to automate the closure of related issues.)

# Description

Please include a summary of the change and link to the related issue.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).