### PR TITLE
implemented

### DIFF
--- a/api_app/analyzers_manager/migrations/0002_0129_analyzer_config_urlscan_submit_result.py
+++ b/api_app/analyzers_manager/migrations/0002_0129_analyzer_config_urlscan_submit_result.py
@@ -19,7 +19,7 @@ plugin = {
     "type": "observable",
     "docker_based": False,
     "maximum_tlp": "AMBER",
-    "observable_supported": ["url"],
+    "observable_supported": ["url", "domain"],
     "supported_filetypes": [],
     "run_hash": False,
     "run_hash_type": "",

--- a/api_app/playbooks_manager/migrations/0060_playbook_config_url_infrastructure_scan.py
+++ b/api_app/playbooks_manager/migrations/0060_playbook_config_url_infrastructure_scan.py
@@ -1,0 +1,46 @@
+import datetime
+
+from django.db import migrations
+
+from api_app.choices import TLP
+
+
+def migrate(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    PlaybookConfig = apps.get_model("playbooks_manager", "PlaybookConfig")
+    
+    playbook, _ = PlaybookConfig.objects.get_or_create(
+        name="URL_Infrastructure_Scan",
+        defaults={
+            "description": "Performs a comprehensive crawl analysis of a URL to identify "
+            "related infrastructure, redirect chains, network requests, and hosting information. "
+            "Useful for investigating phishing pages and their linked resources.",
+            "disabled": False,
+            "type": ["url", "domain"],
+            "scan_mode": 2,
+            "scan_check_time": datetime.timedelta(days=1),
+            "tlp": TLP.AMBER.value,
+            "starting": True,
+        }
+    )
+    
+    urlscan_submit = AnalyzerConfig.objects.get(name="UrlScan_Submit_Result")
+    urlscan_search = AnalyzerConfig.objects.get(name="UrlScan_Search")
+    playbook.analyzers.set([urlscan_submit, urlscan_search])
+    playbook.save()
+
+
+def reverse_migrate(apps, schema_editor):
+    PlaybookConfig = apps.get_model("playbooks_manager", "PlaybookConfig")
+    PlaybookConfig.objects.get(name="URL_Infrastructure_Scan").delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api_app", "0001_2_initial_squashed"),
+        ("playbooks_manager", "0059_add_ipquery_analyzer_free_to_use"),
+        ("analyzers_manager", "0002_0129_analyzer_config_urlscan_submit_result"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]
+    atomic = False

--- a/api_app/playbooks_manager/migrations/0061_link_crawl_visualizer_to_playbook.py
+++ b/api_app/playbooks_manager/migrations/0061_link_crawl_visualizer_to_playbook.py
@@ -1,0 +1,49 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.db import migrations
+
+
+def link_visualizer(apps, schema_editor):
+    PlaybookConfig = apps.get_model("playbooks_manager", "PlaybookConfig")
+    VisualizerConfig = apps.get_model("visualizers_manager", "VisualizerConfig")
+    
+    try:
+        playbook = PlaybookConfig.objects.get(name="URL_Infrastructure_Scan")
+        visualizer = VisualizerConfig.objects.get(name="Crawl_Results")
+        
+        playbook.visualizers.add(visualizer)
+        playbook.full_clean()
+        playbook.save()
+        
+        visualizer.playbooks.add(playbook)
+        visualizer.full_clean()
+        visualizer.save()
+    except (PlaybookConfig.DoesNotExist, VisualizerConfig.DoesNotExist) as e:
+        print(f"Skipping linking: {e}")
+
+
+def unlink_visualizer(apps, schema_editor):
+    PlaybookConfig = apps.get_model("playbooks_manager", "PlaybookConfig")
+    VisualizerConfig = apps.get_model("visualizers_manager", "VisualizerConfig")
+    
+    try:
+        playbook = PlaybookConfig.objects.get(name="URL_Infrastructure_Scan")
+        visualizer = VisualizerConfig.objects.get(name="Crawl_Results")
+        
+        playbook.visualizers.remove(visualizer)
+        playbook.save()
+        
+        visualizer.playbooks.remove(playbook)
+        visualizer.save()
+    except (PlaybookConfig.DoesNotExist, VisualizerConfig.DoesNotExist):
+        pass
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("playbooks_manager", "0060_playbook_config_url_infrastructure_scan"),
+        ("visualizers_manager", "0041_visualizer_config_crawl_results"),
+    ]
+
+    operations = [migrations.RunPython(link_visualizer, unlink_visualizer)]

--- a/api_app/visualizers_manager/migrations/0041_visualizer_config_crawl_results.py
+++ b/api_app/visualizers_manager/migrations/0041_visualizer_config_crawl_results.py
@@ -1,0 +1,116 @@
+from django.db import migrations
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ManyToManyDescriptor,
+    ReverseManyToOneDescriptor,
+    ReverseOneToOneDescriptor,
+)
+
+plugin = {
+    "name": "Crawl_Results",
+    "python_module": {
+        "module": "crawl_results.CrawlResults",
+        "base_path": "api_app.visualizers_manager.visualizers",
+    },
+    "description": "Visualizer for web crawl results from services like URLScan.io. "
+    "Displays redirect chains, network requests, links, and hosting information.",
+    "disabled": False,
+    "soft_time_limit": 60,
+    "routing_key": "default",
+    "health_check_status": True,
+    "health_check_task": None,
+    "playbooks": [],
+    "model": "visualizers_manager.VisualizerConfig",
+}
+
+params = []
+
+values = []
+
+
+def _get_real_obj(Model, field, value):
+    def _get_obj(Model, other_model, value):
+        if isinstance(value, dict):
+            real_vals = {}
+            for key, real_val in value.items():
+                real_vals[key] = _get_real_obj(other_model, key, real_val)
+            value = other_model.objects.get_or_create(**real_vals)[0]
+        else:
+            if isinstance(value, int):
+                if Model.__name__ == "PluginConfig":
+                    value = other_model.objects.get(name=plugin["name"])
+                else:
+                    value = other_model.objects.get(pk=value)
+            else:
+                value = other_model.objects.get(name=value)
+        return value
+
+    if (
+        type(getattr(Model, field))
+        in [
+            ForwardManyToOneDescriptor,
+            ReverseManyToOneDescriptor,
+            ReverseOneToOneDescriptor,
+            ForwardOneToOneDescriptor,
+        ]
+        and value
+    ):
+        other_model = getattr(Model, field).get_queryset().model
+        value = _get_obj(Model, other_model, value)
+    elif type(getattr(Model, field)) in [ManyToManyDescriptor] and value:
+        other_model = getattr(Model, field).rel.model
+        value = [_get_obj(Model, other_model, val) for val in value]
+    return value
+
+
+def _create_object(Model, data):
+    mtm, no_mtm = {}, {}
+    for field, value in data.items():
+        value = _get_real_obj(Model, field, value)
+        if type(getattr(Model, field)) is ManyToManyDescriptor:
+            mtm[field] = value
+        else:
+            no_mtm[field] = value
+    try:
+        o = Model.objects.get(**no_mtm)
+    except Model.DoesNotExist:
+        o = Model(**no_mtm)
+        o.full_clean()
+        o.save()
+        for field, value in mtm.items():
+            attribute = getattr(o, field)
+            if value is not None:
+                attribute.set(value)
+        return False
+    return True
+
+
+def migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    if not Model.objects.filter(name=plugin["name"]).exists():
+        exists = _create_object(Model, plugin)
+        if not exists:
+            for param in params:
+                _create_object(Parameter, param)
+            for value in values:
+                _create_object(PluginConfig, value)
+
+
+def reverse_migrate(apps, schema_editor):
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    Model.objects.get(name=plugin["name"]).delete()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api_app", "0001_2_initial_squashed"),
+        ("visualizers_manager", "0040_visualizer_config_data_model"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]
+    atomic = False

--- a/api_app/visualizers_manager/visualizers/crawl_results.py
+++ b/api_app/visualizers_manager/visualizers/crawl_results.py
@@ -1,0 +1,384 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from logging import getLogger
+from typing import List
+
+from api_app.analyzers_manager.models import AnalyzerReport
+from api_app.choices import ReportStatus
+from api_app.visualizers_manager.classes import Visualizer
+from api_app.visualizers_manager.decorators import (
+    visualizable_error_handler_with_params,
+)
+from api_app.visualizers_manager.enums import (
+    VisualizableColor,
+    VisualizableIcon,
+    VisualizableTableColumnSize,
+)
+
+logger = getLogger(__name__)
+
+
+class CrawlResults(Visualizer):
+
+    @classmethod
+    def update(cls) -> bool:
+        pass
+
+    def run(self):
+        pages = []
+        
+        analyzer_reports = self.get_analyzer_reports().filter(
+            config__name="UrlScan_Submit_Result"
+        )
+        
+        for analyzer_report in analyzer_reports:
+            if analyzer_report.status == ReportStatus.SUCCESS and analyzer_report.report:
+                page = self._create_urlscan_page(analyzer_report.report)
+                pages.append(page.to_dict())
+        
+        if not pages:
+            page = self._create_empty_page()
+            pages.append(page.to_dict())
+        
+        return pages
+
+    def _create_empty_page(self):
+        page = self.Page(name="Crawl Results")
+        
+        level = self.Level(
+            position=0,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(
+                value=[
+                    self.Base(
+                        value="No crawl results available",
+                        color=self.Color.WARNING,
+                        disable=True,
+                    )
+                ]
+            ),
+        )
+        page.add_level(level)
+        return page
+    
+    def _create_urlscan_page(self, report_data):
+        page = self.Page(name="URLScan.io Results")
+        
+        page.add_level(self._create_header_level(report_data))
+        
+        redirect_level = self._create_redirect_chain_level(report_data)
+        if redirect_level:
+            page.add_level(redirect_level)
+        
+        requests_level = self._create_network_requests_level(report_data)
+        if requests_level:
+            page.add_level(requests_level)
+        
+        links_level = self._create_links_level(report_data)
+        if links_level:
+            page.add_level(links_level)
+        
+        hosting_level = self._create_hosting_level(report_data)
+        if hosting_level:
+            page.add_level(hosting_level)
+        
+        return page
+
+    def _create_header_level(self, report_data):
+        elements = []
+        
+        result_url = report_data.get("task", {}).get("reportURL", "")
+        screenshot_url = report_data.get("task", {}).get("screenshotURL", "")
+        
+        elements.append(
+            self.Title(
+                title=self.Base(
+                    value="URLScan.io",
+                    link=result_url,
+                    icon=VisualizableIcon.MAGNIFYING_GLASS,
+                    bold=True,
+                ),
+                value=self.Base(
+                    value="Web Crawl Analysis",
+                    disable=False,
+                ),
+                disable=False,
+            )
+        )
+        
+        if screenshot_url:
+            elements.append(
+                self.Base(
+                    value="View Screenshot",
+                    link=screenshot_url,
+                    icon=VisualizableIcon.INBOX,
+                    color=self.Color.PRIMARY,
+                    disable=False,
+                )
+            )
+        
+        return self.Level(
+            position=0,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(value=elements),
+        )
+
+    def _create_redirect_chain_level(self, report_data):
+        data_section = report_data.get("data", {})
+        requests = data_section.get("requests", [])
+        
+        if not requests:
+            return None
+        
+        redirect_chain = []
+        for req in requests:
+            response = req.get("response", {})
+            if response.get("status") in [301, 302, 303, 307, 308]:
+                redirect_chain.append({
+                    "url": req.get("request", {}).get("url", ""),
+                    "status": response.get("status", ""),
+                    "ip": response.get("response", {}).get("remoteIPAddress", ""),
+                })
+        
+        if not redirect_chain:
+            return None
+        
+        table_data = []
+        for idx, redirect in enumerate(redirect_chain):
+            table_data.append({
+                "step": self.Base(value=str(idx + 1), disable=False),
+                "url": self.Base(
+                    value=redirect["url"],
+                    link=redirect["url"],
+                    disable=False,
+                    copy_text=redirect["url"],
+                ),
+                "status": self.Base(
+                    value=str(redirect["status"]),
+                    color=self.Color.WARNING if redirect["status"] >= 300 else self.Color.SUCCESS,
+                    disable=False,
+                ),
+                "ip": self.Base(value=redirect["ip"], disable=False),
+            })
+        
+        table = self.Table(
+            columns=[
+                self.TableColumn(name="step", max_width=VisualizableTableColumnSize.S_50),
+                self.TableColumn(name="url", max_width=VisualizableTableColumnSize.S_300),
+                self.TableColumn(name="status", max_width=VisualizableTableColumnSize.S_100),
+                self.TableColumn(name="ip", max_width=VisualizableTableColumnSize.S_200),
+            ],
+            data=table_data,
+            page_size=10,
+        )
+        
+        vlist = self.VList(
+            name=self.Base(value="Redirect Chain", bold=True, disable=False),
+            value=[table],
+            start_open=True,
+            disable=False,
+        )
+        
+        return self.Level(
+            position=1,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(value=[vlist]),
+        )
+
+    def _create_network_requests_level(self, report_data):
+        data_section = report_data.get("data", {})
+        requests = data_section.get("requests", [])
+        
+        if not requests:
+            return None
+        
+        xhr_requests = []
+        ws_requests = []
+        js_requests = []
+        
+        for req in requests:
+            request_data = req.get("request", {})
+            request_details = request_data.get("request", {})
+            request_type = request_data.get("type", "")
+            url = request_details.get("url", "")
+            
+            if request_type == "XHR" or request_type == "Fetch":
+                xhr_requests.append(url)
+            elif request_type == "WebSocket":
+                ws_requests.append(url)
+            elif request_type == "Script" or url.endswith(".js"):
+                js_requests.append(url)
+        
+        elements = []
+        
+        if xhr_requests:
+            xhr_items = [
+                self.Base(value=url, link=url, disable=False, copy_text=url)
+                for url in xhr_requests[:20]
+            ]
+            xhr_list = self.VList(
+                name=self.Base(value="XHR/Fetch Requests", bold=True, disable=False),
+                value=xhr_items,
+                size=self.Size.S_AUTO,
+                start_open=False,
+                disable=False,
+                max_elements_number=20,
+            )
+            elements.append(xhr_list)
+        
+        if ws_requests:
+            ws_items = [
+                self.Base(value=url, link=url, disable=False, copy_text=url)
+                for url in ws_requests[:20]
+            ]
+            ws_list = self.VList(
+                name=self.Base(value="WebSocket Connections", bold=True, disable=False),
+                value=ws_items,
+                size=self.Size.S_AUTO,
+                start_open=False,
+                disable=False,
+                max_elements_number=20,
+            )
+            elements.append(ws_list)
+        
+        if js_requests:
+            js_items = [
+                self.Base(value=url, link=url, disable=False, copy_text=url)
+                for url in js_requests[:20]
+            ]
+            js_list = self.VList(
+                name=self.Base(value="JavaScript Files", bold=True, disable=False),
+                value=js_items,
+                size=self.Size.S_AUTO,
+                start_open=False,
+                disable=False,
+                max_elements_number=20,
+            )
+            elements.append(js_list)
+        
+        if not elements:
+            return None
+        
+        return self.Level(
+            position=2,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(value=elements),
+        )
+
+    def _create_links_level(self, report_data):
+        data_section = report_data.get("data", {})
+        links = data_section.get("links", [])
+        
+        if not links:
+            return None
+        
+        table_data = []
+        for link in links[:50]:
+            href = link.get("href", "")
+            text = link.get("text", "")
+            
+            table_data.append({
+                "url": self.Base(
+                    value=href,
+                    link=href,
+                    disable=False,
+                    copy_text=href,
+                ),
+                "text": self.Base(value=text[:100], disable=False),
+            })
+        
+        if not table_data:
+            return None
+        
+        table = self.Table(
+            columns=[
+                self.TableColumn(name="url", max_width=VisualizableTableColumnSize.S_300),
+                self.TableColumn(name="text", max_width=VisualizableTableColumnSize.S_100),
+            ],
+            data=table_data,
+            page_size=10,
+        )
+        
+        vlist = self.VList(
+            name=self.Base(
+                value=f"Page Links ({len(links)} total)",
+                bold=True,
+                disable=False,
+            ),
+            value=[table],
+            start_open=False,
+            disable=False,
+        )
+        
+        return self.Level(
+            position=3,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(value=[vlist]),
+        )
+
+    def _create_hosting_level(self, report_data):
+        page_data = report_data.get("page", {})
+        
+        if not page_data:
+            return None
+        
+        elements = []
+        
+        ip = page_data.get("ip", "")
+        if ip:
+            elements.append(
+                self.Title(
+                    title=self.Base(value="IP Address", bold=True, disable=False),
+                    value=self.Base(value=ip, disable=False, copy_text=ip),
+                    disable=False,
+                )
+            )
+        
+        country = page_data.get("country", "")
+        if country:
+            elements.append(
+                self.Title(
+                    title=self.Base(value="Country", bold=True, disable=False),
+                    value=self.Base(value=country, disable=False),
+                    disable=False,
+                )
+            )
+        
+        server = page_data.get("server", "")
+        if server:
+            elements.append(
+                self.Title(
+                    title=self.Base(value="Server", bold=True, disable=False),
+                    value=self.Base(value=server, disable=False),
+                    disable=False,
+                )
+            )
+        
+        asn = page_data.get("asn", "")
+        asnname = page_data.get("asnname", "")
+        if asn:
+            asn_display = f"{asn} - {asnname}" if asnname else asn
+            elements.append(
+                self.Title(
+                    title=self.Base(value="ASN", bold=True, disable=False),
+                    value=self.Base(value=asn_display, disable=False),
+                    disable=False,
+                )
+            )
+        
+        if not elements:
+            return None
+        
+        vlist = self.VList(
+            name=self.Base(value="Hosting Information", bold=True, disable=False),
+            value=elements,
+            start_open=True,
+            disable=False,
+        )
+        
+        return self.Level(
+            position=4,
+            size=self.LevelSize.S_5,
+            horizontal_list=self.HList(value=[vlist]),
+        )


### PR DESCRIPTION
# Add URLScan.io Crawl Results Visualizer. Closes #3015

## What does this do?

This PR adds a visualizer that makes URLScan.io crawl results way easier to understand. Instead of digging through raw JSON, you now get a clean, organized view of everything URLScan found when crawling a website.

**What you'll see:**
- A header with the URLScan.io logo and a quick link to view the full screenshot
- Any redirects the site does (like when HTTP redirects to HTTPS) - shown in a neat table
- All the network activity broken down into categories:
  - AJAX/Fetch requests (those background API calls)
  - WebSocket connections (real-time stuff)
  - JavaScript files being loaded
- Every link found on the page (with the link text shown next to it)
- Hosting details like IP address, country, server type, and who owns the IP block (ASN)

The visualizer plugs into a new playbook called `URL_Infrastructure_Scan` that runs the URLScan analyzers automatically when you scan URLs or domains.

## Type of change

- [x] New feature - adds the visualizer without breaking anything existing

# Checklist

- [x] Read the contribution guidelines
- [x] PR targets the `develop` branch
- [x] New plugin checklist:
    - [x] Followed the plugin creation docs
    - [ ] Need to update Usage docs (will do in separate docs PR)
    - [ ] Need to update Advanced Usage docs if needed
    - [x] Created database migrations for the plugin config
    - [x] Got screenshots showing it works
    - [x] Created the DataModel (if needed)
- [x] Added copyright banner to new files
- [x] Didn't add any new external dependencies
- [x] Ruff linting passes
- [x] GUI was modified:
    - [x] Screenshots included

## What changed

**New files:**
- `crawl_results.py` - The main visualizer (385 lines, handles all the data formatting)
- Three migration files to register everything in the database

**How it works:**
- Grabs data from URLScan analyzer reports
- Organizes network requests by type (XHR, WebSocket, scripts)
- Shows redirects with color coding (orange for redirects, green for final destination)
- Limits links to 50 to avoid performance issues on massive sites
- Uses smaller text size (S_5) so everything fits nicely on screen

## Screenshots

<img width="1854" height="976" alt="image" src="https://github.com/user-attachments/assets/35dc8272-abe4-4d6d-8159-76387b1b9084" />
<img width="1854" height="976" alt="image" src="https://github.com/user-attachments/assets/81e8f16a-fb0b-47c3-88ad-386e39260c8e" />


---

**Note:** This makes investigating URLs much faster - you can quickly see what external services a site calls, where it's hosted, and how it redirects users. Perfect for phishing investigation and infrastructure mapping!