### PR TITLE
Fix/typo anayzer module capa info

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/capa_info.py
+++ b/api_app/analyzers_manager/file_analyzers/capa_info.py
@@ -109,7 +109,7 @@ class CapaInfo(FileAnalyzer, RulesUtiliyMixin):
         logger.info("Successfully updated signatures")
 
     @classmethod
-    def update(cls, anayzer_module: PythonModule) -> bool:
+    def update(cls, analyzer_module: PythonModule) -> bool:
         try:
             logger.info("Updating capa rules")
             response = requests.get("https://api.github.com/repos/mandiant/capa-rules/releases/latest")
@@ -121,7 +121,7 @@ class CapaInfo(FileAnalyzer, RulesUtiliyMixin):
                 rule_set_directory=RULES_LOCATION,
                 rule_file_path=RULES_FILE,
                 latest_version=latest_version,
-                analyzer_module=anayzer_module,
+                analyzer_module=analyzer_module,
             )
 
             cls._unzip(Path(RULES_FILE))


### PR DESCRIPTION
## Summary

Fixes a typo in the parameter name of the `CapaInfo.update()` classmethod.

The parameter was named `anayzer_module` (missing the `l`) instead of 
`analyzer_module`, in both the method signature and its usage in the 
`_download_rules()` call.

Closes #3400

## Changes

**File:** [api_app/analyzers_manager/file_analyzers/capa_info.py](cci:7://file:///e:/IntelOwl/api_app/analyzers_manager/file_analyzers/capa_info.py:0:0-0:0)

| Line | Change |
|------|--------|
| 112 | `anayzer_module` → `analyzer_module` in method signature |
| 124 | `anayzer_module` → `analyzer_module` in `_download_rules()` call |

## Type of Change

- [x] Bug fix (parameter naming typo — code quality)

## Checklist

- [x] PR targets `develop` branch
- [x] Linters (Ruff) gave 0 errors
- [x] No functional/behavioral change — purely a naming correction
- [x] No new tests required (no logic change)
