### PR TITLE
Fix / Similar investigation button fix

### DIFF
--- a/frontend/src/components/jobs/result/JobInfoCard.jsx
+++ b/frontend/src/components/jobs/result/JobInfoCard.jsx
@@ -29,7 +29,7 @@ import { JobIsRunningAlert } from "./JobIsRunningAlert";
 import { JobFinalStatuses } from "../../../constants/jobConst";
 import { datetimeFormatStr } from "../../../constants/miscConst";
 
-export function JobInfoCard({ job, relatedInvestigationNumber }) {
+export function JobInfoCard({ job, relatedInvestigationNumber = 0 }) {
   // local state
   const [isOpenJobInfoCard, setIsOpenJobInfoCard] = React.useState(false);
   const [isOpenJobWarnings, setIsOpenJobWarnings] = React.useState(false);
@@ -48,9 +48,13 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
     <div id="JobInfoCardSection">
       <ContentSection className="mb-0 bg-darker">
         <Row>
-          <Col sm={12} md={3} className="d-flex justify-content-start">
+          <Col
+            sm={12}
+            md={3}
+            className="d-flex align-items-center justify-content-start"
+          >
             <Button
-              className="bg-darker border-1 lh-sm mx-1"
+              className="bg-darker border-1 d-flex align-items-center mx-1"
               href={`/history/investigations?start_time__gte=${format(
                 startDateRelatedInvestigation,
                 datetimeFormatStr,
@@ -66,7 +70,7 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
               size="xs"
               style={{ fontSize: "0.8rem" }}
             >
-              Similar Investigations: <br /> {relatedInvestigationNumber}
+              Similar Investigations: {relatedInvestigationNumber}
             </Button>
             <UncontrolledTooltip
               placement="top"
@@ -79,7 +83,7 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
             {job.investigation_id && (
               <>
                 <Button
-                  className="bg-darker border-1 lh-sm mx-1"
+                  className="bg-darker border-1 d-flex align-items-center mx-1"
                   href={`/investigation/${job.investigation_id}`}
                   target="_blank"
                   rel="noreferrer"
@@ -87,7 +91,7 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
                   size="xs"
                   style={{ fontSize: "0.8rem" }}
                 >
-                  Investigation: <br /> {job.investigation_name}
+                  Investigation: {job.investigation_name}
                 </Button>
                 <UncontrolledTooltip
                   placement="top"
@@ -287,5 +291,9 @@ export function JobInfoCard({ job, relatedInvestigationNumber }) {
 
 JobInfoCard.propTypes = {
   job: PropTypes.object.isRequired,
-  relatedInvestigationNumber: PropTypes.number.isRequired,
+  relatedInvestigationNumber: PropTypes.number,
+};
+
+JobInfoCard.defaultProps = {
+  relatedInvestigationNumber: 0,
 };

--- a/frontend/src/components/jobs/result/JobResult.jsx
+++ b/frontend/src/components/jobs/result/JobResult.jsx
@@ -88,20 +88,26 @@ export default function JobResult() {
       !jobLoading,
       jobError == null,
     );
-    if (!data.job && jobData && !jobLoading && jobError == null) {
-      axios
-        .get(
-          `${ANALYZABLES_URI}/${jobData.analyzable_id}/related_investigation_number`,
-        )
-        .then((response) => response.data.related_investigation_number)
-        .catch((_) => -1)
-        // use "then" instead of "finally"vecause it doesn't support parameters
-        .then((relatedInvestigationNumber) =>
-          setData({ relatedInvestigationNumber, job: jobData }),
-        );
+    if (jobData && !jobLoading && jobError == null) {
+      // case 1 - fetching investigation number if we dont have it, this'll even sync the job data when the request completes
+      if (data.relatedInvestigationNumber === undefined) {
+        axios
+          .get(
+            `${ANALYZABLES_URI}/${jobData.analyzable_id}/related_investigation_number`,
+          )
+          .then((response) => response.data.related_investigation_number)
+          .catch((_) => -1)
+          .then((relatedVal) =>
+            setData({ relatedInvestigationNumber: relatedVal, job: jobData }),
+          );
+      }
+      // case 2 - if we already have the number
+      else if (data.job !== jobData) {
+        setData((prev) => ({ ...prev, job: jobData }));
+      }
     }
     // eslint-disable-next-line react-hooks/exhaustive-deps
-  }, [jobLoading]);
+  }, [jobLoading, jobData]);
 
   useEffect(() => {
     if (data.job) setDataIsDownloading(false);


### PR DESCRIPTION
# Description
The UI did not show any value when a job had no related investigations. In this case, it should explicitly show `0`.
Closes #3146 

### Changes made
- Defaulted `relatedInvestigationNumber` to `0.
- Adjusted the `useEffect` logic so job data is always synced 
- Small readability cleanup for the WebSocket URL (no behavior change).

Could've made a simple UI change by setting `relatedInvestigationNumber` to `0`, but this would've fixed it at the user end onlly. By setting the value properly in the data flow, the state stays consistent and it’s always clear whether there's a 0 related investigation or the value hasn’t been fetched yet. Let me know if we want to keep it simple

## Screenshot
<img width="427" height="177" alt="Screenshot 2026-01-29 at 11 21 26 PM" src="https://github.com/user-attachments/assets/6b999289-8f73-4b5b-9d8f-32b358c35f7f" />


## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [N/A] I have created new frontend tests for the new component or updated existing ones.
