### PR TITLE
fix: convert Exception to str in HoneyDB and Cymru analyzers

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/cymru.py
+++ b/api_app/analyzers_manager/observable_analyzers/cymru.py
@@ -38,7 +38,7 @@ class Cymru(ObservableAnalyzer):
             results["timeout"] = True
         except Exception as e:
             logger.exception(e)
-            self.report.errors.append(e)
+            self.report.errors.append(str(e))
             results["unexpected_error"] = True
 
         if domains:

--- a/api_app/analyzers_manager/observable_analyzers/honeydb.py
+++ b/api_app/analyzers_manager/observable_analyzers/honeydb.py
@@ -68,6 +68,6 @@ class HoneyDB(classes.ObservableAnalyzer):
             response.raise_for_status()
         except Exception as e:
             logger.exception(e)
-            self.result[endpoint] = {"error": e}
+            self.result[endpoint] = {"error": str(e)}
         else:
             self.result[endpoint] = response.json()


### PR DESCRIPTION
Fixes #3471

In both analyzers, raw Exception objects were stored where strings are required:

- honeydb.py: `{"error": e}` in a JSONField causes `TypeError: Object of type Exception is not JSON serializable`
- cymru.py: `errors.append(e)` appends an Exception to a `CharField ArrayField`

Fixed by wrapping both with `str(e)`.