### PR TITLE
Fix Quad9 analyzers crashes and add tests

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/quad9_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/quad9_malicious_detector.py
@@ -80,9 +80,13 @@ class Quad9MaliciousDetector(DoHMixin, classes.ObservableAnalyzer):
         dns_response = dns.message.from_wire(quad9_response.content)
         resolutions: list[str] = []
         for answer in dns_response.answer:
-            resolutions.extend([resolution.address for resolution in answer])
+            for record in answer:
+                if hasattr(record, "address"):
+                    resolutions.append(record.address)
+                elif hasattr(record, "target"):
+                    resolutions.append(str(record.target))
 
-        return bool(resolutions)
+        return bool(resolutions), resolutions
 
     def _google_dns_query(self, observable) -> bool:
         """Perform a DNS query with Google service, return True if Google answer the

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_resolvers/quad9_dns_resolver.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_resolvers/quad9_dns_resolver.py
@@ -45,10 +45,14 @@ class Quad9DNSResolver(DoHMixin, classes.ObservableAnalyzer):
             else:
                 quad9_response.raise_for_status()
 
-        json_response = quad9_response.json()
+        try:
+            json_response = quad9_response.json()
+        except Exception:
+            json_response = {}
         resolutions: list[str] = []
         for answer in json_response.get("Answer", []):
-            if "data" in answer:
-                resolutions.append(answer["data"])
+            data = answer.get("data")  # safe access
+            if data is not None:  # skip None values
+                resolutions.append(data)
 
         return dns_resolver_response(observable, resolutions)

--- a/tests/api_app/analyzers_manager/observable_analyzers/dns/test_quad9.py
+++ b/tests/api_app/analyzers_manager/observable_analyzers/dns/test_quad9.py
@@ -1,0 +1,31 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+from unittest.mock import patch
+
+import pytest
+
+from api_app.analyzers_manager.observable_analyzers.dns import Quad9DNSResolver
+
+
+@pytest.mark.django_db
+@patch("httpx.Client.get")
+def test_quad9_dns_resolver_handles_non_utf8(mock_get):
+    class MockResponse:
+        content = b"\xd5\x00\x01"
+
+        @staticmethod
+        def raise_for_status():
+            pass
+
+        @staticmethod
+        def json():
+            return {"Answer": [{"data": "1.1.1.1"}]}
+
+    mock_get.return_value = MockResponse()
+
+    analyzer = Quad9DNSResolver(
+        observable_name="test.com", observable_classification="domain", config={}
+    )
+
+    result = analyzer.run()
+    assert "1.1.1.1" in result["resolutions"]


### PR DESCRIPTION
Fix Quad9 analyzers crash on CNAME records and non-UTF8 responses. Closes #3151

# Description

This PR fixes two issues in the Quad9 analyzers:

1. Quad9DNSResolver: Previously crashed on non-UTF8 responses from the Quad9 DoH API. The fix ensures proper handling of JSON decoding errors.
2. Quad9MaliciousDetector: Previously crashed when processing CNAME records instead of A/AAAA records. Now it safely extracts addresses or CNAME targets.

These changes improve the robustness of the analyzers when resolving DNS records and analyzing malicious domains.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).
# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [ ] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [ ] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [x] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).

### Outputs
JSON:
  1. Quad9_Malicious_Detector
  {
  "report": {
    "malicious": false,
    "observable": "www.test.com"
  },
  "data_model": null,
  "errors": [],
  "parameters": {}
}
  2.Quad9_DNS
  {
  "report": {
    "observable": "www.test.com",
    "resolutions": []
  },
  "data_model": null,
  "errors": [],
  "parameters": {
    "query_type": "A"
  }
 }
Screenshots: 
<img width="1836" height="883" alt="Screenshot 2026-01-06 224627" src="https://github.com/user-attachments/assets/03a1d4ae-2bcd-4402-b146-7dbc6467f1b1" />
<img width="1910" height="968" alt="Screenshot 2026-01-06 224650" src="https://github.com/user-attachments/assets/cccb3616-22db-4ade-b435-ec74a6ec06ec" />