### PR TITLE
fix: Typos 'succesfully' → 'successfully' in authApi.js and mixins.py

### DIFF
--- a/api_app/mixins.py
+++ b/api_app/mixins.py
@@ -781,7 +781,7 @@ class RulesUtiliyMixin:
         logger.info(f"Extracting rules at {rule_file_path.parent}")
         with ZipFile(rule_file_path, mode="r") as archive:
             archive.extractall(rule_file_path.parent)  # this will overwrite any existing directory
-        logger.info("Rules have been succesfully extracted")
+        logger.info("Rules have been successfully extracted")
 
     @staticmethod
     def _download_rules(

--- a/frontend/src/components/auth/authApi.js
+++ b/frontend/src/components/auth/authApi.js
@@ -18,7 +18,7 @@ export async function verifyEmail(body) {
   try {
     const resp = await axios.post(`${AUTH_BASE_URI}/verify-email`, body);
     addToast(
-      "Your email has been succesfully verified!",
+      "Your email has been successfully verified!",
       null,
       "success",
       true,
@@ -75,7 +75,7 @@ export async function checkConfiguration(body) {
     }
     return resp;
   } catch (err) {
-    // this API always return 200, this catch should never ne triggered, but it's better to be safe
+    // this API always return 200, this catch should never be triggered, but it's better to be safe
     return Promise.reject(err);
   }
 }


### PR DESCRIPTION
Fixes #3399

###Summary
Fixes a typo in the email verification message raised inside verify email body.

###Change
frontend/src/components/auth/authApi.js (line 21)
frontend/src/components/auth/authApi.js  (line 78)
api_app/mixins.py (line 784)

"succesfully" → "successfully"
###Type of change
 [x] Bug fix (typo in error message)
###Checklist
 [x] Code follows the project's style guidelines
 [x] No new tests required (pure string/message correction)
 [x] No behavior change — only the error message wording is corrected
