### PR TITLE
fix: allow False value for MISP published parameter

### DIFF
--- a/api_app/analyzers_manager/migrations/0181_misp_published_default_none.py
+++ b/api_app/analyzers_manager/migrations/0181_misp_published_default_none.py
@@ -1,0 +1,53 @@
+from django.db import migrations
+
+
+def migrate(apps, schema_editor):
+    PythonModule = apps.get_model("api_app", "PythonModule")
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+
+    pm = PythonModule.objects.get(
+        module="misp.MISP",
+        base_path="api_app.analyzers_manager.observable_analyzers",
+    )
+    param = Parameter.objects.get(python_module=pm, name="published")
+    param.required = False
+    param.full_clean()
+    param.save()
+
+    PluginConfig.objects.filter(
+        parameter=param,
+        for_organization=False,
+        owner=None,
+    ).update(value=None)
+
+
+def reverse_migrate(apps, schema_editor):
+    PythonModule = apps.get_model("api_app", "PythonModule")
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+
+    pm = PythonModule.objects.get(
+        module="misp.MISP",
+        base_path="api_app.analyzers_manager.observable_analyzers",
+    )
+    param = Parameter.objects.get(python_module=pm, name="published")
+    param.required = True
+    param.full_clean()
+    param.save()
+
+    PluginConfig.objects.filter(
+        parameter=param,
+        for_organization=False,
+        owner=None,
+    ).update(value=False)
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api_app", "0061_job_depth_analysis"),
+        ("analyzers_manager", "0180_add_local_db_models_phishing_army"),
+    ]
+    operations = [
+        migrations.RunPython(migrate, reverse_migrate),
+    ]

--- a/api_app/analyzers_manager/observable_analyzers/misp.py
+++ b/api_app/analyzers_manager/observable_analyzers/misp.py
@@ -27,7 +27,7 @@ class MISP(classes.ObservableAnalyzer):
     filter_on_type: bool
     strict_search: bool
     timeout: int = 5
-    published: bool
+    published: bool = None
     metadata: bool
 
     def update(self):
@@ -71,11 +71,7 @@ class MISP(classes.ObservableAnalyzer):
         if self.enforce_warninglist:
             params["enforce_warninglist"] = self.enforce_warninglist
 
-        # https://pymisp.readthedocs.io/en/latest/modules.html#pymisp.PyMISP
-        # fixme: this should be None as default but is False
-        # so it's not possible to set it as False in this way.
-        #  migration required
-        if self.published:
+        if self.published is not None:
             params["published"] = self.published
 
         if self.metadata:


### PR DESCRIPTION
Fixes #3429

## Problem

The MISP analyzer's `published` parameter defaults to `False` (bool). The condition `if self.published:` treats `False` as falsy, so explicitly setting `published=False` to filter unpublished events has no effect. The code has a FIXME comment acknowledging this.

| Value | Expected | Actual (before fix) |
|-------|----------|-------------------|
| `True` | Passed to PyMISP | Passed |
| `False` | Passed to PyMISP | Skipped |
| `None` | Not passed | Not possible (default is False) |

## Fix

1. Changed `published: bool` to `published: bool = None` (follows the pattern in `hudsonrock.py`)
2. Changed `if self.published:` to `if self.published is not None:`
3. Added data migration `0181` to:
   - Set `Parameter.required = False` for `published`
   - Update existing `PluginConfig` defaults from `False` to `None`

Migration is reversible.

## Testing

The code change is straightforward. The condition now correctly handles all three states:
- `True`: pass `published=True` to PyMISP
- `False`: pass `published=False` to PyMISP (was broken, now fixed)
- `None`: do not pass `published` parameter (default behavior)