### PR TITLE
fix: Display 0 when no similar investigations available. Closes #3146

### DIFF
--- a/frontend/src/components/jobs/result/JobInfoCard.jsx
+++ b/frontend/src/components/jobs/result/JobInfoCard.jsx
@@ -29,7 +29,7 @@ import { JobIsRunningAlert } from "./JobIsRunningAlert";
 import { JobFinalStatuses } from "../../../constants/jobConst";
 import { datetimeFormatStr } from "../../../constants/miscConst";
 
-export function JobInfoCard({ job, relatedInvestigationNumber }) {
+export function JobInfoCard({ job, relatedInvestigationNumber = 0}) {
   // local state
   const [isOpenJobInfoCard, setIsOpenJobInfoCard] = React.useState(false);
   const [isOpenJobWarnings, setIsOpenJobWarnings] = React.useState(false);
@@ -287,5 +287,5 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
 
 JobInfoCard.propTypes = {
   job: PropTypes.object.isRequired,
-  relatedInvestigationNumber: PropTypes.number.isRequired,
+  relatedInvestigationNumber: PropTypes.number,
 };


### PR DESCRIPTION
fix: display 0 when no similar investigations available. Closes #3146

# Description

This PR fixes issue https://github.com/intelowlproject/IntelOwl/issues/3146 where the Similar Investigations button did not display any number when there were no similar investigations available. This caused confusion for users who couldn't tell if there were 0 results or if the data failed to load.

Changes made:

 1. Added a default parameter value (= 0) to relatedInvestigationNumber in the JobInfoCard component function declaration
 2. Updated the PropTypes definition to make relatedInvestigationNumber optional (removed .isRequired)
 
Result: The Similar Investigations button now correctly displays "0" when no similar investigations exist, providing clear feedback to users.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).

<img width="1862" height="864" alt="Screenshottt 2026-01-09 234337" src="https://github.com/user-attachments/assets/21255c13-f513-41dd-a5b9-6b8377318adf" />


# Checklist

- [ ] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [ ] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [ ] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [ ] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [ ] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).