### PR TITLE
fix: add HTTP timeout to Yeti connector (Fixes #3256)

### DIFF
--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -58,6 +58,7 @@ class YETI(classes.Connector):
                 headers=headers,
                 json=payload,
                 verify=self.verify_ssl,
+                timeout=60,
             )
             resp.raise_for_status()
         except requests.RequestException as e:


### PR DESCRIPTION
Adds `timeout=60` to the `requests.post()` call in the Yeti connector so that slow or unresponsive Yeti API does not block Celery workers indefinitely.

Fixes #3256