### PR TITLE
fix: correct boolean comparison for is_sample in recent_scans_user 

### DIFF
--- a/api_app/views.py
+++ b/api_app/views.py
@@ -435,7 +435,7 @@ class JobViewSet(ReadAndDeleteOnlyViewSet, SerializerActionMixin):
             raise ValidationError({"detail": "is_sample is required"})
         is_sample = request.data["is_sample"]
         jobs = Job.objects.filter(user__pk=request.user.pk)
-        if is_sample == "True":
+        if is_sample is True:
             jobs = jobs.filter(analyzable__classification=Classification.FILE)
         else:
             jobs = jobs.exclude(analyzable__classification=Classification.FILE)


### PR DESCRIPTION
# Description
Closes #3382
Recent Scans only observable jobs instead of file jobs because a boolean True is compared with the string "True" in `api_app/views.py (line 436)`.
Change:
Updated:
`if is_sample == "True":`
to:
`if is_sample is True:`

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`

