### PR TITLE
Fix: Correct undefined variable in InQuest hash_type error message. Closes #3113

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/inquest.py
+++ b/api_app/analyzers_manager/observable_analyzers/inquest.py
@@ -38,7 +38,7 @@ class InQuest(ObservableAnalyzer):
         hash_type = hash_lengths.get(len(self.observable_name))
         if not hash_type:
             raise AnalyzerRunException(
-                f"Given Hash: '{hash}' is not supported."
+                f"Given Hash: '{self.observable_name}' is not supported. "
                 "Supported hash types are: 'md5', 'sha1', 'sha256', 'sha512'."
             )
         return hash_type


### PR DESCRIPTION

Fixed a bug in the `InQuest.hash_type` property where the error message referenced an undefined variable `hash` instead of `self.observable_name`, causing a NameError crash.

### Impact

When a user submits a hash with an unsupported length:
- **Before**: NameError: name 'hash' is not defined
- **After**: AnalyzerRunException with message: "Given Hash: '<actual_hash_value>' is not supported. Supported hash types are: 'md5', 'sha1', 'sha256', 'sha512'."

Type of Change: Bug fix

### Checklist

- I have read and understood the rules about how to Contribute to this project
- The pull request is for the branch `develop`
- Linters (`Black`, `Flake`, `Isort`) gave 0 errors

### Files Modified

- `api_app/analyzers_manager/observable_analyzers/inquest.py`
