### PR TITLE
Fix: Correct X-End-Of-Life-Date header in deprecated_endpoint decorator. Closes #3109

### DIFF
--- a/api_app/decorators.py
+++ b/api_app/decorators.py
@@ -34,7 +34,7 @@ def deprecated_endpoint(deprecation_date=None, end_of_life_date=None):
                 if deprecation_date:
                     response.headers["X-Deprecation-Date"] = deprecation_date
                 if end_of_life_date:
-                    response.headers["X-End-Of-Life-Date"] = deprecation_date
+                    response.headers["X-End-Of-Life-Date"] = end_of_life_date
             return response
 
         return wrapper_deprecated


### PR DESCRIPTION

Fixed a bug in the `deprecated_endpoint` decorator where the `X-End-Of-Life-Date` response header was incorrectly assigned the value of `deprecation_date` instead of `end_of_life_date`.

This was a simple copy-paste error on line 36 of `api_app/decorators.py` that caused API consumers to receive incorrect information about when deprecated endpoints would actually be removed.

```python
response.headers["X-End-Of-Life-Date"] = deprecation_date  #before
response.headers["X-End-Of-Life-Date"] = end_of_life_date  #after
```
**Impact:** API consumers can now properly plan their migrations with accurate deprecation timelines.

### Type of change

- Bug fix

### Checklist

- I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- The pull request is for the branch `develop`
- Linters (`Black`, `Flake`, `Isort`) gave 0 errors. 