### PR TITLE
fix(forms): assign str.replace() result in _cleaning_and_multiline

### DIFF
--- a/api_app/forms.py
+++ b/api_app/forms.py
@@ -38,8 +38,8 @@ class MultilineJSONField(forms.JSONField):
         if value is not None and "\n" in value:
             cleaned_value = []
             for line in value.splitlines():
-                line.replace("\r", "")
-                line.replace('"', "")
+                line = line.replace("\r", "")
+                line = line.replace('"', "")
                 line = line + "\\n"
                 cleaned_value.append(line)
             value = '"' + "".join(cleaned_value) + '"'


### PR DESCRIPTION
## Description
Fixed a bug in `api_app/forms.py` where `str.replace()` results were being discarded in `_cleaning_and_multiline()`.

Python strings are **immutable** — `.replace()` returns a new string and does not modify in place. The current code calls `line.replace()` without assigning the result back, so carriage returns (`\r`) and double quotes (`"`) are never actually removed.

## Proof

```python
line = 'hello "world"\r'
line.replace("\r", "")         # ❌ line is still 'hello "world"\r'
line = line.replace("\r", "")  # ✅ line is now 'hello "world"'
```

## Changes
- `api_app/forms.py` line 41: `line.replace("\r", "")` → `line = line.replace("\r", "")`
- `api_app/forms.py` line 42: `line.replace('"', "")` → `line = line.replace('"', "")`

## Checklist
- [x] Bug fix (non-breaking change that fixes an issue)
- [x] No new dependencies added
- [x] Minimal 2-line change