### PR TITLE
Fixes the Yeti analyzer API endpoint to match the Yeti v2 API specification.

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/yeti.py
+++ b/api_app/analyzers_manager/observable_analyzers/yeti.py
@@ -22,7 +22,7 @@ class YETI(classes.ObservableAnalyzer):
         headers = {"Accept": "application/json", "X-Api-Key": self._api_key_name}
         if self._url_key_name and self._url_key_name.endswith("/"):
             self._url_key_name = self._url_key_name[:-1]
-        url = f"{self._url_key_name}/api/v2/observablesearch/"
+        url = f"{self._url_key_name}/observables/search/"
 
         # search for observables
         resp = requests.post(


### PR DESCRIPTION
Fixes: #2309 
# Description
Fixes the Yeti analyzer API endpoint to match the Yeti v2 API specification. 
The analyzer was using an outdated endpoint (`/api/v2/observablesearch/`) that returns HTTP 404 errors on Yeti v2 instances. Updated to the correct endpoint (`/observables/search/`).
**Error before fix:**
404 Client Error: Not Found for url: http:///api/v2/observablesearch/

**Change:**
```diff
- url = f"{self._url_key_name}/api/v2/observablesearch/"
+ url = f"{self._url_key_name}/observables/search/"
References:

Yeti Platform: https://github.com/yeti-platform/yeti
Yeti API Docs: https://yeti-platform.readthedocs.io/
Type of change
 Bug fix (non-breaking change which fixes an issue).
Checklist
 I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
 The pull request is for the branch develop
 A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
N/A (no new plugin added, only fixing existing endpoint URL)
 I have inserted the copyright banner at the start of the file
 Please avoid adding new libraries as requirements whenever it is possible. No new libraries added.
 Linters (Ruff) gave 0 errors.
 I have added tests for the feature/bug I solved (see tests folder). All the tests (new and old ones) gave 0 errors.
 If the GUI has been modified: N/A - no GUI changes
 After you had submitted the PR, if DeepSource, Django Doctors or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts
 
