### PR TITLE
fix(forms): assign str.replace() result in _cleaning_and_multiline. Closes #3513

### DIFF
--- a/api_app/forms.py
+++ b/api_app/forms.py
@@ -38,8 +38,8 @@ class MultilineJSONField(forms.JSONField):
         if value is not None and "\n" in value:
             cleaned_value = []
             for line in value.splitlines():
-                line.replace("\r", "")
-                line.replace('"', "")
+                line = line.replace("\r", "")
+                line = line.replace('"', "")
                 line = line + "\\n"
                 cleaned_value.append(line)
             value = '"' + "".join(cleaned_value) + '"'


### PR DESCRIPTION
# Description

Fixed a bug in `api_app/forms.py` where `str.replace()` results were being discarded in `_cleaning_and_multiline()`.

Python strings are **immutable** — `.replace()` returns a new string and does not modify in place. The current code calls `line.replace()` without assigning the result back, so carriage returns (`\r`) and double quotes (`"`) are never actually removed from multiline JSON input.

Closes #3513

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case: *(N/A — no plugin changes)*
- [x] I have inserted the copyright banner at the start of the file: *(file already has no banner — no new files created)*
- [x] Please avoid adding new libraries as requirements whenever it is possible. *(No new libraries added)*
- [x] Linters (`Ruff`) gave 0 errors.
- [ ] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified: *(N/A — no GUI changes)*
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.