### PR TITLE
fix: use Django's built-in password validators instead of custom regex. Closes #3385

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -193,7 +193,7 @@ class RegistrationSerializer(rest_email_auth.serializers.RegistrationSerializer)
 
     def validate_password(self, password):
         """
-        Validate the user's password against a regex pattern.
+        Validate the user's password using Django's built-in validators.
 
         Args:
             password (str): The password to validate.
@@ -202,10 +202,18 @@ class RegistrationSerializer(rest_email_auth.serializers.RegistrationSerializer)
             str: The validated password.
 
         Raises:
-            ValidationError: If the password does not match the regex pattern.
+            ValidationError: If the password fails validation.
         """
         super().validate_password(password)
-        validate_password_strength(password)
+        # Create a temporary user instance with initial data for UserAttributeSimilarityValidator
+        # This allows checking if password is too similar to username, email, etc.
+        temp_user = User(
+            username=self.initial_data.get("username", ""),
+            email=self.initial_data.get("email", ""),
+            first_name=self.initial_data.get("first_name", ""),
+            last_name=self.initial_data.get("last_name", ""),
+        )
+        validate_password_strength(password, user=temp_user)
         return password
 
     def create(self, validated_data):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -183,14 +183,18 @@ class ChangePasswordView(APIView):
         old_password = request.data.get("old_password")
         new_password = request.data.get("new_password")
 
-        # Validate new password strength
+        # Check if new password is provided
+        if not new_password:
+            return Response({"error": "New password is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Validate new password strength with user context for UserAttributeSimilarityValidator
+        user = request.user
         try:
-            validate_password_strength(new_password)
+            validate_password_strength(new_password, user=user)
         except ValidationError as e:
-            return Response({"error": e.message}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": str(e.message)}, status=status.HTTP_400_BAD_REQUEST)
 
         # Check if the old password matches the user's current password
-        user = request.user
         uname = user.username
         if not check_password(old_password, user.password):
             logger.info(f"'{uname}' has inputted invalid old password.")

--- a/intel_owl/consts.py
+++ b/intel_owl/consts.py
@@ -1,19 +1,29 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import re
-
+from django.contrib.auth.password_validation import validate_password as django_validate_password
 from django.core.exceptions import ValidationError
 
 REGEX_EMAIL = r"^[\w\.\+\-]+\@[\w]+\.[a-z]{2,3}$"
 REGEX_CVE = r"CVE-\d{4}-\d{4,7}"
-REGEX_PASSWORD = r"^[a-zA-Z0-9]{12,}$"
 
 
-def validate_password_strength(password: str) -> None:
-    """Validate password against REGEX_PASSWORD. Raises ValidationError if invalid."""
-    if not re.match(REGEX_PASSWORD, password):
-        raise ValidationError("Invalid password")
+def validate_password_strength(password: str, user=None) -> None:
+    """Validate password using Django's built-in validators.
+
+    Uses AUTH_PASSWORD_VALIDATORS from settings which includes:
+    - UserAttributeSimilarityValidator (requires user context)
+    - MinimumLengthValidator (12 characters)
+    - CommonPasswordValidator
+    - NumericPasswordValidator
+
+    Raises ValidationError if password is invalid.
+    """
+    try:
+        django_validate_password(password, user=user)
+    except ValidationError as e:
+        # Re-raise with combined error messages
+        raise ValidationError("; ".join(e.messages))
 
 
 DEFAULT_SOFT_TIME_LIMIT = 300

--- a/intel_owl/settings/auth.py
+++ b/intel_owl/settings/auth.py
@@ -19,6 +19,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": 12},
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -10,7 +10,7 @@ class CustomOAuthTestCase(APITestCase):
         # test data
         username = "john.doe"
         email = "john.doe@example.com"
-        password = "hunter2"
+        password = "verySecureTestPassword123"
         try:
             cls.user = User.objects.get(
                 username=username,

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -26,13 +26,16 @@ change_password_uri = reverse("auth_changepassword")
 @tag("api", "user")
 class TestUserAuth(CustomOAuthTestCase):
     def setUp(self):
+        # Reset user password before each test to ensure independence
+        self.user.set_password("verySecureTestPassword123")
+        self.user.save()
         # test data
         self.testregisteruser = {
             "email": "testregisteruser@test.com",
             "username": "testregisteruser",
             "first_name": "testregisteruser",
             "last_name": "testregisteruser",
-            "password": "testregisteruser",
+            "password": "MyComplexP@ssw0rd!",
             "profile": {
                 "company_name": "companytest",
                 "company_role": "intelowl test",
@@ -230,13 +233,13 @@ class TestUserAuth(CustomOAuthTestCase):
         self.assertTrue(user.check_password(new_password), msg=msg)
 
     def test_change_password_200(self):
-        new_password = "veryStrongPassword123"
+        new_password = "veryStrongPassword456"
 
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": new_password,
             },
         )
@@ -252,7 +255,7 @@ class TestUserAuth(CustomOAuthTestCase):
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": "weak",
             },
         )
@@ -260,27 +263,32 @@ class TestUserAuth(CustomOAuthTestCase):
         msg = (response, content)
 
         self.assertEqual(400, response.status_code, msg=msg)
-        self.assertIn("Invalid password", content["error"], msg=msg)
+        self.assertIn("too short", content["error"], msg=msg)
 
-    def test_change_password_special_chars_400(self):
+    def test_change_password_special_chars_200(self):
+        """Test that passwords with special characters are now allowed."""
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": "intelowlintelowl$",
             },
         )
         content = response.json()
         msg = (response, content)
 
-        self.assertEqual(400, response.status_code, msg=msg)
-        self.assertIn("Invalid password", content["error"], msg=msg)
+        self.assertEqual(200, response.status_code, msg=msg)
+        self.user.refresh_from_db()
+        self.assertTrue(
+            self.user.check_password("intelowlintelowl$"),
+            msg="Password with special characters should be accepted",
+        )
 
     def test_min_password_lenght_400(self):
         current_users = User.objects.count()
 
-        # register new user with invalid password
+        # register new user with invalid password (too short)
         body = {
             **self.creds,
             "email": self.testregisteruser["email"],
@@ -296,35 +304,78 @@ class TestUserAuth(CustomOAuthTestCase):
         # response assertions
         self.assertEqual(400, response.status_code)
         self.assertIn(
-            "Invalid password",
-            content["errors"]["password"],
+            "too short",
+            content["errors"]["password"][0],
         )
 
         # db assertions
         self.assertEqual(User.objects.count(), current_users, msg="no new user was created")
 
-    def test_special_characters_password_400(self):
+    def test_special_characters_password_201(self):
+        """Test that passwords with special characters are now allowed during registration."""
         current_users = User.objects.count()
 
-        # register new user with invalid password
         body = {
-            **self.creds,
-            "email": self.testregisteruser["email"],
-            "username": "blahblah",
-            "first_name": "blahblah",
-            "last_name": "blahblah",
+            "email": "specialchars@test.com",
+            "username": "specialcharsuser",
+            "first_name": "SpecialChars",
+            "last_name": "User",
             "password": "intelowlintelowl$",
+            "profile": self.testregisteruser["profile"],
         }
 
-        response = self.client.post(register_uri, body)
+        response = self.client.post(register_uri, body, format="json")
         content = response.json()
 
-        # response assertions
+        # response assertions - special characters should now be allowed
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(content["username"], body["username"])
+
+        # db assertions
+        self.assertEqual(User.objects.count(), current_users + 1, msg="new user was created")
+
+    def test_password_similar_to_username_400(self):
+        """Test that passwords too similar to username are rejected."""
+        current_users = User.objects.count()
+
+        body = {
+            "email": "similarpass@test.com",
+            "username": "mysecureusername",
+            "first_name": "Test",
+            "last_name": "User",
+            "password": "mysecureusername",  # Same as username
+            "profile": self.testregisteruser["profile"],
+        }
+
+        response = self.client.post(register_uri, body, format="json")
+        content = response.json()
+
+        # response assertions - password too similar to username should be rejected
         self.assertEqual(400, response.status_code)
-        self.assertIn(
-            "Invalid password",
-            content["errors"]["password"],
-        )
+        self.assertIn("too similar", content["errors"]["password"][0])
+
+        # db assertions
+        self.assertEqual(User.objects.count(), current_users, msg="no new user was created")
+
+    def test_common_password_400(self):
+        """Test that common passwords are rejected."""
+        current_users = User.objects.count()
+
+        body = {
+            "email": "commonpass@test.com",
+            "username": "commonpassuser",
+            "first_name": "Test",
+            "last_name": "User",
+            "password": "password1234",  # Common password
+            "profile": self.testregisteruser["profile"],
+        }
+
+        response = self.client.post(register_uri, body, format="json")
+        content = response.json()
+
+        # response assertions - common password should be rejected
+        self.assertEqual(400, response.status_code)
+        self.assertIn("too common", content["errors"]["password"][0])
 
         # db assertions
         self.assertEqual(User.objects.count(), current_users, msg="no new user was created")


### PR DESCRIPTION
# Description

This PR replaces the custom `REGEX_PASSWORD` pattern with Django's built-in password validation system as suggested by @mlodic in issue #3385.

## Problem
The current custom regex `r"^[a-zA-Z0-9]{12,}$"` has two main security issues:
- **Too permissive**: Accepts weak passwords like `aaaaaaaaaaaa` (all same characters)
- **Too restrictive**: Blocks special characters entirely, preventing stronger passwords like `MyP@ssw0rd!`

## Solution
Replaced custom regex validation with Django's `django.contrib.auth.password_validation.validate_password`, which leverages the configured `AUTH_PASSWORD_VALIDATORS`:
- `UserAttributeSimilarityValidator` - Prevents passwords too similar to username/email
- `MinimumLengthValidator` - Enforces 12-character minimum (maintains existing policy)
- `CommonPasswordValidator` - Rejects commonly used passwords
- `NumericPasswordValidator` - Prevents purely numeric passwords

## Changes Made
- **`intel_owl/consts.py`**: Removed `REGEX_PASSWORD`, replaced `validate_password_strength()` with Django's validator
- **`intel_owl/settings/auth.py`**: Set `MinimumLengthValidator` to 12 characters
- **`authentication/serializers.py`**: Pass user context to validators during registration for similarity checks
- **`authentication/views.py`**: Pass user context in `ChangePasswordView`, added null check for new password
- **`tests/auth/__init__.py`**: Updated test user password to meet new validation requirements
- **`tests/auth/test_auth.py`**: Updated test expectations (special chars now allowed), added password reset in setUp, added new validator tests

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed (N/A - no plugins modified)
- [x] I have inserted the copyright banner at the start of the file (already present in all modified files)
- [x] Please avoid adding new libraries as requirements whenever it is possible (no new libraries added)
- [ ] If external libraries/packages with restrictive licenses were added (N/A)
- [x] Linters (`Ruff`) gave 0 errors (pre-commit hooks passed)
- [x] I have added tests for the feature/bug I solved - All 15 auth tests pass
- [ ] If the GUI has been modified (N/A)
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts (will address if any arise)
- [x] I have addressed raised Copilot issues (will address if any arise)
- [ ] I have reviewed and verified any LLM-generated code included in this PR. Also, I have explicitly stated that I have used LLMs in this PR.

## Testing
All 15 authentication tests pass:
- `test_change_password_200` - Password change with valid password
-  `test_change_password_special_chars_200` - Special characters now accepted
-  `test_change_password_weak_password_400` - Weak passwords rejected
-  `test_common_password_400` - Common passwords rejected
-  `test_password_similar_to_username_400` - Similar passwords rejected
-  `test_min_password_lenght_400` - Short passwords rejected
-  `test_special_characters_password_201` - Special chars accepted in registration
- All existing tests continue to pass