### PR TITLE
fix: hibp make_hibp_request returns empty string instead of list on 404 for breach endpoints

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/hibp_utils.py
+++ b/api_app/analyzers_manager/observable_analyzers/hibp_utils.py
@@ -52,8 +52,11 @@ def make_hibp_request(
             else:
                 return response.text
         elif response.status_code == 404:
-            # No breaches found - treat as success with empty result
-            return [] if "json" in url else ""
+            # No breaches found - treat as success with empty result.
+            # Breach endpoints (haveibeenpwned.com) return JSON lists;
+            # the pwned-passwords range endpoint (api.pwnedpasswords.com)
+            # returns plain text. Use the host to pick the right empty value.
+            return [] if "haveibeenpwned.com" in url else ""
         elif response.status_code == 403:
             raise RuntimeError("Forbidden: Check API key or User-Agent.")  # noqa: E501
         elif response.status_code == 429:


### PR DESCRIPTION
## Summary

`make_hibp_request` in `hibp_utils.py` uses `"json" in url` to decide what to return on a 404 response. Breach account URLs (e.g. `https://haveibeenpwned.com/api/v3/breachedaccount/user@example.com`) do not contain the substring `"json"`, so a 404 (meaning no breaches found) incorrectly returns `""` (empty string) instead of `[]` (empty list).

That empty string is then passed directly to `normalize_breach_data()` in `hibp_breaches.py`, which does `for breach in breaches:` — iterating characters of the string instead of breach dicts. Each character is treated as a dict, and `.get("Name")` is called on a string, raising `AttributeError: 'str' object has no attribute 'get'`.

## Fix

Replace the `"json" in url` heuristic with `"haveibeenpwned.com" in url`, which correctly identifies breach endpoints (JSON lists) vs the pwned-passwords range endpoint at `api.pwnedpasswords.com` (plain text).

## Affected file

`api_app/analyzers_manager/observable_analyzers/hibp_utils.py`

## Test plan

- [ ] Run `HibpBreachesTestCase` with a mocked 404 from `make_hibp_request` returning `[]` for a breach email lookup
- [ ] Confirm `normalize_breach_data([])` returns `[]` without error
- [ ] Confirm `HibpPasswords` behavior unchanged (passwords endpoint returns 200 with text in practice; 404 would still return `""`)