### PR TITLE
UI fix: prevent datetime fields from overflowing on Reports Search Page

### DIFF
--- a/frontend/src/components/search/ReportsSearch.jsx
+++ b/frontend/src/components/search/ReportsSearch.jsx
@@ -156,7 +156,9 @@ export default function ReportsSearch() {
               Advanced search in plugin reports of the performed analysis.
             </span>
           </Row>
-          <Row id="search-input-fields-first-row d-flex flex-wrap">
+          <Row 
+            id="search-input-fields-first-row"
+            className="d-flex flex-wrap">
             <Col xxl={4} sm={12} className="d-flex align-items-center mt-4">
               <Label className="col-3 fw-bold mb-0" for="search__type">
                 Type:
@@ -252,7 +254,7 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.startTime}
-                      className="col-6"
+                      className="flex-grow-1 w-100"
                     />
                   </div>
                   <div className="d-flex align-items-center">
@@ -268,7 +270,7 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.startTime}
-                      className="col-6"
+                      className="flex-grow-1 w-100"
                     />
                   </div>
                 </div>
@@ -300,7 +302,7 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.endTime}
-                      className="col-6"
+                      className="flex-grow-1 w-100"
                     />
                   </div>
                   <div className="d-flex align-items-center">
@@ -316,7 +318,7 @@ export default function ReportsSearch() {
                       onBlur={formik.handleBlur}
                       onChange={formik.handleChange}
                       invalid={formik.errors.endTime}
-                      className="col-6"
+                      className="flex-grow-1 w-100"
                     />
                   </div>
                 </div>


### PR DESCRIPTION
Fix Reports Search datetime overflow layout. Closes #3096

# Description

This PR fixes a UI layout issue on the **Reports Search** page (`/search`) where the **datetime-local input fields** ("Start time" and "End time") were overflowing their container columns and overlapping with adjacent fields (notably the "Errors" field).

### What was changed
- Fixed incorrect usage of Bootstrap utility classes being placed inside the `id` attribute
- Added proper `d-flex` and `flex-wrap` classes to the first row to allow responsive wrapping
- Updated `datetime-local` inputs to use `flex-grow-1 w-100` so they stay within their container width
- Ensured form fields remain contained within their respective columns across screen sizes

This is a **frontend-only CSS/layout fix** and does not affect backend logic or APIs.

Related issue: https://github.com/intelowlproject/IntelOwl/issues/3096

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature
- [ ] Breaking change

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`

- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed

- [ ] I have inserted the copyright banner at the start of the file  
  (Not applicable — no new files were created)

- [x] Please avoid adding new libraries as requirements whenever it is possible  
  No new libraries were added

- [ ] If external libraries/packages with restrictive licenses were added, they were added in the Legal Notice section  
  (Not applicable)

- [ ] Linters (`Black`, `Flake`, `Isort`) gave 0 errors  
  (Not applicable — frontend-only change)

- [ ] I have added tests for the feature/bug I solved  
  (UI-only layout fix, no existing frontend tests affected)

- [x] If the GUI has been modified:
  - [ ] I have provided a screenshot of the result in the PR
  - [ ] I have created new frontend tests for the new component or updated existing ones

- [ ] After submitting the PR, if any CI or third-party linters triggered alerts, I have addressed them

