### PR TITLE
Add MachoInfo static analyzer for Mach-O binaries

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/macho_info.py
+++ b/api_app/analyzers_manager/file_analyzers/macho_info.py
@@ -1,0 +1,50 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import logging
+
+import machofile
+
+from api_app.analyzers_manager.classes import FileAnalyzer
+
+logger = logging.getLogger(__name__)
+
+
+class MachoInfo(FileAnalyzer):
+    def run(self):
+        results = {}
+        try:
+            macho = machofile.UniversalMachO(file_path=self.filepath)
+            macho.parse()
+
+            results["general_info"] = macho.get_general_info()
+            results["header"] = macho.get_macho_header()
+            results["architectures"] = macho.get_architectures()
+            results["load_commands"] = macho.get_load_commands()
+            results["load_commands_set"] = macho.get_load_commands_set()
+            results["segments"] = macho.get_segments()
+            results["imported_functions"] = macho.get_imported_functions()
+            results["exported_symbols"] = macho.get_exported_symbols()
+            results["dylib_names"] = macho.get_dylib_names()
+            results["entry_point"] = macho.get_entry_point()
+            results["uuid"] = macho.get_uuid()
+            results["version_info"] = macho.get_version_info()
+            results["similarity_hashes"] = macho.get_similarity_hashes()
+            results["import_hash"] = macho.get_import_hash()
+            results["export_hash"] = macho.get_export_hash()
+            results["dylib_hash"] = macho.get_dylib_hash()
+            results["symhash"] = macho.get_symhash()
+            results["code_signature"] = macho.get_code_signature_info()
+
+        except Exception as exc:
+            warning_message = (
+                f"job_id:{self.job_id} analyzer:{self.analyzer_name}"
+                f" md5:{self.md5} filename: {self.filename}"
+                f" MachoInfoError {exc}"
+            )
+            logger.warning(warning_message)
+            self.report.errors.append(warning_message)
+            self.report.status = self.report.STATUSES.FAILED
+            self.report.save()
+
+        return results

--- a/api_app/analyzers_manager/migrations/0176_analyzer_config_macho_info.py
+++ b/api_app/analyzers_manager/migrations/0176_analyzer_config_macho_info.py
@@ -1,0 +1,124 @@
+from django.db import migrations
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ManyToManyDescriptor,
+    ReverseManyToOneDescriptor,
+    ReverseOneToOneDescriptor,
+)
+
+plugin = {
+    "python_module": {
+        "health_check_schedule": None,
+        "update_schedule": None,
+        "module": "macho_info.MachoInfo",
+        "base_path": "api_app.analyzers_manager.file_analyzers",
+    },
+    "name": "MachoInfo",
+    "description": "Static Mach-O analysis",
+    "disabled": False,
+    "soft_time_limit": 30,
+    "routing_key": "local",
+    "health_check_status": True,
+    "type": "file",
+    "docker_based": False,
+    "maximum_tlp": "RED",
+    "observable_supported": [],
+    "supported_filetypes": ["application/x-mach-binary"],
+    "run_hash": False,
+    "run_hash_type": "",
+    "not_supported_filetypes": [],
+    "mapping_data_model": {},
+    "model": "analyzers_manager.AnalyzerConfig",
+}
+
+params = []
+
+values = []
+
+
+def _get_real_obj(Model, field, value):
+    def _get_obj(Model, other_model, value):
+        if isinstance(value, dict):
+            real_vals = {}
+            for key, real_val in value.items():
+                real_vals[key] = _get_real_obj(other_model, key, real_val)
+            value = other_model.objects.get_or_create(**real_vals)[0]
+        else:
+            if isinstance(value, int):
+                if Model.__name__ == "PluginConfig":
+                    value = other_model.objects.get(name=plugin["name"])
+                else:
+                    value = other_model.objects.get(pk=value)
+            else:
+                value = other_model.objects.get(name=value)
+        return value
+
+    if (
+        type(getattr(Model, field))
+        in [
+            ForwardManyToOneDescriptor,
+            ReverseManyToOneDescriptor,
+            ReverseOneToOneDescriptor,
+            ForwardOneToOneDescriptor,
+        ]
+        and value
+    ):
+        other_model = getattr(Model, field).get_queryset().model
+        value = _get_obj(Model, other_model, value)
+    elif type(getattr(Model, field)) in [ManyToManyDescriptor] and value:
+        other_model = getattr(Model, field).rel.model
+        value = [_get_obj(Model, other_model, val) for val in value]
+    return value
+
+
+def _create_object(Model, data):
+    mtm, no_mtm = {}, {}
+    for field, value in data.items():
+        value = _get_real_obj(Model, field, value)
+        if type(getattr(Model, field)) is ManyToManyDescriptor:
+            mtm[field] = value
+        else:
+            no_mtm[field] = value
+    try:
+        o = Model.objects.get(**no_mtm)
+    except Model.DoesNotExist:
+        o = Model(**no_mtm)
+        o.full_clean()
+        o.save()
+        for field, value in mtm.items():
+            attribute = getattr(o, field)
+            if value is not None:
+                attribute.set(value)
+        return False
+    return True
+
+
+def migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    if not Model.objects.filter(name=plugin["name"]).exists():
+        exists = _create_object(Model, plugin)
+        if not exists:
+            for param in params:
+                _create_object(Parameter, param)
+            for value in values:
+                _create_object(PluginConfig, value)
+
+
+def reverse_migrate(apps, schema_editor):
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    Model.objects.get(name=plugin["name"]).delete()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("api_app", "0071_delete_last_elastic_report"),
+        ("analyzers_manager", "0175_analyzer_config_cleanbrowsing_malicious_detector"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -116,3 +116,4 @@ DeepDiff==8.6.1
 lxml==6.0.2
 Faker==36.1.0
 beautifulsoup4==4.14.2
+machofile==2026.02.10

--- a/tests/api_app/analyzers_manager/unit_tests/file_analyzers/test_macho_info.py
+++ b/tests/api_app/analyzers_manager/unit_tests/file_analyzers/test_macho_info.py
@@ -1,0 +1,84 @@
+from unittest.mock import MagicMock, patch
+
+from api_app.analyzers_manager.file_analyzers.macho_info import MachoInfo
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.choices import TLP, PythonModuleBasePaths
+from api_app.models import PythonModule
+
+from .base_test_class import BaseFileAnalyzerTest
+
+
+class TestMachoInfo(BaseFileAnalyzerTest):
+    analyzer_class = MachoInfo
+
+    @classmethod
+    def get_sample_file_path(cls, mimetype: str) -> str:
+        if mimetype != "application/x-mach-binary":
+            raise ValueError(f"No test file defined for mimetype {mimetype}")
+        return "/tmp/test_macho"
+
+    @classmethod
+    def get_sample_file_bytes(cls, mimetype: str) -> bytes:
+        if mimetype != "application/x-mach-binary":
+            raise ValueError(f"No test bytes defined for mimetype {mimetype}")
+        return b"fake macho bytes"
+
+    @classmethod
+    def setUpTestData(cls):
+        super().setUpTestData()
+        python_module, _ = PythonModule.objects.get_or_create(
+            module="macho_info.MachoInfo",
+            base_path=PythonModuleBasePaths.FileAnalyzer.value,
+            defaults={
+                "update_schedule": None,
+                "health_check_schedule": None,
+            },
+        )
+        AnalyzerConfig.objects.get_or_create(
+            name="MachoInfo",
+            python_module=python_module,
+            defaults={
+                "description": "Static Mach-O analysis",
+                "disabled": False,
+                "soft_time_limit": 30,
+                "routing_key": "local",
+                "health_check_status": True,
+                "type": "file",
+                "docker_based": False,
+                "maximum_tlp": TLP.RED,
+                "observable_supported": [],
+                "supported_filetypes": ["application/x-mach-binary"],
+                "run_hash": False,
+                "run_hash_type": "",
+                "not_supported_filetypes": [],
+                "mapping_data_model": {},
+            },
+        )
+
+    def get_mocked_response(self):
+        mock_macho = MagicMock()
+        mock_macho.get_general_info.return_value = {"file_type": "MH_EXECUTE"}
+        mock_macho.get_macho_header.return_value = {"magic": "0xfeedfacf"}
+        mock_macho.get_architectures.return_value = ["x86_64"]
+        mock_macho.get_load_commands.return_value = [{"cmd": "LC_SEGMENT_64"}]
+        mock_macho.get_load_commands_set.return_value = ["LC_SEGMENT_64"]
+        mock_macho.get_segments.return_value = [{"name": "__TEXT"}]
+        mock_macho.get_imported_functions.return_value = ["_printf"]
+        mock_macho.get_exported_symbols.return_value = ["_main"]
+        mock_macho.get_dylib_names.return_value = ["/usr/lib/libSystem.B.dylib"]
+        mock_macho.get_entry_point.return_value = {"entryoff": 4096}
+        mock_macho.get_uuid.return_value = "12345678-1234-1234-1234-1234567890ab"
+        mock_macho.get_version_info.return_value = {"platform": "macOS"}
+        mock_macho.get_similarity_hashes.return_value = {"symhash": "deadbeef"}
+        mock_macho.get_import_hash.return_value = "importhash"
+        mock_macho.get_export_hash.return_value = "exporthash"
+        mock_macho.get_dylib_hash.return_value = "dylibhash"
+        mock_macho.get_symhash.return_value = "symhash"
+        mock_macho.get_code_signature_info.return_value = {"signed": False}
+
+        return [
+            patch(
+                "api_app.analyzers_manager.file_analyzers.macho_info.machofile.UniversalMachO",
+                return_value=mock_macho,
+            )
+        ]


### PR DESCRIPTION
## Description
Adds a new file analyzer `MachoInfo` for static analysis of macOS Mach-O binaries using the `machofile` library.

Closes #2948

## Changes
- `api_app/analyzers_manager/file_analyzers/macho_info.py` — new analyzer using `machofile.UniversalMachO`
- `api_app/analyzers_manager/migrations/0176_analyzer_config_macho_info.py` — DB migration to register the plugin
- `requirements/project-requirements.txt` — pin `machofile==2026.02.10`
- `tests/api_app/analyzers_manager/unit_tests/file_analyzers/test_macho_info.py` — unit tests with mocked responses

## What it extracts
- File header, architectures, segments, load commands
- Imported functions, exported symbols, dylib names
- Entry point, UUID, version info
- Similarity hashes (import hash, export hash, symhash, dylib hash)
- Code signature info

## Test
`Ran 2 tests in 0.035s OK`