### PR TITLE
Fix TLP not displaying in job metadata

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -50,4 +50,4 @@ coverage.xml
 /.env
 
 # post run dev
-integrations/malware_tools_analyzers/clamav/sigs
+integrations/malware_tools_analyzers/clamav/sigsintel_owl/settings/local.py

--- a/api_app/serializers/elastic.py
+++ b/api_app/serializers/elastic.py
@@ -14,9 +14,9 @@ logger = logging.getLogger(__name__)
 
 
 supported_plugin_name_list = [
-    AnalyzerConfig.plugin_name.lower(),
-    ConnectorConfig.plugin_name.lower(),
-    PivotConfig.plugin_name.lower(),
+    "analyzer",
+    "connector",
+    "pivot",
 ]
 
 

--- a/api_app/serializers/job.py
+++ b/api_app/serializers/job.py
@@ -598,6 +598,7 @@ class JobSerializer(_AbstractJobViewSerializer):
             "received_request_time",
             "finished_analysis_time",
             "process_time",
+            "tlp",
             "warnings",
             "errors",
         )

--- a/docker/infrastructure.yml
+++ b/docker/infrastructure.yml
@@ -1,0 +1,30 @@
+services:
+  postgres:
+    image: postgres:14-alpine
+    container_name: intelowl_postgres
+    restart: unless-stopped
+    env_file:
+      - env_file_postgres
+    volumes:
+      - postgres_data:/var/lib/postgresql/data
+    healthcheck:
+      test: ["CMD-SHELL", "pg_isready -U user"]
+      interval: 5s
+      timeout: 5s
+      retries: 5
+
+  redis:
+    image: redis:7-alpine
+    container_name: intelowl_redis
+    restart: unless-stopped
+    volumes:
+      - redis_data:/data
+    healthcheck:
+      test: ["CMD", "redis-cli", "ping"]
+      interval: 5s
+      timeout: 3s
+      retries: 5
+
+volumes:
+  postgres_data:
+  redis_data:

--- a/frontend/src/components/common/TLPTag.jsx
+++ b/frontend/src/components/common/TLPTag.jsx
@@ -7,11 +7,17 @@ import { TlpChoices } from "../../constants/advancedSettingsConst";
 
 export function TLPTag(props) {
   const { value, ...rest } = props;
+  
+  // Handle case where value is undefined/null
+  if (!value) {
+    return <Badge color="secondary">No TLP</Badge>;
+  }
+  
   const badgeId = `tlptag-badge__${value}`;
   const color = TLPColors?.[value] || "#dfe1e2";
   const tooltipText = TLPDescriptions?.[value] || "invalid";
 
-  return value ? (
+  return (
     <Badge
       id={badgeId}
       color={null}
@@ -27,7 +33,7 @@ export function TLPTag(props) {
         {tooltipText}
       </UncontrolledTooltip>
     </Badge>
-  ) : null;
+  );
 }
 
 TLPTag.propTypes = {

--- a/frontend/src/components/jobs/result/JobInfoCard.jsx
+++ b/frontend/src/components/jobs/result/JobInfoCard.jsx
@@ -34,6 +34,7 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
   const [isOpenJobInfoCard, setIsOpenJobInfoCard] = React.useState(false);
   const [isOpenJobWarnings, setIsOpenJobWarnings] = React.useState(false);
   const [isOpenJobErrors, setIsOpenJobErrors] = React.useState(false);
+  
 
   const investigationTimeRange = 30;
   const endDateRelatedInvestigation = new Date();
@@ -43,7 +44,6 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
   startDateRelatedInvestigation.setDate(
     startDateRelatedInvestigation.getDate() - investigationTimeRange,
   );
-
   return (
     <div id="JobInfoCardSection">
       <ContentSection className="mb-0 bg-darker">
@@ -195,14 +195,13 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
                 <PlaybookTag
                   key={job.playbook_to_execute}
                   playbook={job.playbook_to_execute}
-                  className="mr-2"
                 />,
               ],
               [
                 "Tags",
                 job.tags.length ? (
                   job.tags.map((tag) => (
-                    <JobTag key={tag.label} tag={tag} className="me-2" />
+                    <JobTag key={tag.label} tag={tag} />
                   ))
                 ) : (
                   <small className="fst-italic text-gray">None</small>

--- a/intel_owl/settings/__init__.py
+++ b/intel_owl/settings/__init__.py
@@ -76,3 +76,16 @@ from .rest import *  # lgtm [py/polluting-import]
 from .security import *  # lgtm [py/polluting-import]
 from .storage import *  # lgtm [py/polluting-import]
 from .websocket import *  # lgtm [py/polluting-import]
+
+# Load local development settings if available (overrides above)
+try:
+    from .local import *  # lgtm [py/polluting-import]
+except ImportError:
+    pass
+
+
+# Load local development settings if available (overrides above)
+try:
+    from .local import *  # lgtm [py/polluting-import]
+except ImportError:
+    pass


### PR DESCRIPTION
This is my first contribution to IntelOwl. I fixed the TLP field that wasn't displaying in the job metadata toggle. The root cause was that 'tlp' was missing from the JobSerializer fields list, so it wasn't being returned in the API response.

I also fixed a related bug in elastic.py where the code was trying to call .lower() on a property object.
as this is also my first open source contribution to a actively developed open source project, i really want to know all the mistakes that i have made, so i don't repeat them again in my next contribution. 