### PR TITLE
fix(analyzers): disable TalosReputation analyzer. Closes #3451

### DIFF
--- a/api_app/analyzers_manager/migrations/0181_disable_talos_reputation.py
+++ b/api_app/analyzers_manager/migrations/0181_disable_talos_reputation.py
@@ -14,7 +14,7 @@ def reverse_migrate(apps, schema_editor):
 class Migration(migrations.Migration):
 
     dependencies = [
-        ("analyzers_manager", "0181_misp_published_default_none"),
+        ("analyzers_manager", "0180_add_local_db_models_phishing_army"),
     ]
 
     operations = [migrations.RunPython(migrate, reverse_migrate)]

--- a/api_app/analyzers_manager/migrations/0182_disable_talos_reputation.py
+++ b/api_app/analyzers_manager/migrations/0182_disable_talos_reputation.py
@@ -1,0 +1,20 @@
+from django.db import migrations
+
+
+def migrate(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    AnalyzerConfig.objects.filter(name="TalosReputation").update(disabled=True)
+
+
+def reverse_migrate(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    AnalyzerConfig.objects.filter(name="TalosReputation").update(disabled=False)
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analyzers_manager", "0181_misp_published_default_none"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]

--- a/api_app/visualizers_manager/visualizers/ip_reputation_services.py
+++ b/api_app/visualizers_manager/visualizers/ip_reputation_services.py
@@ -329,20 +329,6 @@ class IPReputationServices(Visualizer):
             )
             return tor_report
 
-    @visualizable_error_handler_with_params("Talos Reputation")
-    def _talos(self):
-        try:
-            analyzer_report = self.get_analyzer_reports().get(config__name="TalosReputation")
-        except AnalyzerReport.DoesNotExist:
-            logger.warning("TalosReputation report does not exist")
-        else:
-            found = analyzer_report.report.get("found", False)
-            talos_report = self.Bool(
-                value="Talos Reputation",
-                disable=not (analyzer_report.status == ReportStatus.SUCCESS and found),
-            )
-            return talos_report
-
     def run(self) -> List[Dict]:
         first_level_elements = []
         second_level_elements = []
@@ -377,8 +363,6 @@ class IPReputationServices(Visualizer):
         third_level_elements.append(self._firehol())
 
         third_level_elements.append(self._tor())
-
-        third_level_elements.append(self._talos())
 
         page = self.Page(name="Reputation")
         page.add_level(

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -14,7 +14,6 @@ from api_app.analyzers_manager.observable_analyzers import (
     ja4_db,
     maxmind,
     phishing_army,
-    talos,
     tor,
     tor_nodes_danmeuk,
     tweetfeeds,
@@ -89,11 +88,6 @@ class CronTests(CustomTestCase):
         maxmind.Maxmind.update()
         for db in maxmind.Maxmind.get_db_names():
             self.assertTrue(os.path.exists(db))
-
-    @if_mock_connections(patch("requests.get", return_value=MockUpResponse({}, 200, text="91.192.100.61")))
-    def test_talos_updater(self, mock_get=None):
-        db_file_path = talos.Talos.update()
-        self.assertTrue(os.path.exists(db_file_path))
 
     @if_mock_connections(
         patch(


### PR DESCRIPTION
## Summary
- The upstream Talos IP blocklist URL (`https://snort.org/downloads/ip-block-list`) now requires accepting Terms & Conditions, making programmatic fetching impossible. Cisco added this intermediary page in 2024.
- Per maintainer guidance, this PR disables the TalosReputation analyzer rather than attempting a workaround.

## Changes
- **Migration `0182_disable_talos_reputation.py`**: Sets `disabled=True` on the `TalosReputation` analyzer config, following the same pattern used in migration `0169` for GuardDog.
- **`ip_reputation_services.py`**: Removes the `_talos()` visualizer method and its invocation, since the analyzer will no longer produce reports.
- **`tests/test_crons.py`**: Removes the `test_talos_updater` test and the `talos` import.

The analyzer source code (`talos.py`) is intentionally kept so existing reports/data remain accessible.

## Test plan
- [ ] Verify migration applies cleanly: `python manage.py migrate analyzers_manager`
- [ ] Verify IP Reputation Services visualizer renders without Talos entry
- [ ] Verify `test_crons.py` tests pass without the removed Talos test

Closes #3451

🤖 Generated with [Claude Code](https://claude.com/claude-code)