### PR TITLE
fix: remove logging.basicConfig from bbot and phunter analyzers

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/bbot.py
+++ b/api_app/analyzers_manager/observable_analyzers/bbot.py
@@ -10,7 +10,6 @@ from api_app.analyzers_manager.exceptions import AnalyzerRunException
 from api_app.choices import Classification
 from api_app.models import PythonConfig
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 

--- a/api_app/analyzers_manager/observable_analyzers/phunter.py
+++ b/api_app/analyzers_manager/observable_analyzers/phunter.py
@@ -6,7 +6,6 @@ import requests
 from api_app.analyzers_manager.classes import DockerBasedAnalyzer, ObservableAnalyzer
 from api_app.analyzers_manager.exceptions import AnalyzerRunException
 
-logging.basicConfig(level=logging.DEBUG)
 logger = logging.getLogger(__name__)
 
 


### PR DESCRIPTION
## Problem

`bbot.py` and `phunter.py` both call `logging.basicConfig(level=logging.DEBUG)` at module level.

Calling `logging.basicConfig` in a library module is wrong:
- If the root logger has no handlers yet (e.g., module imported before Django sets up logging), this sets the root logger to DEBUG globally, leaking verbose output from all loggers including third-party ones
- If Django's logging is already configured, `basicConfig` is a no-op, but the intent was clearly wrong
- Both files already use the correct pattern: `logger = logging.getLogger(__name__)`

These lines were leftover debug artifacts.

## Fix

Remove the two `logging.basicConfig(level=logging.DEBUG)` calls. The `logging.getLogger(__name__)` calls remain and provide properly scoped module loggers as intended.

## Files changed

- `api_app/analyzers_manager/observable_analyzers/bbot.py`
- `api_app/analyzers_manager/observable_analyzers/phunter.py`