### PR TITLE
docs: fix broken CyberChef URL in CHANGELOG (githuba -> github)

### DIFF
--- a/.github/CHANGELOG.md
+++ b/.github/CHANGELOG.md
@@ -620,7 +620,7 @@ We are proud to announce two new sponsorships today!
 If you are interested in helping the project through a donation, read [here](https://github.com/intelowlproject/IntelOwl/blob/master/.github/partnership_and_sponsors.md) how you can do it!
 
 **New/Improved Analyzers:**
-- New [CyberChef](https://gchq.githuba.io/CyberChef/) Analyzer! Run your own recipes in IntelOwl! Check the [docs](https://intelowlproject.github.io/docs/advanced_usage/#cyberchef)!
+- New [CyberChef](https://gchq.github.io/CyberChef/) Analyzer! Run your own recipes in IntelOwl! Check the [docs](https://intelowlproject.github.io/docs/advanced_usage/#cyberchef)!
 
 **Other:**
 - fixes: [#931](https://github.com/intelowlproject/IntelOwl/issues/931)


### PR DESCRIPTION
## Summary

Fixes a broken hyperlink in [.github/CHANGELOG.md](cci:7://file:///e:/IntelOwl/.github/CHANGELOG.md:0:0-0:0) introduced in the `v3.3.2` 
release notes.

The CyberChef URL contained a one-character typo — `githuba.io` instead of 
`github.io` — causing a 404 for anyone clicking the link.

Closes #3394

## Change

**File:** [.github/CHANGELOG.md](cci:7://file:///e:/IntelOwl/.github/CHANGELOG.md:0:0-0:0) — line 623

```diff
- New [CyberChef](https://gchq.githuba.io/CyberChef/) Analyzer!
+ New [CyberChef](https://gchq.github.io/CyberChef/) Analyzer!
