### PR TITLE
Fix pdns visualizer crash

### DIFF
--- a/api_app/visualizers_manager/visualizers/passive_dns/analyzer_extractor.py
+++ b/api_app/visualizers_manager/visualizers/passive_dns/analyzer_extractor.py
@@ -1,3 +1,7 @@
+"""In this module there are functions to extract the data required by
+Passive DNS visualizer from the analyzers reports.
+"""
+
 import dataclasses
 import datetime
 import logging


### PR DESCRIPTION


# Description:
This PR fixes the AttributeError crashes in the Passive DNS visualizer by correcting the
underlying data extraction logic in analyzer_extractor.py.

# Root Cause Fixes:
   * MnemonicPDNS: The crash happened because the API returns a dictionary when not in COF format.
     I’ve updated the extractor to specifically look into the data key in those cases.
   * Robtex/CIRCL: These now use proper type checking (isinstance) to safely handle cases where the
     API returns an error string or a malformed object instead of a list.
   * Validin: Fixed a logic error where the records object was being treated as a list instead of a
     dictionary.


https://github.com/user-attachments/assets/7dca2af3-a5bf-430a-9178-1e8a9c3804e2



# Type of change

- Bug fix (non-breaking change which fixes an issue).

# Checklist
  - [x] I have read and understood the rules about [how to Contribute
     (https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
   - [x] The pull request is for the branch develop
   - [x] I have inserted the copyright banner at the start of the file: # This file is a part of
     IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying
     permission.
   - [x] Linters (Ruff) gave 0 errors.
   - [x] I have added tests for the feature/bug I solved (see tests folder). All the tests (new and
     old ones) gave 0 errors.

# Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).