### PR TITLE
feat: improve generic observable type detection in InQuest analyzer

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/inquest.py
+++ b/api_app/analyzers_manager/observable_analyzers/inquest.py
@@ -24,8 +24,14 @@ REGISTRY_PATTERN = re.compile(
     re.IGNORECASE,
 )
 
-# XMP ID pattern (UUID format   )
-XMPID_PATTERN = re.compile(r"^[a-fA-F0-9]{8}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{4}-[a-fA-F0-9]{12}$")
+# XMP ID pattern (UUID format)
+XMPID_PATTERN = re.compile(
+    r"^[a-fA-F0-9]{8}-"
+    r"[a-fA-F0-9]{4}-"
+    r"[a-fA-F0-9]{4}-"
+    r"[a-fA-F0-9]{4}-"
+    r"[a-fA-F0-9]{12}$"
+)
 
 # Filename pattern - must have an extension, no path separators
 FILENAME_PATTERN = re.compile(r"^[\w\-. ]+\.[a-zA-Z0-9]{1,10}$")

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_inquest.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_inquest.py
@@ -82,3 +82,12 @@ class TypeOfGenericTestCase(InQuestTestCase):
     def test_type_of_generic_unknown_defaults_to_filename(self):
         self.analyzer.observable_name = "random-text-no-extension"
         self.assertEqual(self.analyzer.type_of_generic(), "filename")
+
+    @patch("api_app.analyzers_manager.observable_analyzers.inquest.logger.warning")
+    def test_type_of_generic_unknown_warning(self, mock_warning):
+        self.analyzer.observable_name = "random-text-no-extension"
+        self.analyzer.type_of_generic()
+        mock_warning.assert_called_once_with(
+            "Could not determine type of generic observable: "
+            "'random-text-no-extension'. Defaulting to 'filename'."
+        )


### PR DESCRIPTION
# Description
Improved the [type_of_generic()](cci:1://file:///home/lakshita/development/honeynet/IntelOwl/api_app/analyzers_manager/observable_analyzers/inquest.py:41:4-75:25) method in the InQuest analyzer to provide more thorough validation of generic observable types.
**Closes #3280**

## Changes Made
1. **Enhanced email regex**: Updated the pattern to handle TLDs longer than 3 characters and subdomains
2. **Added detection for Windows registry keys**: Pattern matching for `HKEY_*`, `HKLM`, `HKCU`, etc.
3. **Added detection for XMP IDs**: UUID-like pattern matching
4. **Added basic filename validation**: Proper pattern validation instead of defaulting
5. **Added warning logging**: Log when observable type cannot be determined
6. 
## Type of change
- [x] Bug fix (non-breaking change which fixes an issue)

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Black`, `Flake`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
