### PR TITLE
fix: correct "Missmatch" typo to "Mismatch" in ValidationError message

### DIFF
--- a/api_app/models.py
+++ b/api_app/models.py
@@ -996,7 +996,7 @@ class PluginConfig(OwnershipAbstractModel):
         """
         if self.config.python_module != self.parameter.python_module:
             raise ValidationError(
-                f"Missmatch between config python module {self.config.python_module}"
+                f"Mismatch between config python module {self.config.python_module}"
                 f" and parameter python module {self.parameter.python_module}"
             )
 


### PR DESCRIPTION
## Summary
Fixes a typo in the user-facing `ValidationError` message raised inside `PluginConfig.clean_parameter()`.

## Change
[api_app/models.py](cci:7://file:///e:/IntelOwl/api_app/models.py:0:0-0:0) line 966:
- `"Missmatch between config python module..."` → `"Mismatch between config python module..."`

## Type of change
- [x] Bug fix (typo in error message)

## Checklist
- [x] Code follows the project's style guidelines
- [x] No new tests required (pure string/message correction)
- [x] No behavior change — only the error message wording is corrected

Fixes #3392 