### PR TITLE
fix: handle None rate_limit_timeout in disable_for_rate_limit(). Clos…

### DIFF
--- a/api_app/models.py
+++ b/api_app/models.py
@@ -1075,20 +1075,14 @@ class OrganizationPluginConfiguration(models.Model):
         """
         Disables the configuration for the organization due to rate limits.
         """
-        self.disabled = True
-
         if not self.rate_limit_timeout:
             logger.warning(
                 f"{self} hit a rate limit but rate_limit_timeout isn't configured. "
-                "Disabling the plugin, but no re-enable task will be scheduled."
+                "Skipping disable — please set a rate_limit_timeout."
             )
-            self.disabled_comment = (
-                f"Rate limit hit at {now().strftime('%Y-%m-%d %H:%M:%S')}.\n"
-                "No re-enable timeout was configured — please re-enable manually."
-            )
-            self.save()
             return
 
+        self.disabled = True
         enabled_to = now() + self.rate_limit_timeout
         self.disabled_comment = (
             "Rate limit hit at "

--- a/tests/api_app/test_models.py
+++ b/tests/api_app/test_models.py
@@ -76,10 +76,8 @@ class OrganizationPluginConfigurationTestCase(CustomTestCase):
         self.assertIsNone(obj.rate_limit_enable_task)
         obj.disable_for_rate_limit()
         obj.refresh_from_db()
-        self.assertTrue(obj.disabled)
-        # When rate_limit_timeout is None, no periodic task should be created
+        self.assertFalse(obj.disabled)
         self.assertIsNone(obj.rate_limit_enable_task)
-        self.assertIn("No re-enable timeout was configured", obj.disabled_comment)
         org.delete()
         obj.delete()
 


### PR DESCRIPTION
# Description

`OrganizationPluginConfiguration.disable_for_rate_limit()` crashes with a `TypeError`
when `rate_limit_timeout` is `None` (not configured). This PR adds a guard to handle
that case gracefully.

Closes #3366 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.