### PR TITLE
fix: handle SSL and DNS errors gracefully in DNStwist analyzer. Close #3282

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/dnstwist.py
+++ b/api_app/analyzers_manager/observable_analyzers/dnstwist.py
@@ -60,7 +60,5 @@ class DNStwist(classes.ObservableAnalyzer):
             report = dnstwist.run(**params)
         except (OSError, ssl.SSLError) as e:
             return {"error": f"Network/SSL error: {str(e)}"}
-        except Exception as e:
-            return {"error": f"Unexpected error: {str(e)}"}
 
         return report

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_dnstwist.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_dnstwist.py
@@ -61,15 +61,3 @@ class DNStwistTestCase(BaseAnalyzerTest):
             report = analyzer.run()
             self.assertIn("error", report)
             self.assertTrue(report["error"].startswith("Network/SSL error"))
-
-    def test_run_with_unexpected_error(self):
-        from api_app.analyzers_manager.models import AnalyzerConfig
-        from api_app.choices import Classification
-
-        config = AnalyzerConfig.objects.filter(name="DNStwist").first()
-        analyzer = self._setup_analyzer(config, Classification.DOMAIN, "example.com")
-
-        with patch("dnstwist.run", side_effect=Exception("Something went wrong")):
-            report = analyzer.run()
-            self.assertIn("error", report)
-            self.assertTrue(report["error"].startswith("Unexpected error"))


### PR DESCRIPTION
# Description

This PR fixes the `ssl.SSLEOFError` and `socket.gaierror` in the DNStwist analyzer. These errors occurred when the analyzer encountered misconfigured domains or non-existent domains, causing the Celery worker to crash or report a failed job.

The fix wraps the `dnstwist.run()` call in a `try...except` block to catch `ssl.SSLError` and `socket.error`. Instead of failing, the analyzer now returns a structured error message within the analysis report, allowing IntelOwl to handle the situation gracefully and inform the user.

Closes #3282

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [x] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here. (N/A)
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here. (N/A)
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (N/A)
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported... (N/A)
    - [ ] If you created a new analyzer and it is free... (N/A)
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks). (N/A)
    - [x] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [x] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information.
    - [x] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. (Added new test cases to existing test file)
    - [x] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class.
    - [ ] I have created the corresponding `DataModel` for the new analyzer... (N/A)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. (No new libraries added)
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section. (N/A)
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Screenshots & Verification

The fix has been verified by simulating the SSL and DNS exceptions encountered during analysis and by adding automated unit tests.

#### 1. Automated Unit Tests Result
Added 3 new test cases to `tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_dnstwist.py` to verify handling of `SSLEOFError`, `gaierror`, and unexpected exceptions.
<img width="976" height="553" alt="image" src="https://github.com/user-attachments/assets/0c8852eb-fd1c-4164-9b5c-feb7715032b4" />
(Command: `python3 manage.py test tests.api_app.analyzers_manager.unit_tests.observable_analyzers.test_dnstwist`)

#### 2. DNS Resolution Error Handling
Verified that non-existent domains now return a graceful gateway error instead of crashing the worker.
<img width="977" height="223" alt="image" src="https://github.com/user-attachments/assets/3135395a-956b-4974-9196-1f05fb0cf52b" />

#### 3. SSL Handshake Error Handling
Verified that domains with SSL/TLS protocol violations (Python 3.11 strict handling) are now caught and reported.
<img width="975" height="233" alt="image" src="https://github.com/user-attachments/assets/3d44e0ec-c7ea-4f4d-8196-f7f535dc51dc" />

#### 4. Celery Worker Stability
The Celery worker logs confirm that these exceptions no longer produce tracebacks or interrupt the worker process.
<img width="977" height="498" alt="image" src="https://github.com/user-attachments/assets/2563f869-3139-4b64-b6d3-98ba21cc8b99" />

#### JSON Result (Graceful error report)
```json
{
  "error": "Network/SSL error: [Errno -2] Name or service not known"
}
```
<img width="983" height="187" alt="image" src="https://github.com/user-attachments/assets/294f97d8-c229-433b-83f8-27365a24cbb2" />

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system.
