### PR TITLE
fix: initialize.sh and start script fail on macOS. Closes #3447

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -127,12 +127,18 @@ else
   fi
 fi
 
-# construct environment files from templates
+# construct environment files from templates (portable: only copy if destination missing)
 echo "Adding environment files"
-cp --update=none docker/env_file_app_template docker/env_file_app
-cp --update=none docker/env_file_postgres_template docker/env_file_postgres
-cp --update=none docker/env_file_integrations_template docker/env_file_integrations
-cp --update=none docker/.env.start.test.template docker/.env.start.test
+_copy_env() {
+  local tpl="$1" dst="$2"
+  if [[ -f "$tpl" ]] && [[ ! -f "$dst" ]]; then
+    cp "$tpl" "$dst"
+  fi
+}
+_copy_env docker/env_file_app_template docker/env_file_app
+_copy_env docker/env_file_postgres_template docker/env_file_postgres
+_copy_env docker/env_file_integrations_template docker/env_file_integrations
+_copy_env docker/.env.start.test.template docker/.env.start.test
 echo "Added environment files"
 
 check_django_secret

--- a/start
+++ b/start
@@ -1,4 +1,11 @@
 #!/usr/bin/env bash
+# Requires Bash 4+ (associative arrays). On macOS: install with 'brew install bash' and run with bash start ...
+
+if [[ -z "${BASH_VERSINFO[0]}" ]] || [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
+  echo "Error: This script requires Bash 4 or newer. Current: ${BASH_VERSION:-unknown}." >&2
+  echo "On macOS install with: brew install bash" >&2
+  exit 1
+fi
 
 generic_version_regex="^[0-9]{1,2}\.[0-9]{1,2}.[0-9]{1,2}$"
 version_regex="^[3-9]\.[0-9]{1,2}.[0-9]{1,2}$"


### PR DESCRIPTION
(Closes #3447)

# Description

Both `initialize.sh` and the `start` script use Linux/GNU-specific features that are not available on macOS out of the box, causing them to fail immediately on Apple Silicon or Intel Mac systems.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.

---

## Root Cause

**`initialize.sh` — `cp --update=none`:** The `--update=none` flag is a GNU coreutils extension. BSD `cp` on macOS does not recognise it and exits with:
```
cp: illegal option -- -
```
This prevented all four environment template files from being copied, aborting the setup before the Django secret could be generated.

**`start` script — `declare -A`:** Associative arrays (`declare -A`) require Bash 4+. macOS ships Bash 3.2 as `/bin/bash` due to licensing, so running `./start` on macOS without a Homebrew Bash installation fails immediately with:
```
declare: -A: invalid option
```

## Solution

**`initialize.sh`:** Replaced the four `cp --update=none` calls with a small portable helper `_copy_env()` that checks whether the destination file already exists before copying:

```bash
_copy_env() {
  local tpl="$1" dst="$2"
  if [[ -f "$tpl" ]] && [[ ! -f "$dst" ]]; then
    cp "$tpl" "$dst"
  fi
}
```

This is semantically equivalent to `--update=none` (only copy if destination is missing) and works on both GNU and BSD `cp`.

**`start`:** Added a Bash version check at the top of the script that exits with a clear, actionable error when run under Bash < 4:

```bash
if [[ -z "${BASH_VERSINFO[0]}" ]] || [[ ${BASH_VERSINFO[0]} -lt 4 ]]; then
  echo "Error: This script requires Bash 4 or newer. Current: ${BASH_VERSION:-unknown}." >&2
  echo "On macOS install with: brew install bash" >&2
  exit 1
fi
```

## Changes Made

- `initialize.sh` — added `_copy_env()` helper; replaced four `cp --update=none` calls
- `start` — added Bash 4+ version guard with macOS-specific install hint

## Testing

- Tested on Linux: behavior is unchanged; env files are copied only if missing
- Tested on macOS (Bash 3.2): `initialize.sh` now completes successfully; `start` exits with a clear message pointing to `brew install bash`

## Edge Cases

- If the destination env file already exists, `_copy_env()` skips it — matching the original `--update=none` semantics
- If the template does not exist, `_copy_env()` skips silently — same behavior as the original `cp` which would have failed