### PR TITLE
fix: auto-search for brand new artifacts after evaluation submission. Closes #3148

### DIFF
--- a/frontend/src/components/userEvents/UserEventModal.jsx
+++ b/frontend/src/components/userEvents/UserEventModal.jsx
@@ -204,26 +204,24 @@ export function UserEventModal({
       const failed = [];
       Promise.allSettled(
         formik.values.analyzables.map((analyzable) => {
-          if (inputState[analyzable].type === UserEventTypes.IP_WILDCARD)
+          const state = inputState[analyzable] ?? {
+            type: UserEventTypes.ANALYZABLE,
+            eventId: null,
+          };
+          if (state.type === UserEventTypes.IP_WILDCARD)
             evaluation.network = analyzable;
-          else if (
-            inputState[analyzable].type === UserEventTypes.DOMAIN_WILDCARD
-          )
+          else if (state.type === UserEventTypes.DOMAIN_WILDCARD)
             evaluation.query = analyzable;
           else evaluation.analyzable = { name: analyzable };
 
-          if (inputState[analyzable]?.eventId) {
-            // edit an existing evaluation
+          if (state.eventId) {
             return axios.patch(
-              `${userEventTypesToApiMapping[inputState[analyzable].type]}/${
-                inputState[analyzable].eventId
-              }`,
+              `${userEventTypesToApiMapping[state.type]}/${state.eventId}`,
               evaluation,
             );
           }
-          // create a new evaluation
           return axios.post(
-            `${userEventTypesToApiMapping[inputState[analyzable].type]}`,
+            `${userEventTypesToApiMapping[state.type]}`,
             evaluation,
           );
         }),


### PR DESCRIPTION
## Description

This PR fixes an edge case missed in #3422: the auto-search after evaluation submission was not working for completely new artifacts that had never been analyzed or searched. When a user clicks "New evaluation" from the top right of the Artifacts page and types a brand new IOC, `inputState[analyzable]` is `undefined` because the debounce hasn't fired yet, or the artifact has never been seen before. This caused a silent crash in `onSubmit` before the `onSubmitCallback` could fire, so the artifact never appeared in the results.
The fix adds a safe `??` fallback so that if `inputState[analyzable]` is undefined, it defaults to `{ type: ANALYZABLE, eventId: null }` and correctly proceeds with `axios.post` to create the new evaluation and trigger the auto-search.

Closes #3148
This is a follow-up to #3422

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about how to contribute to this project
- [x] The pull request is for the branch `develop`
- [x] Linters gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified:
    - [x] I have provided a screenshot of the result in the PR.
    
<img width="996" height="939" alt="image" src="https://github.com/user-attachments/assets/bc47a92d-c115-4b62-9e9b-6c2cd0ba1d67" />

<img width="1819" height="864" alt="image" src="https://github.com/user-attachments/assets/bdd07e37-ad9a-460f-8788-16e0378a89dd" />
