### PR TITLE
fix(frontend): prevent datetime inputs overflow in Reports Search page

### DIFF
--- a/frontend/src/components/search/ReportsSearch.jsx
+++ b/frontend/src/components/search/ReportsSearch.jsx
@@ -230,11 +230,11 @@ export default function ReportsSearch() {
               </Input>
             </Col>
           </Row>
-          <Row id="search-input-fields-second-row">
+          <Row id="search-input-fields-second-row" className="flex-wrap">
             <Col
               xxl={4}
               sm={12}
-              className="d-flex align-items-center flex-wrap mt-3"
+              className="d-flex align-items-center flex-wrap mt-3 overflow-hidden"
             >
               <Label className="col-3 fw-bold mb-0">Start time:</Label>
               <div className="d-flex flex-column align-item-start">
@@ -252,7 +252,8 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.startTime}
-                      className="col-6"
+                      className="bg-darker border-dark"
+                      style={{ maxWidth: "200px" }}
                     />
                   </div>
                   <div className="d-flex align-items-center">
@@ -268,7 +269,8 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.startTime}
-                      className="col-6"
+                      className="bg-darker border-dark"
+                      style={{ maxWidth: "200px" }}
                     />
                   </div>
                 </div>
@@ -282,7 +284,7 @@ export default function ReportsSearch() {
             <Col
               xxl={4}
               sm={12}
-              className="d-flex align-items-center flex-wrap mt-3"
+              className="d-flex align-items-center flex-wrap mt-3 overflow-hidden"
             >
               <Label className="col-3 fw-bold mb-0">End time:</Label>
               <div className="d-flex flex-column align-item-start">
@@ -300,7 +302,8 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.endTime}
-                      className="col-6"
+                      className="bg-darker border-dark"
+                      style={{ maxWidth: "200px" }}
                     />
                   </div>
                   <div className="d-flex align-items-center">
@@ -316,7 +319,8 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.endTime}
-                      className="col-6"
+                      className="bg-darker border-dark"
+                      style={{ maxWidth: "200px" }}
                     />
                   </div>
                 </div>


### PR DESCRIPTION
## Description

Fix UI overflow issue in the Reports Search page where the "End time" and "Errors" columns were overlapping/overflowing due to wide datetime-local inputs. Related issue #3096  

### Changes

- Added `flex-wrap` class to the second row to allow proper wrapping on smaller screens
- Added `overflow-hidden` class to Start time and End time columns
- Added `maxWidth: 200px` inline style to all datetime inputs to constrain their width
- Added consistent `bg-darker border-dark` styling to datetime inputs to match other form inputs

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [N/A] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed _(This is a UI bugfix only)_
- [N/A] I have inserted the copyright banner _(No new files created, only modified existing file)_
- [x] No new libraries added
- [N/A] External libraries with restrictive licenses _(No new libraries)_
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors
- [N/A] I have added tests _(CSS/styling fix, covered by visual inspection)_
- [x] GUI has been modified:
    - [x] I have provided a screenshot of the result in the PR
    - [N/A] Frontend tests _(CSS styling fix, no new components)_

## Screenshots

### Before (Bug)
<img width="1512" height="829" alt="Screenshot 2025-12-03 at 7 58 59 PM" src="https://github.com/user-attachments/assets/bfb2dc9f-5525-465d-b31a-d5446bcc17a3" />

### After (Fixed)

<img width="1512" height="830" alt="Screenshot 2025-12-03 at 8 06 25 PM" src="https://github.com/user-attachments/assets/7dcd0a0f-bc3a-442e-b6c4-ba32a610a8b4" />

