### PR TITLE
chore: remove deprecated ask_analysis_availability endpoint

### DIFF
--- a/api_app/serializers/job.py
+++ b/api_app/serializers/job.py
@@ -1168,7 +1168,8 @@ class JobResponseSerializer(rfs.ModelSerializer):
 
 class JobAvailabilitySerializer(rfs.ModelSerializer):
     """
-    Serializer for ask_analysis_availability
+    Serializer for ask_multi_analysis_availability endpoint.
+    Checks for existing analysis based on MD5 hash(es) to avoid redundant analysis.
     """
 
     class Meta:

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -14,7 +14,6 @@ from .views import (
     analyze_multiple_files,
     analyze_multiple_observables,
     analyze_observable,
-    ask_analysis_availability,
     ask_multi_analysis_availability,
     plugin_state_viewer,
 )
@@ -29,7 +28,6 @@ router.register(r"plugin-config", PluginConfigViewSet, basename="plugin-config")
 # These come after /api/..
 urlpatterns = [
     # standalone endpoints
-    path("ask_analysis_availability", ask_analysis_availability),
     path("ask_multi_analysis_availability", ask_multi_analysis_availability),
     path("analyze_file", analyze_file),
     path(

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -38,7 +38,6 @@ from intel_owl import tasks
 from intel_owl.celery import app as celery_app
 from intel_owl.settings._util import get_environment
 
-from .decorators import deprecated_endpoint
 from .filters import JobFilter
 from .mixins import PaginationMixin
 from .models import (
@@ -81,46 +80,12 @@ logger = logging.getLogger(__name__)
 # REST API endpoints
 
 
-@deprecated_endpoint(deprecation_date="01-07-2023")
-@api_view(["POST"])
-def ask_analysis_availability(request):
-    """
-    API endpoint to check for existing analysis based on an MD5 hash.
-
-    This endpoint helps avoid redundant analysis by checking if there is already an analysis
-    in progress or completed with status "running" or "reported_without_fails" for the provided MD5 hash.
-    The analyzers that need to be executed should be specified to ensure expected results.
-
-    Deprecated: This endpoint will be deprecated after 01-07-2023.
-
-    Parameters:
-    - request (POST): Contains the MD5 hash and analyzer details.
-
-    Returns:
-    - 200: JSON response with the analysis status, job ID, and analyzers to be executed.
-    """
-    serializer = JobAvailabilitySerializer(
-        data=request.data, context={"request": request}
-    )
-    serializer.is_valid(raise_exception=True)
-    try:
-        job = serializer.save()
-    except Job.DoesNotExist:
-        result = None
-    else:
-        result = job
-    return Response(
-        JobResponseSerializer(result).data,
-        status=status.HTTP_200_OK,
-    )
-
-
 @api_view(["POST"])
 def ask_multi_analysis_availability(request):
     """
     API endpoint to check for existing analysis for multiple MD5 hashes.
 
-    Similar to `ask_analysis_availability`, this endpoint checks for existing analysis for multiple MD5 hashes.
+    This endpoint checks for existing analysis for multiple MD5 hashes.
     It prevents redundant analysis by verifying if there are any jobs in progress or completed with status
     "running" or "reported_without_fails". The analyzers required should be specified to ensure accurate results.
 

--- a/tests/api_app/test_api.py
+++ b/tests/api_app/test_api.py
@@ -90,23 +90,6 @@ class ApiViewTests(CustomViewSetTestCase):
         md5 = hashlib.md5(binary).hexdigest()  # nosec
         return uploaded_file, md5
 
-    def test_ask_analysis_availability(self):
-        md5 = os.environ.get("TEST_MD5", "446c5fbb11b9ce058450555c1c27153c")
-        analyzers_needed = ["Classic_DNS", "CIRCLPassiveDNS"]
-        data = {"md5": md5, "analyzers": analyzers_needed, "minutes_ago": 1}
-        response = self.client.post(
-            "/api/ask_analysis_availability", data, format="json"
-        )
-        self.assertEqual(response.status_code, 200)
-
-    def test_ask_analysis_availability__run_all_analyzers(self):
-        md5 = os.environ.get("TEST_MD5", "446c5fbb11b9ce058450555c1c27153c")
-        data = {"md5": md5, "analyzers": []}
-        response = self.client.post(
-            "/api/ask_analysis_availability", data, format="json"
-        )
-        self.assertEqual(response.status_code, 200)
-
     def test_analyze_file__pcap(self):
         # set a fake API key or YARAify_File_Scan will be skipped as not configured
         models.PluginConfig.objects.create(


### PR DESCRIPTION
Summary: Deleted the legacy /api/ask_analysis_availability endpoint (deprecated July 2023) to reduce technical debt and streamline the API.

Refactor: Removed redundant URL routes, associated unit tests, and unused imports while updating JobAvailabilitySerializer documentation.

Breaking Change: Redirected core logic to the multi-hash endpoint; clients must now migrate to /api/ask_multi_analysis_availability for all queries.