### PR TITLE
Fix Dehashed analyzer for v2 API endpoint

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/dehashed.py
+++ b/api_app/analyzers_manager/observable_analyzers/dehashed.py
@@ -1,7 +1,6 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import base64
 import logging
 import re
 
@@ -20,7 +19,7 @@ class DehashedSearch(ObservableAnalyzer):
     - API key is mandatory for dehased.com's API.
     """
 
-    url: str = "https://api.dehashed.com/"
+    url: str = "https://api.dehashed.com/v2/"
     size: int
     pages: int
     operator: str
@@ -74,13 +73,10 @@ class DehashedSearch(ObservableAnalyzer):
                 self.operator = "name"
 
     def __search(self, value: str) -> list:
-        # the API uses basic auth so we need to base64 encode the auth payload
-        auth_b64 = base64.b64encode(self._api_key_name.encode()).decode()
-        # construct headers
         headers = CaseInsensitiveDict(
             {
                 "Accept": "application/json",
-                "Authorization": f"Basic {auth_b64}",
+                "Qs-Api-Key": self._api_key_name,
                 "User-Agent": "IntelOwl",
             }
         )

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_dehashed.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_dehashed.py
@@ -31,5 +31,5 @@ class DehashedSearchTestCase(BaseAnalyzerTest):
             "size": 100,
             "pages": 1,
             "operator": "password",  # Set default operator for hash types
-            "_api_key_name": "test_api_key:test_password",
+            "_api_key_name": "test_api_key",
         }


### PR DESCRIPTION
## Description
Fixes the Dehashed analyzer which was returning 404 errors due to an API endpoint change.

Fixes #2828

## Changes
- Updated base URL from `https://api.dehashed.com/` to `https://api.dehashed.com/v2/`
- Replaced deprecated `Authorization: Basic <base64>` header with new `Qs-Api-Key` authentication
- Removed unused `base64` import

## Testing
Verified locally:
- Old `/search` endpoint → `404`
- New `/v2/search` endpoint → `401` (correct, no key) / `200` (with valid key)