### PR TITLE
fix: stringify Exception objects in HoneyDB and Cymru analyzers

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/cymru.py
+++ b/api_app/analyzers_manager/observable_analyzers/cymru.py
@@ -38,7 +38,7 @@ class Cymru(ObservableAnalyzer):
             results["timeout"] = True
         except Exception as e:
             logger.exception(e)
-            self.report.errors.append(e)
+            self.report.errors.append(str(e))
             results["unexpected_error"] = True
 
         if domains:

--- a/api_app/analyzers_manager/observable_analyzers/honeydb.py
+++ b/api_app/analyzers_manager/observable_analyzers/honeydb.py
@@ -68,6 +68,6 @@ class HoneyDB(classes.ObservableAnalyzer):
             response.raise_for_status()
         except Exception as e:
             logger.exception(e)
-            self.result[endpoint] = {"error": e}
+            self.result[endpoint] = {"error": str(e)}
         else:
             self.result[endpoint] = response.json()


### PR DESCRIPTION
## Summary

- **HoneyDB** (`honeydb.py:71`): `self.result[endpoint] = {"error": e}` stores a raw Exception in the result dict. This dict is returned from `run()`, passed to `after_run_success()`, assigned to `report.report` (a `JSONField`), and saved. `json.dumps` raises `TypeError: Object of type Exception is not JSON serializable`.
- **Cymru** (`cymru.py:41`): `self.report.errors.append(e)` appends a raw Exception to `report.errors`, which is `ArrayField(CharField(max_length=512))`. While Postgres may implicitly cast to string, passing a non-string object violates the field's type contract.

Both are fixed by wrapping `e` in `str()`.

Closes #3471

## Test plan
- [x] `ruff check` passes on both files
- [x] `ruff format --check` passes on both files
- [ ] Existing Cymru unit tests pass (requires Docker environment)