### PR TITLE
fix: update YARAify URL in FREE_TO_USE_ANALYZERS playbook

### DIFF
--- a/api_app/playbooks_manager/migrations/0002_0001_playbook_config_free_to_use_analyzers.py
+++ b/api_app/playbooks_manager/migrations/0002_0001_playbook_config_free_to_use_analyzers.py
@@ -108,7 +108,7 @@ plugin = {
                     "https://github.com/dr4k0nia/yara-rules",
                     "https://github.com/Yara-Rules/rules.git",
                     "https://github.com/Neo23x0/signature-base.git",
-                    "https://yaraify-api.abuse.ch/download/yaraify-rules.zip",
+                    "https://yaraify.abuse.ch/yarahub/yaraify-rules.zip",
                 ],
             },
             "APKiD": {},


### PR DESCRIPTION
### Description
Updates the YARAify download URL in the `FREE_TO_USE_ANALYZERS` playbook configuration to use the new `yarahub` endpoint (`https://yaraify.abuse.ch/yarahub/yaraify-rules.zip`). 

### Linked Issue
Fixes #3140