### PR TITLE
fix(storage): share S3 cached file across analyzers

### DIFF
--- a/api_app/analyzers_manager/classes.py
+++ b/api_app/analyzers_manager/classes.py
@@ -241,17 +241,6 @@ class FileAnalyzer(BaseAnalyzerMixin, metaclass=ABCMeta):
 
     def after_run(self):
         super().after_run()
-        # We delete the file only if we have single copy for analyzer
-        # and the file has been saved locally.
-        # Otherwise we would remove the single file that we have on the server
-        if not settings.LOCAL_STORAGE and self.filepath is not None:
-            import os
-
-            try:
-                os.remove(self.filepath)
-            except OSError:
-                logger.warning(f"Filepath {self.filepath} does not exists")
-
         logger.info(f"FINISHED analyzer: {self.__repr__()} -> File: ({self.filename}, md5: {self.md5})")
 
 

--- a/intel_owl/settings/storage.py
+++ b/intel_owl/settings/storage.py
@@ -34,17 +34,12 @@ else:
 
     class S3Boto3StorageWrapper(S3Boto3Storage):
         def retrieve(self, file, analyzer):
-            # FIXME we can optimize this a lot.
-            #  Right now we are doing an http request FOR analyzer. We can have a
-            #  proxy that will store the content and then save it locally
-
-            # The idea is to download the file in MEDIA_ROOT/analyzer/namefile
-            # if it does not exist
-            path_dir = os.path.join(MEDIA_ROOT, analyzer)
+            # Download the file once into MEDIA_ROOT/<filename> and share the
+            # cached copy across all analyzers that need the same sample.
             name = file.name
-            _path = os.path.join(path_dir, name)
+            _path = os.path.join(MEDIA_ROOT, name)
             if not os.path.exists(_path):
-                os.makedirs(path_dir, exist_ok=True)
+                os.makedirs(MEDIA_ROOT, exist_ok=True)
                 if not self.exists(name):
                     raise AssertionError
                 with self.open(name) as s3_file_object:


### PR DESCRIPTION
## Summary
- Cache the downloaded S3 file at `MEDIA_ROOT/<filename>` instead of `MEDIA_ROOT/<analyzer>/<filename>`, so all analyzers share a single cached copy rather than each downloading and storing their own.
- Remove the per-analyzer file deletion in `FileAnalyzer.after_run()` since the shared file must not be removed while concurrent analyzers may still need it.
- Resolves the `FIXME` noted in `S3Boto3StorageWrapper.retrieve()`.

Closes #3459

## Changes
### `intel_owl/settings/storage.py`
- Removed the per-analyzer subdirectory from the cache path (`MEDIA_ROOT/<analyzer>/<name>` -> `MEDIA_ROOT/<name>`)
- Updated comments to reflect the new shared-cache behavior

### `api_app/analyzers_manager/classes.py`
- Removed the `os.remove()` call in `FileAnalyzer.after_run()` that deleted the cached file after each analyzer finished — this is no longer safe since the file is now shared across concurrent analyzers

## Test plan
- [ ] Set `LOCAL_STORAGE=False` (S3 mode) and upload a file with multiple analyzers enabled
- [ ] Verify only one copy of the file appears under `MEDIA_ROOT/` (no per-analyzer subdirectories)
- [ ] Verify all analyzers complete successfully and read the shared cached file
- [ ] Verify local storage mode (`LOCAL_STORAGE=True`) is unaffected

🤖 Generated with [Claude Code](https://claude.com/claude-code)