### PR TITLE
Fix: Restrict ALLOWED_HOSTS to prevent Host Header Injection (#3432)

### DIFF
--- a/intel_owl/settings/security.py
+++ b/intel_owl/settings/security.py
@@ -1,22 +1,40 @@
-import os
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
 import logging
 
-from intel_owl.settings.commons import STAGE_LOCAL, STAGE_PRODUCTION, STAGE_STAGING
+# Security Stuff
+from django.core.management.utils import get_random_secret_key
+
+from ._util import get_secret
+from .commons import STAGE_LOCAL, STAGE_PRODUCTION, STAGE_STAGING, WEB_CLIENT_DOMAIN
 
 logger = logging.getLogger(__name__)
 
-# Get WEB_CLIENT_DOMAIN from environment
-WEB_CLIENT_DOMAIN = os.environ.get("WEB_CLIENT_DOMAIN", "").strip()
+# SECURITY WARNING: keep the secret key used in production secret!
+SECRET_KEY = get_secret("DJANGO_SECRET", None) or get_random_secret_key()
+
+HTTPS_ENABLED = get_secret("HTTPS_ENABLED", False) == "True"
+if HTTPS_ENABLED:
+    CSRF_COOKIE_SECURE = True
+    SESSION_COOKIE_SECURE = True
+    WEB_CLIENT_URL = f"https://{WEB_CLIENT_DOMAIN}"
+else:
+    WEB_CLIENT_URL = f"http://{WEB_CLIENT_DOMAIN}"
+
+CSRF_COOKIE_SAMESITE = "Strict"
+CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}"]
+if STAGE_LOCAL:
+    # required to allow requests from port 3001 (frontend development)
+    CSRF_TRUSTED_ORIGINS = [f"{WEB_CLIENT_URL}:80/"]
 
 # Conditional ALLOWED_HOSTS configuration
 if STAGE_PRODUCTION or STAGE_STAGING:
-    # Validate WEB_CLIENT_DOMAIN is set
     if not WEB_CLIENT_DOMAIN:
         raise ValueError(
             "WEB_CLIENT_DOMAIN must be set in production/staging environments."
         )
 
-    # Parse WEB_CLIENT_DOMAIN into individual hosts (supports comma-separated)
     _allowed_hosts = sorted(
         {
             host.strip()
@@ -25,24 +43,22 @@ if STAGE_PRODUCTION or STAGE_STAGING:
         }
     )
 
-    # Validate that we have at least one valid host
     if not _allowed_hosts:
         raise ValueError(
             "WEB_CLIENT_DOMAIN contained no valid hosts after parsing."
         )
 
     ALLOWED_HOSTS = _allowed_hosts
+    logger.info(f"ALLOWED_HOSTS restricted to: {ALLOWED_HOSTS}")
 
-    logger.info(f"ALLOWED_HOSTS restricted to production values: {ALLOWED_HOSTS}")
 elif STAGE_LOCAL:
-    # Allow all hosts for local development
     ALLOWED_HOSTS = ["*"]
     logger.warning(
-        "ALLOWED_HOSTS set to ['*'] - this should only be used in local development!"
+        "ALLOWED_HOSTS set to ['*'] - only use this in local development!"
     )
+
 else:
-    # Default fallback for unknown environments
-    ALLOWED_HOSTS = ["*"]
-    logger.warning(
-        "ALLOWED_HOSTS set to ['*'] - environment not detected, using permissive setting!"
+    raise RuntimeError(
+        "Unknown deployment stage. Please configure STAGE and "
+        "WEB_CLIENT_DOMAIN appropriately."
     )


### PR DESCRIPTION
 ## Description
Fixes the Host Header Injection vulnerability reported in #3432 by 
implementing environment-based ALLOWED_HOSTS configuration.

## Changes Made
- Modified `intel_owl/settings/security.py` to conditionally set 
  ALLOWED_HOSTS based on environment
- Imported `STAGE_LOCAL`, `STAGE_PRODUCTION`, `STAGE_STAGING` from 
  `intel_owl.settings.commons`
- Added support for comma-separated domains via `WEB_CLIENT_DOMAIN`
- Added validation to prevent empty or whitespace-only domain configurations
- Used `sorted()` for deterministic ordering
- Added appropriate logging (`info` for production, `warning` for development)

## Backward Compatibility
**Important**: Production and staging deployments must set the 
`WEB_CLIENT_DOMAIN` environment variable before upgrading. 
If not set, the application will fail to start with a clear error message.

## Environment Variables
- `STAGE_PRODUCTION`: Set to `true` for production environment
- `STAGE_STAGING`: Set to `true` for staging environment
- `STAGE_LOCAL`: Set to `true` for local development
- `WEB_CLIENT_DOMAIN`: Comma-separated list of allowed domains 
  (e.g., `example.com,www.example.com`)

## Testing
- [x] Verified `STAGE_LOCAL` exists in `commons.py`
- [x] Verified all imports are valid
- [x] Logic covers all environment cases
- [x] Edge cases handled (empty, whitespace-only domains)

## Related Issue
Fixes #3432