### PR TITLE
Fix semantic_version_comp crash on "v" prefixed versions and simplify Docker Compose version parsing. Closes #3446

### DIFF
--- a/initialize.sh
+++ b/initialize.sh
@@ -18,8 +18,8 @@ semantic_version_comp () {
 
   # Convert version numbers to arrays
   local IFS=.
-  read -ra ver1 <<< "$1"
-  read -ra ver2 <<< "$2"
+  read -ra ver1 <<< "$ver1"
+  read -ra ver2 <<< "$ver2"
   # Fill empty fields in ver1 with zeros
   for ((i=${#ver1[@]}; i<${#ver2[@]}; i++)); do
       ver1[i]=0
@@ -118,7 +118,7 @@ if ! docker compose version; then
   fi
 else
   # docker compose exists
-  docker_compose_version="$(docker compose version | cut -d 'v' -f3)"
+  docker_compose_version="$(docker compose version --short)"
   if [[ $(semantic_version_comp "$docker_compose_version" "$MINIMUM_DOCKER_COMPOSE_VERSION") == "lessThan" ]]; then
     echo "Error: Docker compose version is too old. Please upgrade to at least $MINIMUM_DOCKER_COMPOSE_VERSION." >&2
     exit 1


### PR DESCRIPTION
# Description

This PR fixes two related bugs in `initialize.sh` that cause the script to fail during installation:

### Bug 1: `semantic_version_comp` crashes on `v`-prefixed versions

Lines 16-17 correctly strip the `v` prefix from version strings into `ver1`/`ver2`, but lines 21-22 overwrite them by reading from the original `$1`/`$2` arguments instead of the stripped values. When a version like `v2.3.4` is passed, `read -ra ver1 <<< "v2.3.4"` produces `["v2","3","4"]`, and the subsequent arithmetic comparison `((10#${ver1[0]}))` with `ver1[0]="v2"` causes a bash error:

<img width="890" height="489" alt="image" src="https://github.com/user-attachments/assets/47f23765-55c5-481d-bff1-192cd23d3e41" />


**Fix:** Changed `read -ra ver1 <<< "$1"` → `read -ra ver1 <<< "$ver1"` (and same for `ver2`) so the stripped values are actually used.

### Bug 2: Docker Compose version parsing fails without `v` prefix

Line 121 uses `cut -d 'v' -f3` to extract the version number from `docker compose version` output. This assumes the output always contains a `v` before the version number (e.g., `Docker Compose version v2.3.4`). However, newer versions of Docker Compose output `Docker Compose version 5.0.2` (without the `v`), causing `cut` to return an empty string. This leads to an incorrect "version too old" error even when the version is valid.
## Before
<img width="1317" height="495" alt="image" src="https://github.com/user-attachments/assets/6085092e-512d-4692-8999-b807ed345130" />

## After
<img width="1340" height="538" alt="image" src="https://github.com/user-attachments/assets/2944d616-4737-4295-aa6c-41b52a0b4b6e" />


**Fix:** Replaced the fragile `cut` command with `docker compose version --short`, which reliably returns just the version number regardless of format.

Closes #3446

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - N/A
- [ ] I have inserted the copyright banner at the start of the file: N/A (shell script, not a Python module)
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section. N/A
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified: N/A
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

