### PR TITLE
fix(frontend): rename INVESTIGAITON to INVESTIGATION

### DIFF
--- a/frontend/src/components/history/History.jsx
+++ b/frontend/src/components/history/History.jsx
@@ -30,7 +30,7 @@ export default function History() {
   if (pageType === HistoryPages.JOB) {
     startTimeString = "received_request_time__gte";
     endTimeString = "received_request_time__lte";
-  } else if (pageType === HistoryPages.INVESTIGAITON) {
+  } else if (pageType === HistoryPages.INVESTIGATION) {
     startTimeString = "start_time__gte";
     endTimeString = "start_time__lte";
   }

--- a/frontend/src/components/history/HistoryNav.jsx
+++ b/frontend/src/components/history/HistoryNav.jsx
@@ -17,7 +17,7 @@ export function HistoryNav({ pageType, startTimeParam, endTimeParam }) {
   let createButtonTitle = "New evaluation";
   if (pageType === HistoryPages.JOB) {
     createButtonTitle = "Create job";
-  } else if (pageType === HistoryPages.INVESTIGAITON) {
+  } else if (pageType === HistoryPages.INVESTIGATION) {
     createButtonTitle = "Create Investigation";
   }
 
@@ -29,7 +29,7 @@ export function HistoryNav({ pageType, startTimeParam, endTimeParam }) {
   const onClick = async () => {
     if (pageType === HistoryPages.JOB) {
       navigate("/scan");
-    } else if (pageType === HistoryPages.INVESTIGAITON) {
+    } else if (pageType === HistoryPages.INVESTIGATION) {
       try {
         const investigationId = await createInvestigation();
         if (investigationId) navigate(`/investigation/${investigationId}`);

--- a/frontend/src/components/history/HistoryTable.jsx
+++ b/frontend/src/components/history/HistoryTable.jsx
@@ -66,7 +66,7 @@ export function HistoryTable({ pageType, startTimeParam, endTimeParam }) {
       const newParams = { ...currentParams };
       newParams[startTimeParam] = searchFromDateValue;
       newParams[endTimeParam] = searchToDateValue;
-      if (pageType === HistoryPages.INVESTIGAITON) {
+      if (pageType === HistoryPages.INVESTIGATION) {
         newParams.analyzed_object_name = searchNameRequest;
       }
       setSearchParams(newParams);
@@ -81,7 +81,7 @@ export function HistoryTable({ pageType, startTimeParam, endTimeParam }) {
 
   let tableComponent;
   switch (pageType) {
-    case HistoryPages.INVESTIGAITON:
+    case HistoryPages.INVESTIGATION:
       tableComponent = (
         <InvestigationTable
           searchFromDateValue={searchFromDateValue}

--- a/frontend/src/constants/miscConst.js
+++ b/frontend/src/constants/miscConst.js
@@ -27,7 +27,7 @@ export const localTimezone = Intl.DateTimeFormat().resolvedOptions().timeZone;
 
 export const HistoryPages = Object.freeze({
   JOB: "jobs",
-  INVESTIGAITON: "investigations",
+  INVESTIGATION: "investigations",
   USER_EVENT: "user-events",
   USER_DOMAIN_WILDCARD_EVENT: "user-domain-wildcard-events",
   USER_IP_WILDCARD_EVENT: "user-ip-wildcard-events",


### PR DESCRIPTION
## Summary
- Fixed typo in `HistoryPages.INVESTIGAITON` → `HistoryPages.INVESTIGATION` across all references

## Files Changed (4 files, 6 occurrences)
- `frontend/src/constants/miscConst.js` — constant definition
- `frontend/src/components/history/History.jsx` — 1 reference
- `frontend/src/components/history/HistoryNav.jsx` — 2 references
- `frontend/src/components/history/HistoryTable.jsx` — 2 references

## Notes
This is a non-breaking rename of an internal constant key. The string value `"investigations"` (used for routing) remains unchanged — only the JavaScript property name is corrected.

## Checklist
- [x] Typo fix only — no logic changes
- [x] All references updated consistently
- [x] No breaking changes (value unchanged, only key name fixed)