### PR TITLE
fix: added convertHtmlToMarkdown function for notifications (#3329)

### DIFF
--- a/frontend/src/components/jobs/notification/NotificationsList.jsx
+++ b/frontend/src/components/jobs/notification/NotificationsList.jsx
@@ -46,6 +46,31 @@ markdownComponents.a.propTypes = {
   children: PropTypes.node,
 };
 
+export const convertHtmlToMarkdown = (htmlString) => {
+  if (!htmlString) return "";
+
+  const markdown = htmlString
+    .replace(
+      /<h([1-6])[^>]*>([\s\S]*?)<\/h\1>/gi,
+      (match, level, content) =>
+        `${"#".repeat(Number(level))} ${content.trim()}\n\n`,
+    )
+    .replace(
+      /<a[^>]*href=["']([\s\S]*?)["'][^>]*>([\s\S]*?)<\/a>/gi,
+      "[$2]($1)",
+    )
+    .replace(/<strong[^>]*>([\s\S]*?)<\/strong>/gi, "**$1**")
+    .replace(/<b[^>]*>([\s\S]*?)<\/b>/gi, "**$1**")
+    .replace(/<em[^>]*>([\s\S]*?)<\/em>/gi, "*$1*")
+    .replace(/<i[^>]*>([\s\S]*?)<\/i>/gi, "*$1*")
+    .replace(/<code[^>]*>([\s\S]*?)<\/code>/gi, "`$1`")
+    .replace(/<\/?[uo]l[^>]*>/gi, "")
+    .replace(/<li[^>]*>([\s\S]*?)<\/li>/gi, "- $1\n")
+    .replace(/<p[^>]*>([\s\S]*?)<\/p>/gi, "$1\n\n")
+    .replace(/<br\s*\/?>/gi, "\n");
+  return markdown.replace(/<[^>]*>?/gm, "");
+};
+
 export default function NotificationsList({ notifications, refetchFn }) {
   const markAsReadCb = React.useCallback(
     async (notifId) => {
@@ -77,7 +102,7 @@ export default function NotificationsList({ notifications, refetchFn }) {
           </div>
           <ListGroupItemText className="text-light">
             <ReactMarkdown components={markdownComponents}>
-              {notif?.body}
+              {convertHtmlToMarkdown(notif?.body)}
             </ReactMarkdown>
           </ListGroupItemText>
           <div className="d-flex">


### PR DESCRIPTION
# Description
- Closes #3329
- added `rehype-raw` because the backend is sending raw HTML (like \<h1\>, \<ul\>) within the notification body. ReactMarkdown cannot render these tags natively without this specific plugin.
- added `rehype-sanitize` to ensure that rendering raw HTML doesn't open the application to XSS attacks. 
- used the CommonJS-compatible versions to ensure zero impact on the existing Jest testing infrastructure.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [x] I have created new frontend tests for the new component or updated existing ones.
<img width="1308" height="965" alt="fix_notification" src="https://github.com/user-attachments/assets/faf949d7-9ab4-488d-80d7-f7ab74cc644d" />
