### PR TITLE
Support for Podman

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -54,78 +54,171 @@ check_django_secret () {
   fi
 }
 
+# Function to install and set up Docker
+setup_docker () {
+  # Check if docker is installed
+  if ! [ -x "$(command -v docker)" ]; then
+    echo 'Error: docker is not installed.' >&2
+    # Ask if user wants to install docker
+    read -p "Do you want to install docker? [y/n] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      # Install docker
+      if ! curl --version > /dev/null 2>&1; then
+        echo "curl is required to install dependencies." >&2
+        exit 1
+      fi
+      curl -fsSL https://get.docker.com -o get-docker.sh
+      sudo sh get-docker.sh
+      # Check if docker is installed
+      if ! [ -x "$(command -v docker)" ]; then
+        echo 'Error: Could not install docker.' >&2
+        exit 1
+      fi
+      rm get-docker.sh
+    else
+      echo 'You chose to do not install Docker. Exiting'
+      exit 1
+    fi
+  else
+    docker_version=$(sudo docker version --format '{{.Server.Version}}')
+
+    if [[ $(semantic_version_comp "$docker_version" "$MINIMUM_DOCKER_VERSION") == "lessThan" ]]; then
+      echo "Error: Docker version is too old. Please upgrade to at least $MINIMUM_DOCKER_VERSION." >&2
+      exit 1
+    else
+      echo "Docker version $docker_version detected"
+    fi
+  fi
+
+  # docker compose V1 is no longer supported
+  if [ -x "$(command -v docker-compose)" ] && ! docker compose version; then
+    echo "Error: Docker compose V1 is no longer supported. Please install at least v$MINIMUM_DOCKER_COMPOSE_VERSION of docker compose V2." >&2
+    exit 1
+  fi
+
+  if ! docker compose version; then
+    echo 'Error: docker compose is not installed.' >&2
+    # Ask if user wants to install docker compose
+    read -p "Do you want to install docker compose? [y/n] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      # Install docker compose
+      sudo mkdir -p /usr/local/lib/docker/cli-plugins
+      sudo curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
+      sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
+      # Check if docker compose is installed
+      if ! docker compose version; then
+        echo 'Error: Could not install docker compose.' >&2
+        exit 1
+      fi
+    else
+      echo 'You chose to do not install docker compose. Exiting' >&2
+      exit 1
+    fi
+  else
+    # docker compose exists
+    docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
+    if [[ $(semantic_version_comp "$docker_compose_version" "$MINIMUM_DOCKER_COMPOSE_VERSION") == "lessThan" ]]; then
+      echo "Error: Docker compose version is too old. Please upgrade to at least $MINIMUM_DOCKER_COMPOSE_VERSION." >&2
+      exit 1
+    else
+      echo "Docker compose version $docker_compose_version detected"
+    fi
+  fi
+}
+
+# Function to install and set up Podman
+setup_podman () {
+  # Check if podman is installed
+  if ! [ -x "$(command -v podman)" ]; then
+    echo 'Error: podman is not installed.' >&2
+    # Ask if user wants to install podman
+    read -p "Do you want to install podman? [y/n] " -n 1 -r
+    echo
+    if [[ $REPLY =~ ^[Yy]$ ]]; then
+      if [ -x "$(command -v apt)" ]; then
+        sudo apt update
+        sudo apt install -y podman
+      elif [ -x "$(command -v dnf)" ]; then
+        sudo dnf install -y podman
+      elif [ -x "$(command -v yum)" ]; then
+        sudo yum install -y podman
+      else
+        echo "Could not determine package manager for your system. Please install podman manually." >&2
+        exit 1
+      fi
+      
+      # Check if podman is installed
+      if ! [ -x "$(command -v podman)" ]; then
+        echo 'Error: Could not install podman.' >&2
+        exit 1
+      fi
+    else
+      echo 'You chose to do not install Podman. Exiting'
+      exit 1
+    fi
+  else
+    echo "Podman is already installed."
+  fi
+
+  # Install podman-compose
+  echo "Installing podman-compose..."
+  sudo curl -o /usr/local/bin/podman-compose https://raw.githubusercontent.com/containers/podman-compose/main/podman_compose.py
+  sudo chmod +x /usr/local/bin/podman-compose
+  
+  if ! [ -x "$(command -v podman-compose)" ]; then
+    echo 'Error: Could not install podman-compose.' >&2
+    exit 1
+  else
+    echo "podman-compose installed successfully"
+  fi
+  
+  # Configure containers.conf
+  CONTAINERS_CONF="/usr/share/containers/containers.conf"
+  if [ -f "$CONTAINERS_CONF" ]; then
+    # Check if compose_providers is already uncommented and configured
+    if grep -q "^compose_providers=" "$CONTAINERS_CONF"; then
+      echo "compose_providers already configured in $CONTAINERS_CONF"
+    # Check if there's a commented compose_providers line
+    elif grep -q "^#compose_providers=" "$CONTAINERS_CONF"; then
+      echo "Uncommenting and setting compose_providers in $CONTAINERS_CONF"
+      sudo sed -i 's|^#compose_providers=.*|compose_providers=[\"/usr/local/bin/podman-compose\"]|' "$CONTAINERS_CONF"
+    # Otherwise, add it after the [engine] section
+    else
+      echo "Adding compose_providers in $CONTAINERS_CONF"
+      sudo sed -i '/\[engine\]/a compose_providers=[\"/usr/local/bin/podman-compose\"]' "$CONTAINERS_CONF"
+    fi
+  else
+    echo "Warning: $CONTAINERS_CONF not found. Please manually configure compose_providers." >&2
+  fi
+}
+
 echo "This script will check (and possibly guide you through) the installation of dependencies for IntelOwl!"
 echo "CARE! This script is delivered AS IS and could not work correctly in every possible environment. It has been tested on Ubuntu 22.04 LTS. In the case you face any error, you should just follow the official documentation and do all the required operation manually."
 
-# Check if docker is installed
-if ! [ -x "$(command -v docker)" ]; then
-  echo 'Error: docker is not installed.' >&2
-  # Ask if user wants to install docker
-  read -p "Do you want to install docker? [y/n] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    # Install docker
-    if ! curl --version > /dev/null 2>&1; then
-      echo "curl is required to install dependencies." >&2
-      exit 1
-    fi
-    curl -fsSL https://get.docker.com -o get-docker.sh
-    sudo sh get-docker.sh
-    # Check if docker is installed
-    if ! [ -x "$(command -v docker)" ]; then
-      echo 'Error: Could not install docker.' >&2
-      exit 1
-    fi
-    rm get-docker.sh
-  else
-    echo 'You chose to do not install Docker. Exiting'
-    exit 1
-  fi
-else
-  docker_version=$(sudo docker version --format '{{.Server.Version}}')
-
-  if [[ $(semantic_version_comp "$docker_version" "$MINIMUM_DOCKER_VERSION") == "lessThan" ]]; then
-    echo "Error: Docker version is too old. Please upgrade to at least $MINIMUM_DOCKER_VERSION." >&2
-    exit 1
-  else
-    echo "Docker version $docker_version detected"
-  fi
-fi
-
-# docker compose V1 is no longer supported
-if [ -x "$(command -v docker-compose)" ] && ! docker compose version; then
-  echo "Error: Docker compose V1 is no longer supported. Please install at least v$MINIMUM_DOCKER_COMPOSE_VERSION of docker compose V2." >&2
-  exit 1
-fi
-
-if ! docker compose version; then
-  echo 'Error: docker compose is not installed.' >&2
-  # Ask if user wants to install docker compose
-  read -p "Do you want to install docker compose? [y/n] " -n 1 -r
-  echo
-  if [[ $REPLY =~ ^[Yy]$ ]]; then
-    # Install docker compose
-    sudo curl -SL "https://github.com/docker/compose/releases/latest/download/docker-compose-$(uname -s)-$(uname -m)" -o /usr/local/lib/docker/cli-plugins/docker-compose
-    sudo chmod +x /usr/local/lib/docker/cli-plugins/docker-compose
-    # Check if docker compose is installed
-    if ! docker compose version; then
-      echo 'Error: Could not install docker compose.' >&2
-      exit 1
-    fi
-  else
-    echo 'You chose to do not install docker compose. Exiting' >&2
-    exit 1
-  fi
-else
-  # docker compose exists
-  docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
-  if [[ $(semantic_version_comp "$docker_compose_version" "$MINIMUM_DOCKER_COMPOSE_VERSION") == "lessThan" ]]; then
-    echo "Error: Docker compose version is too old. Please upgrade to at least $MINIMUM_DOCKER_COMPOSE_VERSION." >&2
-    exit 1
-  else
-    echo "Docker compose version $docker_compose_version detected"
-  fi
-fi
+# Ask user which container engine they want to use
+echo "Which container engine would you like to use?"
+PS3="Please select an option (1-2): "
+options=("Docker" "Podman")
+select opt in "${options[@]}"
+do
+    case $opt in
+        "Docker")
+            echo "You selected Docker. Setting up Docker environment..."
+            setup_docker
+            break
+            ;;
+        "Podman")
+            echo "You selected Podman. Setting up Podman environment..."
+            setup_podman
+            break
+            ;;
+        *) 
+            echo "Invalid option. Please try again."
+            ;;
+    esac
+done
 
 # construct environment files from templates
 echo "Adding environment files"


### PR DESCRIPTION
Closes #2393 

# Description

This PR attempts to add support for Podman to Intelowl

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks. 
    - [ ] If the plugin requires mocked testing, `_monkeypatch()` was used in its class to apply the necessary decorators.
    - [ ] I have added that raw JSON sample to the `MockUpResponse` of the `_monkeypatch()` method. This serves us to provide a valid sample for testing.
- [ ] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [ ] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).