### PR TITLE
feat(frontend): allow deleting entries from artifact history table (#3444)

### DIFF
--- a/frontend/src/components/analyzables/result/AnalyzableOverview.jsx
+++ b/frontend/src/components/analyzables/result/AnalyzableOverview.jsx
@@ -56,39 +56,42 @@ export function AnalyzableOverview({ analyzable }) {
     { cache: false },
   );
 
-  const handleDelete = async (row) => {
-    // eslint-disable-next-line no-alert
-    if (window.confirm("Are you sure you want to delete this entry?")) {
-      try {
-        let url = "";
-        switch (row.type) {
-          case AnalyzableHistoryTypes.JOB:
-            url = `${JOB_BASE_URI}/${row.id}`;
-            break;
-          case AnalyzableHistoryTypes.USER_EVENT:
-            url = `${USER_EVENT_ANALYZABLE}/${row.id}`;
-            break;
-          case AnalyzableHistoryTypes.USER_IP_WILDCARD_EVENT:
-            url = `${USER_EVENT_IP_WILDCARD}/${row.id}`;
-            break;
-          case AnalyzableHistoryTypes.USER_DOMAIN_WILDCARD_EVENT:
-            url = `${USER_EVENT_DOMAIN_WILDCARD}/${row.id}`;
-            break;
-          default:
-            return;
+  const handleDelete = React.useCallback(
+    async (row) => {
+      // eslint-disable-next-line no-alert
+      if (window.confirm("Are you sure you want to delete this entry?")) {
+        try {
+          let url = "";
+          switch (row.type) {
+            case AnalyzableHistoryTypes.JOB:
+              url = `${JOB_BASE_URI}/${row.id}`;
+              break;
+            case AnalyzableHistoryTypes.USER_EVENT:
+              url = `${USER_EVENT_ANALYZABLE}/${row.id}`;
+              break;
+            case AnalyzableHistoryTypes.USER_IP_WILDCARD_EVENT:
+              url = `${USER_EVENT_IP_WILDCARD}/${row.id}`;
+              break;
+            case AnalyzableHistoryTypes.USER_DOMAIN_WILDCARD_EVENT:
+              url = `${USER_EVENT_DOMAIN_WILDCARD}/${row.id}`;
+              break;
+            default:
+              return;
+          }
+          await axios.delete(url);
+          addToast("Entry deleted successfully", null, "success");
+          refetch();
+        } catch (err) {
+          addToast("Error deleting entry", err.parsedMsg, "danger");
         }
-        await axios.delete(url);
-        addToast("Entry deleted successfully", null, "success");
-        refetch();
-      } catch (err) {
-        addToast("Error deleting entry", err.parsedMsg, "danger");
       }
-    }
-  };
+    },
+    [refetch],
+  );
 
   const columns = React.useMemo(
     () => getAnalyzablesHistoryTableColumns(user?.username, handleDelete),
-    [user?.username],
+    [user?.username, handleDelete],
   );
 
   const jobs = history?.jobs?.map((job) => ({
@@ -250,7 +253,7 @@ export function AnalyzableOverview({ analyzable }) {
                 (analyzable?.last_data_model?.external_references || []).map(
                   (value, index) => (
                     <BaseVisualizer
-                      key={`external_references-${btoa(value).slice(0, 20)}`}
+                      key={`external_reference-${value}`}
                       value={value}
                       id={`external_references-${index}`}
                       size="h6"
@@ -263,7 +266,7 @@ export function AnalyzableOverview({ analyzable }) {
                 (analyzable?.last_data_model?.related_threats || []).map(
                   (value, index) => (
                     <BaseVisualizer
-                      key={`related_threats-${btoa(value).slice(0, 20)}`}
+                      key={`related_threat-${value}`}
                       value={value}
                       id={`related_threats-${index}`}
                       size="h6"

--- a/frontend/src/components/analyzables/result/analyzablesHistoryTableColumns.jsx
+++ b/frontend/src/components/analyzables/result/analyzablesHistoryTableColumns.jsx
@@ -162,14 +162,14 @@ export const getAnalyzablesHistoryTableColumns = (
     },
     disableSortBy: true,
     Cell: ({ value, row }) =>
-      value && (
+      value ? (
         <TableCell
           id={`table-cell-description__${row.id}`}
           isCopyToClipboard
           isTruncate
           value={value}
         />
-      ),
+      ) : null,
     minWidth: 200,
   },
   {
@@ -182,7 +182,7 @@ export const getAnalyzablesHistoryTableColumns = (
         {row.user === currentUser && (
           <>
             <Button
-              id={`analyzable-history-delete__${row.id}`}
+              id={`analyzable-history-delete__${row.type}__${row.id}`}
               color="link"
               className="p-0 text-danger"
               onClick={() => handleDelete(row)}
@@ -193,7 +193,7 @@ export const getAnalyzablesHistoryTableColumns = (
             </Button>
             <UncontrolledTooltip
               placement="top"
-              target={`analyzable-history-delete__${row.id}`}
+              target={`analyzable-history-delete__${row.type}__${row.id}`}
             >
               Delete
             </UncontrolledTooltip>

--- a/frontend/tests/components/analyzables/result/AnalyzableOverview.test.jsx
+++ b/frontend/tests/components/analyzables/result/AnalyzableOverview.test.jsx
@@ -25,79 +25,83 @@ describe("test AnalyzableOverview", () => {
   const userReportDate = new Date();
   userReportDate.setDate(new Date().getDate() - 2);
 
-  // Default mocks for existing tests
-  useAuthStore.mockReturnValue([{ username: "admin" }]);
-  axios.delete = jest.fn();
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Default mocks for existing tests
+    useAuthStore.mockReturnValue([{ username: "admin" }]);
+    axios.delete = jest.fn();
 
-  useAxios.mockReturnValue([
-    {
-      data: {
-        jobs: [
-          {
-            playbook: "Dns",
-            id: 13,
-            user: "admin",
-            date: jobDate,
-            data_model: {
-              id: 14,
-              analyzers_report: [],
-              ietf_report: [],
-              evaluation: "trusted",
-              reliability: 7,
-              kill_chain_phase: null,
-              external_references: ["test references"],
-              related_threats: ["my comment"],
-              tags: ["scanner"],
-              malware_family: null,
-              additional_info: {},
+    // Default useAxios mock for original tests
+    useAxios.mockReturnValue([
+      {
+        data: {
+          jobs: [
+            {
+              playbook: "Dns",
+              id: 13,
+              user: "admin",
               date: jobDate,
-              rank: null,
-              resolutions: [],
+              data_model: {
+                id: 14,
+                analyzers_report: [],
+                ietf_report: [],
+                evaluation: "trusted",
+                reliability: 7,
+                kill_chain_phase: null,
+                external_references: ["test references"],
+                related_threats: ["my comment"],
+                tags: ["scanner"],
+                malware_family: null,
+                additional_info: {},
+                date: jobDate,
+                rank: null,
+                resolutions: [],
+              },
             },
-          },
-        ],
-        user_events: [
-          {
-            id: 6,
-            user: "admin",
-            date: userReportDate,
-            next_decay: "2025-06-03T10:36:04.762720Z",
-            decay_times: 1,
-            analyzable: {
-              id: 1,
-              name: "google.com",
-              // ...
-            },
-            data_model: {
-              id: 15,
-              analyzers_report: [],
-              ietf_report: [],
-              evaluation: "malicious",
-              reliability: 6,
-              kill_chain_phase: null,
-              external_references: [],
-              related_threats: [],
-              tags: null,
-              malware_family: null,
-              additional_info: {},
+          ],
+          user_events: [
+            {
+              id: 6,
+              user: "admin",
               date: userReportDate,
-              rank: null,
-              resolutions: [],
+              next_decay: "2025-06-03T10:36:04.762720Z",
+              decay_times: 1,
+              analyzable: {
+                id: 1,
+                name: "google.com",
+              },
+              data_model: {
+                id: 15,
+                analyzers_report: [],
+                ietf_report: [],
+                evaluation: "malicious",
+                reliability: 6,
+                kill_chain_phase: null,
+                external_references: [],
+                related_threats: [],
+                tags: null,
+                malware_family: null,
+                additional_info: {},
+                date: userReportDate,
+                rank: null,
+                resolutions: [],
+              },
+              reason: "my reason",
+              data_model_object_id: 15,
+              decay_progression: 0,
+              decay_timedelta_days: 3,
+              data_model_content_type: 44,
             },
-            reason: "my reason",
-            data_model_object_id: 15,
-            decay_progression: 0,
-            decay_timedelta_days: 3,
-            data_model_content_type: 44,
-          },
-        ],
-        user_domain_wildcard_events: [],
-        user_ip_wildcard_events: [],
+          ],
+          user_domain_wildcard_events: [],
+          user_ip_wildcard_events: [],
+        },
+        loading: false,
+        error: null,
       },
-      loading: false,
-      error: null,
-    },
-  ]);
+      jest.fn(),
+    ]);
+  });
 
   test("AnalyzableOverview components", async () => {
     const user = userEvent.setup();
@@ -380,13 +384,7 @@ describe("test AnalyzableOverview", () => {
               id: 13,
               user: "admin",
               date: jobDate,
-              data_model: {
-                evaluation: "trusted",
-                reliability: 7,
-                tags: ["scanner"],
-                related_threats: ["my comment"],
-                external_references: ["test references"],
-              },
+              data_model: { evaluation: "trusted" },
             },
           ],
           user_events: [],
@@ -400,21 +398,16 @@ describe("test AnalyzableOverview", () => {
     ]);
     useAuthStore.mockReturnValue([{ username: "admin" }]);
 
-    window.confirm = jest.fn().mockReturnValue(true);
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
     axios.delete.mockResolvedValue({});
 
     const { container } = render(
       <BrowserRouter>
-        <AnalyzableOverview
-          analyzable={{
-            id: 1,
-            discovery_date: jobDate,
-          }}
-        />
+        <AnalyzableOverview analyzable={{ id: 1, discovery_date: jobDate }} />
       </BrowserRouter>,
     );
     const deleteButton = container.querySelector(
-      "#analyzable-history-delete__13",
+      "#analyzable-history-delete__job__13",
     );
     expect(deleteButton).toBeInTheDocument();
 
@@ -430,5 +423,148 @@ describe("test AnalyzableOverview", () => {
       "success",
     );
     expect(refetch).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  test("AnalyzableOverview delete user event", async () => {
+    const user = userEvent.setup();
+    const refetch = jest.fn();
+    useAxios.mockReturnValue([
+      {
+        data: {
+          jobs: [],
+          user_events: [
+            {
+              id: 6,
+              user: "admin",
+              date: jobDate,
+              data_model: { evaluation: "malicious" },
+            },
+          ],
+          user_domain_wildcard_events: [],
+          user_ip_wildcard_events: [],
+        },
+        loading: false,
+        error: null,
+      },
+      refetch,
+    ]);
+    useAuthStore.mockReturnValue([{ username: "admin" }]);
+
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    axios.delete.mockResolvedValue({});
+
+    const { container } = render(
+      <BrowserRouter>
+        <AnalyzableOverview analyzable={{ id: 1, discovery_date: jobDate }} />
+      </BrowserRouter>,
+    );
+    const deleteButton = container.querySelector(
+      "#analyzable-history-delete__user_evaluation__6",
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    await user.click(deleteButton);
+
+    expect(axios.delete).toHaveBeenCalledWith("/api/user_event/analyzable/6");
+    expect(addToast).toHaveBeenCalledWith(
+      "Entry deleted successfully",
+      null,
+      "success",
+    );
+    expect(refetch).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  test("AnalyzableOverview delete IP wildcard event", async () => {
+    const user = userEvent.setup();
+    const refetch = jest.fn();
+    useAxios.mockReturnValue([
+      {
+        data: {
+          jobs: [],
+          user_events: [],
+          user_domain_wildcard_events: [],
+          user_ip_wildcard_events: [
+            {
+              id: 7,
+              user: "admin",
+              date: jobDate,
+              data_model: { evaluation: "malicious" },
+            },
+          ],
+        },
+        loading: false,
+        error: null,
+      },
+      refetch,
+    ]);
+    useAuthStore.mockReturnValue([{ username: "admin" }]);
+
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    axios.delete.mockResolvedValue({});
+
+    const { container } = render(
+      <BrowserRouter>
+        <AnalyzableOverview analyzable={{ id: 1, discovery_date: jobDate }} />
+      </BrowserRouter>,
+    );
+    const deleteButton = container.querySelector(
+      "#analyzable-history-delete__user_ip_wildcard_evaluation__7",
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    await user.click(deleteButton);
+
+    expect(axios.delete).toHaveBeenCalledWith("/api/user_event/ip_wildcard/7");
+    expect(refetch).toHaveBeenCalled();
+    confirmSpy.mockRestore();
+  });
+
+  test("AnalyzableOverview delete domain wildcard event", async () => {
+    const user = userEvent.setup();
+    const refetch = jest.fn();
+    useAxios.mockReturnValue([
+      {
+        data: {
+          jobs: [],
+          user_events: [],
+          user_domain_wildcard_events: [
+            {
+              id: 8,
+              user: "admin",
+              date: jobDate,
+              data_model: { evaluation: "malicious" },
+            },
+          ],
+          user_ip_wildcard_events: [],
+        },
+        loading: false,
+        error: null,
+      },
+      refetch,
+    ]);
+    useAuthStore.mockReturnValue([{ username: "admin" }]);
+
+    const confirmSpy = jest.spyOn(window, "confirm").mockReturnValue(true);
+    axios.delete.mockResolvedValue({});
+
+    const { container } = render(
+      <BrowserRouter>
+        <AnalyzableOverview analyzable={{ id: 1, discovery_date: jobDate }} />
+      </BrowserRouter>,
+    );
+    const deleteButton = container.querySelector(
+      "#analyzable-history-delete__user_domain_wildcard_evaluation__8",
+    );
+    expect(deleteButton).toBeInTheDocument();
+
+    await user.click(deleteButton);
+
+    expect(axios.delete).toHaveBeenCalledWith(
+      "/api/user_event/domain_wildcard/8",
+    );
+    expect(refetch).toHaveBeenCalled();
+    confirmSpy.mockRestore();
   });
 });


### PR DESCRIPTION
(Issue #3444 )

# Description

This PR implements the ability for users to delete their own entries (Jobs, User Events, and Wildcard Events) directly from the Artifact Overview history table. 

Key changes:
- Created a `handleDelete` function in `AnalyzableOverview.jsx` that supports all history entry types.
- Updated the table configuration in `analyzablesHistoryTableColumns.jsx` to include an "Actions" column with a responsive delete button.
- Restricted deletion permissions so only the record owner can see the delete action.
- Fixed a `react/no-array-index-key` ESLint error in the tags rendering.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

## ScreenShots 
<img width="1900" height="1079" alt="Screenshot 2026-03-17 225245" src="https://github.com/user-attachments/assets/2444b7f8-4df0-4d1c-912b-2815d6dcf7b9" />
<img width="1919" height="1015" alt="image" src="https://github.com/user-attachments/assets/4efd654f-99d5-42fa-9d80-1e356a4a2315" />


# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
