### PR TITLE
fix: Update PhishStats Base URL

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -16,7 +16,7 @@ class PhishStats(ObservableAnalyzer):
     Analyzer that uses PhishStats API to check if the observable is a phishing site.
     """
 
-    url: str = "https://phishstats.info:2096/api"
+    url: str = "https://api.phishstats.info/api/phishing"
 
     @classmethod
     def update(cls) -> bool:


### PR DESCRIPTION
## Description
Updates the PhishStats to use the new API Base URL

The old URL `https://phishstats.info:2096/api` is no longer functional. This PR updates it to the new endpoint `https://api.phishstats.info/api/phishing` as documented in the [PhishStats API documentation](https://phishstats.info/api-docs).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Checklist
- [x] I have read and understood the rules about contributing to this project
- [x] The pull request is for the branch `develop`