### PR TITLE
Fix potential Host Header Injection by restricting ALLOWED_HOSTS. Clo…

### DIFF
--- a/intel_owl/settings/security.py
+++ b/intel_owl/settings/security.py
@@ -24,7 +24,11 @@ CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}"]
 if STAGE_LOCAL:
     # required to allow requests from port 3001 (frontend development)
     CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}:80/"]
-ALLOWED_HOSTS = ["*"]
+# Restrict hosts in production environments
+if STAGE_PRODUCTION or STAGE_STAGING:
+    ALLOWED_HOSTS = [WEB_CLIENT_DOMAIN]
+else:
+    ALLOWED_HOSTS = ["*"]
 
 # https://docs.djangoproject.com/en/4.2/ref/settings/#data-upload-max-memory-size
 DATA_UPLOAD_MAX_MEMORY_SIZE = 100 * (10**6)

--- a/intel_owl/settings/security.py
+++ b/intel_owl/settings/security.py
@@ -26,7 +26,16 @@ if STAGE_LOCAL:
     CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}:80/"]
 # Restrict hosts in production environments
 if STAGE_PRODUCTION or STAGE_STAGING:
-    ALLOWED_HOSTS = [WEB_CLIENT_DOMAIN]
+    _allowed_hosts_env = get_secret("ALLOWED_HOSTS", None)
+    if _allowed_hosts_env:
+        _extra_allowed_hosts = [
+            host.strip() for host in _allowed_hosts_env.split(",") if host.strip()
+        ]
+    else:
+        _extra_allowed_hosts = []
+    _allowed_hosts = set(_extra_allowed_hosts)
+    _allowed_hosts.add(WEB_CLIENT_DOMAIN)
+    ALLOWED_HOSTS = list(_allowed_hosts)
 else:
     ALLOWED_HOSTS = ["*"]
 

--- a/intel_owl/settings/security.py
+++ b/intel_owl/settings/security.py
@@ -31,11 +31,13 @@ if STAGE_PRODUCTION or STAGE_STAGING:
         _extra_allowed_hosts = [
             host.strip() for host in _allowed_hosts_env.split(",") if host.strip()
         ]
+        # Prevent wildcard host acceptance in production/staging
+        _extra_allowed_hosts = [host for host in _extra_allowed_hosts if host != "*"]
     else:
         _extra_allowed_hosts = []
     _allowed_hosts = set(_extra_allowed_hosts)
     _allowed_hosts.add(WEB_CLIENT_DOMAIN)
-    ALLOWED_HOSTS = list(_allowed_hosts)
+    ALLOWED_HOSTS = sorted(_allowed_hosts)
 else:
     ALLOWED_HOSTS = ["*"]
 

--- a/intel_owl/settings/security.py
+++ b/intel_owl/settings/security.py
@@ -5,7 +5,7 @@
 from django.core.management.utils import get_random_secret_key
 
 from ._util import get_secret
-from .commons import STAGE_LOCAL, WEB_CLIENT_DOMAIN
+from .commons import STAGE_LOCAL, STAGE_PRODUCTION, STAGE_STAGING, WEB_CLIENT_DOMAIN
 
 # SECURITY WARNING: keep the secret key used in production secret!
 SECRET_KEY = get_secret("DJANGO_SECRET", None) or get_random_secret_key()
@@ -24,20 +24,8 @@ CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}"]
 if STAGE_LOCAL:
     # required to allow requests from port 3001 (frontend development)
     CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}:80/"]
-# Restrict hosts in production environments
 if STAGE_PRODUCTION or STAGE_STAGING:
-    _allowed_hosts_env = get_secret("ALLOWED_HOSTS", None)
-    if _allowed_hosts_env:
-        _extra_allowed_hosts = [
-            host.strip() for host in _allowed_hosts_env.split(",") if host.strip()
-        ]
-        # Prevent wildcard host acceptance in production/staging
-        _extra_allowed_hosts = [host for host in _extra_allowed_hosts if host != "*"]
-    else:
-        _extra_allowed_hosts = []
-    _allowed_hosts = set(_extra_allowed_hosts)
-    _allowed_hosts.add(WEB_CLIENT_DOMAIN)
-    ALLOWED_HOSTS = sorted(_allowed_hosts)
+    ALLOWED_HOSTS = [WEB_CLIENT_DOMAIN]
 else:
     ALLOWED_HOSTS = ["*"]
 


### PR DESCRIPTION
# Description

This PR improves security by restricting `ALLOWED_HOSTS` in production and staging environments.

Currently the project sets:

ALLOWED_HOSTS = ["*"]

Allowing all hosts may expose the application to **Host Header Injection** attacks if the Host header is used when generating absolute URLs (for example through `request.build_absolute_uri()` in authentication flows such as OAuth callbacks or password reset links).

### Fix

This change restricts `ALLOWED_HOSTS` for production and staging environments while keeping `"*"` allowed for development environments.

This ensures secure host validation in production without affecting developer setups.

## Type of change

* [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

* [x] I have read and understood the rules about how to Contribute
* [x] The pull request is for the branch `develop`
* [x] Please avoid adding new libraries as requirements whenever possible
* [x] Linters (`Ruff`) gave 0 errors

### Notes

* No new libraries were added.
* No plugins, analyzers, connectors, or GUI components were modified.
* This is a small security improvement to configuration handling.
