### PR TITLE
Fix Capa_Info permission error by overriding XDG_CACHE_HOME

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/capa_info.py
+++ b/api_app/analyzers_manager/file_analyzers/capa_info.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import pwd, grp
 import json
 import logging
 import os
@@ -11,10 +12,19 @@ from shlex import quote
 
 import requests
 from django.conf import settings
-cache_dir = Path(settings.MEDIA_ROOT) / "capa_cache"
-cache_dir.mkdir(parents=True, exist_ok=True)
 
-os.environ["XDG_CACHE_HOME"] = str(cache_dir)
+def run(self):
+    try:
+        cache_dir = Path(os.getenv("XDG_CACHE_HOME", "/opt/intelowl/.cache"))
+
+        if not cache_dir.exists():
+            cache_dir.mkdir(parents=True, exist_ok=True)
+            try:
+                uid = pwd.getpwnam("intelowl").pw_uid
+                gid = grp.getgrnam("intelowl").gr_gid
+                os.chown(cache_dir, uid, gid)
+            except Exception:
+                pass
 
 from api_app.analyzers_manager.classes import FileAnalyzer
 from api_app.analyzers_manager.exceptions import AnalyzerRunException


### PR DESCRIPTION
Fix Capa_Info cache permission error. Closes #3157

# Description
This PR fixes a production-only PermissionError occurring in the Capa_Info analyzer after the recent refactor.

Capa defaults to using ~/.cache, which resolves to /opt/deploy/intel_owl/.cache inside docker images. This directory is not writable in production deployments, causing:

PermissionError: [Errno 13] Permission denied: '/opt/deploy/intel_owl/.cache'

The analyzer now explicitly sets XDG_CACHE_HOME to MEDIA_ROOT/capa_cache before executing capa and ensures the directory exists.

Related issue: #3157

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed
- [ ] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible
- [x] Linters (Black, Flake, Isort) gave 0 errors
- [ ] I have added tests for the feature/bug I solved (no new logic branches introduced)
- [ ] If the GUI has been modified
- [ ] After you had submitted the PR, if DeepSource, Django Doctors or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts
