### PR TITLE
Fix memory amplification when parsing malformed eve.json

### DIFF
--- a/integrations/pcap_analyzers/app.py
+++ b/integrations/pcap_analyzers/app.py
@@ -59,8 +59,8 @@ def intercept_suricata_result(context, future: Future) -> None:
                 try:
                     res["report"]["data"].append(json.loads(line))
                 except json.JSONDecodeError as e:
-                    logger.debug(e)
-                    res["report"]["data"].append(fp.read())
+                    logger.warning(f"Skipping malformed JSON line in eve.json: {e}")
+                    continue
 
     # 3. set final result after modifications
     future._result = res  # skipcq PYL-W0212


### PR DESCRIPTION
Fixes #3202

## Summary

Prevents memory amplification vulnerability in PCAP Suricata result processing where a single malformed JSON line would cause the entire remainder of the file to be read into memory.

## Changes

- Skip malformed JSON lines with a warning log instead of reading remaining file
- Continue processing subsequent valid lines  
- Prevents potential DoS via memory exhaustion

## Testing

- Malformed JSON lines are now skipped with a warning logged
- Valid lines continue to be processed correctly
- No unbounded memory consumption occurs