### PR TITLE
Fix job stuck in RUNNING state when pipeline setup fails

### DIFF
--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -256,6 +256,7 @@ def job_pipeline(
     job_id: int,
 ):
     from api_app.models import Job
+    from api_app.websocket import JobConsumer
 
     job = Job.objects.get(pk=job_id)
     try:
@@ -270,6 +271,14 @@ def job_pipeline(
         ):
             report.status = report.STATUSES.FAILED.value
             report.save()
+
+        # Set job to FAILED status and record completion time
+        job.status = Job.STATUSES.FAILED.value
+        job.finished_analysis_time = now()
+        job.save(update_fields=["status", "finished_analysis_time"])
+
+        # Notify WebSocket clients of the failure
+        JobConsumer.serialize_and_send_job(job)
 
 
 @shared_task(base=FailureLoggedTask, name="run_plugin", soft_time_limit=500)


### PR DESCRIPTION
### Summary

When job.execute() raises an exception during pipeline setup, related reports are marked as FAILED, but the Job itself remains in RUNNING state, finished_analysis_time is not set, and no WebSocket notification is sent. This causes silent stuck jobs in production when failures occur during task dispatch (e.g., broker issues, invalid queues, analyzer setup errors).
This PR updates the Job status to FAILED, records the completion time, and notifies connected clients in the exception handler, ensuring the job lifecycle is consistent even when pipeline dispatch fails.

---

### Impact
	•	Prevents jobs from remaining indefinitely in RUNNING state
	•	Ensures completion timestamps are always set on failure
	•	UI and API clients receive immediate failure notification
	•	Keeps existing success-path behavior unchanged