### PR TITLE
Initialize .env files and removal of `load_env` from `start`

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -132,6 +132,7 @@ echo "Adding environment files"
 cp --update=none docker/env_file_app_template docker/env_file_app
 cp --update=none docker/env_file_postgres_template docker/env_file_postgres
 cp --update=none docker/env_file_integrations_template docker/env_file_integrations
+cp --update=none docker/.env.start.test.template docker/.env.start.test
 echo "Added environment files"
 
 check_django_secret

--- a/start
+++ b/start
@@ -88,17 +88,13 @@ set_defaults_values () {
   export PYCTI_VERSION=$pycti_default_version
 }
 
-load_env () {
-  export "$(grep -v '^#' "$1")"
-}
-
 if ! docker compose version > /dev/null 2>&1; then
   echo "Run ./initialize.sh to install Docker Compose 2"
 fi
 
 check_parameters "$@" && shift 2
 
-load_env "docker/.env"
+. docker/.env
 current_version=${REACT_APP_INTELOWL_VERSION/"v"/""}
 
 docker_analyzers=("pcap_analyzers" "tor_analyzers" "malware_tools_analyzers" "thug" "cyberchef" "phoneinfoga" "phishing_analyzers" "nuclei_analyzer")
@@ -116,7 +112,7 @@ if [[ ${test_mode["${env_argument}"]} ]]; then
   is_test=true
   test_appendix=".test"
   # load relevant .env file
-  load_env "docker/.env.start.test"
+  . docker/.env.start.test
 else
   is_test=false
   test_appendix=""
@@ -363,7 +359,8 @@ for value in "${compose_files[@]}" ; do
     to_run+=" -f $value"
   fi
 done
-
+echo $REACT_APP_INTELOWL_VERSION
+echo $REPO_DOWNLOADER_ENABLED
 if grep "docker" <<< "$(groups)" > /dev/null 2>&1; then
   docker compose --project-directory docker ${to_run[@]} -p "$project_name" "$cmd_argument" "$@"
 else

--- a/start
+++ b/start
@@ -359,8 +359,7 @@ for value in "${compose_files[@]}" ; do
     to_run+=" -f $value"
   fi
 done
-echo $REACT_APP_INTELOWL_VERSION
-echo $REPO_DOWNLOADER_ENABLED
+
 if grep "docker" <<< "$(groups)" > /dev/null 2>&1; then
   docker compose --project-directory docker ${to_run[@]} -p "$project_name" "$cmd_argument" "$@"
 else


### PR DESCRIPTION
# Description
Removed custom `load_env` function from `start` script in favor of `.` and added creation of default `docker/.env.start.test` file from its template in `initialize.sh`.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).