### PR TITLE
fix: add background color to TLP badges

### DIFF
--- a/frontend/src/components/common/TLPTag.jsx
+++ b/frontend/src/components/common/TLPTag.jsx
@@ -10,6 +10,7 @@ export function TLPTag(props) {
   const badgeId = `tlptag-badge__${value}`;
   const color = TLPColors?.[value] || "#dfe1e2";
   const tooltipText = TLPDescriptions?.[value] || "invalid";
+  const textColor = value === "CLEAR" ? "#000000" : "#FFFFFF";
 
   return value ? (
     <Badge
@@ -18,7 +19,9 @@ export function TLPTag(props) {
       style={{
         borderRadius: 5,
         userSelect: "none",
+        backgroundColor: color,
         border: `1px solid ${color}`,
+        color: textColor,
       }}
       {...rest}
     >


### PR DESCRIPTION
## Description
Fixed TLP badge display issue where badges were showing only borders without background colors.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

## Changes Made
- Added `backgroundColor` property to TLP badge component styling
- Added text color logic for better readability (black text for CLEAR, white text for GREEN/AMBER/RED)

## Testing
Tested with all TLP values - badges now display correctly with proper colored backgrounds.

## Screenshots

<img width="1350" height="359" alt="Screenshot 2026-02-04 at 7 04 09 PM" src="https://github.com/user-attachments/assets/4edc7a07-f76d-4641-8845-7c85cbcdd871" />

# Checklist
- [x] I have read and understood the rules about how to Contribute to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (Black, Flake, Isort) gave 0 errors
- [x] If the GUI has been modified:
    - [x] I have provided a screenshot of the result in the PR


Fixes #3150 - TLP value is not shown properly