### PR TITLE
fix: correct Yeti analyzer API endpoint and request payload for v2 API

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/yeti.py
+++ b/api_app/analyzers_manager/observable_analyzers/yeti.py
@@ -16,13 +16,13 @@ class YETI(classes.ObservableAnalyzer):
     def run(self):
         # request payload
         payload = {
-            "filter": {"value": self._job.analyzable.name},
-            "params": {"regex": self.regex, "range": self.results_count},
+            "query": {"value": self._job.analyzable.name},
+            "count": self.results_count,
         }
         headers = {"Accept": "application/json", "X-Api-Key": self._api_key_name}
         if self._url_key_name and self._url_key_name.endswith("/"):
             self._url_key_name = self._url_key_name[:-1]
-        url = f"{self._url_key_name}/api/v2/observablesearch/"
+        url = f"{self._url_key_name}/api/v2/observables/search/"
 
         # search for observables
         resp = requests.post(


### PR DESCRIPTION
# Analyser Yeti wrong api request. Closes #2309

### Description
The YETI observable analyzer was hitting the wrong endpoint (/api/v2/observablesearch/), which caused a 404 error.
It was also using the old filter/params payload format that doesn’t match Yeti v2 anymore.

### Changes
1. Fixed the endpoint to /api/v2/observables/search/
2. Updated the payload to use query and count as expected by Yeti v2

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).

https://github.com/user-attachments/assets/a76823e0-315d-4b00-b78a-4df4db6cb01f

