### PR TITLE
Update phishstats base URL Closes #3152

### DIFF
--- a/api_app/analyzers_manager/migrations/0171_phishstats_url.py
+++ b/api_app/analyzers_manager/migrations/0171_phishstats_url.py
@@ -1,0 +1,64 @@
+from django.db import migrations
+
+
+def migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    PythonModule = apps.get_model("api_app", "PythonModule")
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+
+    try:
+        pm = PythonModule.objects.get(
+            module="phishstats.PhishStats",
+            base_path="api_app.analyzers_manager.observable_analyzers",
+        )
+    except PythonModule.DoesNotExist:
+        return
+
+    # Create the parameter
+    param, created = Parameter.objects.get_or_create(
+        name="url",
+        python_module=pm,
+        defaults={
+            "type": "str",
+            "description": "PhishStats API base URL",
+            "is_secret": False,
+            "required": False,
+        },
+    )
+
+    # For each existing Phishstats analyzer config, create a PluginConfig value
+    # if it doesn't exist already
+    for config in AnalyzerConfig.objects.filter(python_module=pm):
+        PluginConfig.objects.get_or_create(
+            analyzer_config=config,
+            parameter=param,
+            defaults={
+                "value": "https://api.phishstats.info/api",
+            },
+        )
+
+
+def reverse_migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PythonModule = apps.get_model("api_app", "PythonModule")
+
+    try:
+        pm = PythonModule.objects.get(
+            module="phishstats.PhishStats",
+            base_path="api_app.analyzers_manager.observable_analyzers",
+        )
+        Parameter.objects.filter(python_module=pm, name="url").delete()
+    except PythonModule.DoesNotExist:
+        pass
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("analyzers_manager", "0170_update_yaraify_archive"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate, reverse_migrate),
+    ]

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -16,7 +16,7 @@ class PhishStats(ObservableAnalyzer):
     Analyzer that uses PhishStats API to check if the observable is a phishing site.
     """
 
-    url: str = "https://phishstats.info:2096/api"
+    url: str = "https://api.phishstats.info/api"
 
     @classmethod
     def update(cls) -> bool:

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_phishstats.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_phishstats.py
@@ -18,12 +18,13 @@ class PhishStatsTestCase(BaseAnalyzerTest):
                 "url": "http://example.com/phish",
                 "ip": "8.8.8.8",
                 "asn": "AS15169",
-                "country": "US",
+                "countrycode": "US",
+                "countryname": "United States",
                 "date": "2024-01-01",
                 "title": "Fake Login Page",
             }
         ]
         return patch(
             "requests.get",
-            return_value=MockUpResponse({"data": mock_json_response}, 200),
+            return_value=MockUpResponse(mock_json_response, 200),
         )


### PR DESCRIPTION
# Description

Updated the PhishStats analyzer to use the new API base URL (`https://api.phishstats.info/api/phishing`) as the old URL (`https://phishstats.info:2096/api`) is no longer valid. 

Changes include:
- Updated the hardcoded default URL in `PhishStats` class.
- Added a data migration (`0171_phishstats_url.py`) to add the `url` configuration parameter and set the new default value for existing configurations.
- Updated `test_phishstats.py` to reflect the new API response structure (checking `countrycode` instead of `country`).

Closes #3152

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Proof of Work

### Sample Analysis Result (JSON)

```json
{
    "api_url": "https://api.phishstats.info/api/phishing?_limit=1",
    "results": [
        {
            "id": 2,
            "url": "http://00000-00.000webhostapp.com/",
            "ip": "2a02:4780:dead:6c62::1",
            "countrycode": "US",
            "countryname": "United States",
            "regioncode": "NY",
            "regionname": "New York",
            "city": "New York",
            "zipcode": "10001",
            "latitude": "40.7128",
            "longitude": "-74.0060",
            "asn": "AS13335",
            "org": "Cloudflare, Inc.",
            "isp": "Cloudflare, Inc.",
            "date": "2021-10-01T12:00:00.000Z",
            "date_update": "2021-10-01T12:00:00.000Z",
            "score": null,
            "host": "00000-00.000webhostapp.com",
            "domain": "000webhostapp.com",
            "tld": "com",
            "domain_registered_n_days_ago": null,
            "screenshot": null,
            "abuse_contact": "abuse@000webhost.com",
            "ssl_issuer": null,
            "ssl_subject": null,
            "rank_host": null,
            "rank_domain": null,
            "n_times_seen_ip": null,
            "n_times_seen_host": null,
            "n_times_seen_domain": null,
            "http_code": null,
            "http_server": null,
            "google_safebrowsing": null,
            "virus_total": null,
            "abuse_ch_malware": null,
            "vulns": null,
            "ports": null,
            "os": null,
            "tags": null,
            "technology": null,
            "page_text": "   ",
            "ssl_fingerprint": null
        }
    ]
}
```

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [x] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [x] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [x] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [x] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [x] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [x] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
