### PR TITLE
fix: redact secret param values in debug logs

### DIFF
--- a/api_app/classes.py
+++ b/api_app/classes.py
@@ -150,8 +150,9 @@ class Plugin(metaclass=ABCMeta):
         for parameter in self.__parameters:
             attribute_name = f"_{parameter.name}" if parameter.is_secret else parameter.name
             setattr(self, attribute_name, parameter.value)
+            logged_value = "<redacted>" if parameter.is_secret else parameter.value
             logger.debug(
-                f"Adding to {self.__class__.__name__} param {attribute_name} with value {parameter.value} "
+                f"Adding to {self.__class__.__name__} param {attribute_name} with value {logged_value}"
             )
 
     def before_run(self):

--- a/api_app/serializers/plugin.py
+++ b/api_app/serializers/plugin.py
@@ -34,7 +34,7 @@ class PluginConfigSerializer(ModelWithOwnershipSerializer, rfs.ModelSerializer):
         def to_internal_value(data):
             if not data:
                 raise ValidationError({"detail": "Empty insertion"})
-            logger.info(f"verifying that value {data} ({type(data)}) is JSON compliant")
+            logger.debug(f"verifying that value ({type(data)}) is JSON compliant")
             try:
                 return json.loads(data)
             except json.JSONDecodeError:
@@ -42,7 +42,7 @@ class PluginConfigSerializer(ModelWithOwnershipSerializer, rfs.ModelSerializer):
                     data = json.dumps(data)
                     return json.loads(data)
                 except json.JSONDecodeError:
-                    logger.info(f"value {data} ({type(data)}) raised ValidationError")
+                    logger.debug(f"value ({type(data)}) raised ValidationError")
                     raise ValidationError({"detail": "Value is not JSON-compliant."})
 
         def get_attribute(self, instance: PluginConfig):


### PR DESCRIPTION
## Description

Closes #3465

Two places in the codebase logged sensitive credential values that could appear in plaintext in log files.

**`api_app/classes.py` — `Plugin.config()`**

Parameters marked `is_secret=True` (API keys, tokens, passwords) were logged verbatim at `DEBUG` level:

```python
# before
logger.debug(f"Adding to {self.__class__.__name__} param {attribute_name} with value {parameter.value} ")
```

The fix checks `parameter.is_secret` and substitutes `<redacted>` in the log message, while leaving `setattr` unchanged so the plugin still receives the real value.

**`api_app/serializers/plugin.py` — `PluginConfigSerializer.CustomValueField.to_internal_value()`**

The raw submitted value (which may be a secret being saved for the first time) was logged at `INFO` level. This method is a static method and has no access to whether the parameter is a secret, so the value is removed from the log message entirely and the level is demoted to `DEBUG`.

## Changes

- `api_app/classes.py`: log `<redacted>` instead of `parameter.value` when `parameter.is_secret` is True
- `api_app/serializers/plugin.py`: drop the value from two log messages in `to_internal_value`, demote from `INFO` to `DEBUG`

## Type of change

- [x] Bug fix

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/)
- [x] The pull request is for the branch `develop`
- [x] I have inserted the copyright banner at the start of the new files I created
- [x] I ran the linter (`ruff check`) and the checks pass