### PR TITLE
Handle 500 server errors and timeouts in Threatminer analyzer (closes #3192)

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/threatminer.py
+++ b/api_app/analyzers_manager/observable_analyzers/threatminer.py
@@ -36,23 +36,25 @@ class Threatminer(classes.ObservableAnalyzer):
         try:
             response = requests.get(self.url + uri, params=params, timeout=30)
             response.raise_for_status()
+
         except requests.Timeout:
-            return {
-                "status": "failed",
-                "message": "Threatminer API request timed out — external service may be slow or unavailable.",
-            }
+            error_message = "Threatminer API request timed out — external service may be slow or unavailable."
+            self.report.errors.append(error_message)
+            return {"threatminer_error": error_message}
+
+        except requests.HTTPError as http_err:
+            if response is not None and response.status_code >= 500:
+                error_message = (
+                    f"Threatminer API returned server error ({response.status_code}) "
+                    "— this is an external service issue. Try again later."
+                )
+                self.report.errors.append(error_message)
+                return {"threatminer_error": error_message}
+            raise AnalyzerRunException(f"Threatminer request failed: {str(http_err)}")
+
         except requests.RequestException as e:
-            # Gracefully handle server-side errors (e.g. 500, 502, etc.)
-            if response and response.status_code >= 500:
-                return {
-                    "status": "failed",
-                    "message": (
-                        f"Threatminer API returned server error ({response.status_code}) "
-                        "— this is an external service issue. Try again later."
-                    ),
-                }
-            else:
-                # Re-raise other errors (e.g. 400, 401, connection refused)
-                raise AnalyzerRunException(f"Threatminer request failed: {str(e)}")
+            error_message = f"Threatminer request failed: {str(e)}"
+            self.report.errors.append(error_message)
+            return {"threatminer_error": error_message}
 
         return response.json()


### PR DESCRIPTION
# Description
This PR adds error handling to the Threatminer analyzer to gracefully manage 500 Internal Server Errors and timeouts from the external API. Instead of failing the analyzer, it returns a friendly message indicating an external service issue(closes #3192).

I first investigated the root cause of the 500 error by running manual curl tests on the Threatminer API endpoints (e.g., `curl -v "https://api.threatminer.org/v2/host.php?q=8.8.8.8&rt=2"` and `rt=1`). The tests consistently returned HTTP 500 with no response body, via Cloudflare proxy, confirming it's an external server-side issue on Threatminer's end (not an IntelOwl bug, param error, or rate limiting). Since we can't fix their API, error handling is the best solution to prevent job failures.

Tested locally: The analyzer now returns the custom message for 500 errors, and the playbook completes without marking Threatminer as a full failure.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [x] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. [](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community)
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [x] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [x] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests).
    - [ ] If a new analyzer has been added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [ ] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing.
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.