### PR TITLE
PostgreSQL upgrade to v18. Closes #3272

### DIFF
--- a/docker/env_file_postgres_template
+++ b/docker/env_file_postgres_template
@@ -1,4 +1,3 @@
 POSTGRES_PASSWORD=password
 POSTGRES_USER=user
 POSTGRES_DB=intel_owl_db
-PGDATA=/var/lib/postgresql/pgdata

--- a/docker/env_file_postgres_template
+++ b/docker/env_file_postgres_template
@@ -1,3 +1,4 @@
 POSTGRES_PASSWORD=password
 POSTGRES_USER=user
 POSTGRES_DB=intel_owl_db
+PGDATA=/var/lib/postgresql/pgdata

--- a/docker/postgres.override.yml
+++ b/docker/postgres.override.yml
@@ -4,7 +4,7 @@ services:
     image: library/postgres:18-alpine
     container_name: intelowl_postgres
     volumes:
-      - postgres_data_v18:/var/lib/postgresql
+      - postgres_data_v18:/var/lib/postgresql/data
     env_file:
       - ./env_file_postgres
     healthcheck:

--- a/docker/postgres.override.yml
+++ b/docker/postgres.override.yml
@@ -4,7 +4,7 @@ services:
     image: library/postgres:18-alpine
     container_name: intelowl_postgres
     volumes:
-      - postgres_data_v18:/var/lib/postgresql/data/
+      - postgres_data_v18:/var/lib/postgresql
     env_file:
       - ./env_file_postgres
     healthcheck:

--- a/docker/postgres.override.yml
+++ b/docker/postgres.override.yml
@@ -1,10 +1,10 @@
 services:
 
   postgres:
-    image: library/postgres:16-alpine
+    image: library/postgres:18-alpine
     container_name: intelowl_postgres
     volumes:
-      - postgres_data:/var/lib/postgresql/data/
+      - postgres_data_v18:/var/lib/postgresql/data/
     env_file:
       - ./env_file_postgres
     healthcheck:
@@ -25,3 +25,6 @@ services:
     depends_on:
       postgres:
         condition: service_healthy
+
+volumes:
+  postgres_data_v18:


### PR DESCRIPTION
## Description

Upgrades the PostgreSQL Docker image from version 16 to version 18 for the upcoming IntelOwl v7.0.0 release.

This PR includes:
- Updated `postgres.override.yml` to use `postgres:18-alpine`
- New isolated volume `postgres_data_v18` to prevent conflicts with v6 data
- Removed custom `PGDATA` environment variable (using PostgreSQL defaults)
- Fixed volume mount configuration to prevent anonymous volume creation (addresses issue from intelowlproject/GreedyBear#766)

## Related PRs/Issues
- Closes #3272
- Documentation PR: intelowlproject/docs#51

## Technical Details

### What Changed

**Files Modified:**
1. `docker/postgres.override.yml`
   - Updated PostgreSQL image: `postgres:16-alpine` → `postgres:18-alpine`
   - Changed volume name: `postgres_data` → `postgres_data_v18` (for v6/v7 isolation)
   - Mount configuration: `postgres_data_v18:/var/lib/postgresql/data`

2. `docker/env_file_postgres_template`
   - Removed custom `PGDATA` variable (uses PostgreSQL's default `/var/lib/postgresql/data`)

### Why These Changes?

**Volume Isolation:** Using a new volume name (`postgres_data_v18`) ensures users' v6 data remains untouched during the upgrade. This prevents accidental data loss and allows for safe rollback if needed.

**Anonymous Volume Prevention:** The configuration prevents the issue documented in GreedyBear#766 where mounting to a parent directory causes Docker to create shadow anonymous volumes, leading to data loss.

### Testing
- ✅ Configuration validated with `docker compose config`
- ✅ Linters passed (no code changes, only Docker config)
- ✅ Migration guide created and verified step-by-step in docs PR

## Migration Guide
Users can follow the comprehensive 12-step migration guide in the [documentation PR](https://github.com/intelowlproject/docs/pull/51) to safely migrate their data from PostgreSQL 16 to 18.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [x] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [ ] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [ ] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.``` (N/A - only modified Docker configuration files)
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library. (No new libraries added)
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section. (N/A - no new libraries)
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does check these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors. (Infrastructure change - validated with `docker compose config`)
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).
