### PR TITLE
feat: encrypt secrets at rest using Fernet (#1639)

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/yara_scan.py
+++ b/api_app/analyzers_manager/file_analyzers/yara_scan.py
@@ -373,14 +373,15 @@ class YaraScan(FileAnalyzer):
             parameter__name="private_repositories",
             parameter__python_module=cls.python_module,
         ):
-            if not plugin.value:
+            plugin_value = plugin.decrypted_value
+            if not plugin_value:
                 continue
             owner = (
                 f"{plugin.organization.name}.{plugin.organization.owner}"
                 if plugin.for_organization
                 else plugin.owner.username
             )
-            for url, ssh_key in plugin.value.items():
+            for url, ssh_key in plugin_value.items():
                 logger.info(f"Adding personal private url {url}")
                 storage.add_repo(url, owner, ssh_key)
 

--- a/api_app/classes.py
+++ b/api_app/classes.py
@@ -149,10 +149,13 @@ class Plugin(metaclass=ABCMeta):
         self.__parameters = self._config.read_configured_params(self._user, runtime_configuration)
         for parameter in self.__parameters:
             attribute_name = f"_{parameter.name}" if parameter.is_secret else parameter.name
-            setattr(self, attribute_name, parameter.value)
-            logger.debug(
-                f"Adding to {self.__class__.__name__} param {attribute_name} with value {parameter.value} "
-            )
+            param_value = parameter.value
+            if parameter.is_secret and param_value is not None:
+                from api_app.crypto import decrypt_secret
+
+                param_value = decrypt_secret(param_value)
+            setattr(self, attribute_name, param_value)
+            logger.debug(f"Adding to {self.__class__.__name__} param {attribute_name}")
 
     def before_run(self):
         """

--- a/api_app/crypto.py
+++ b/api_app/crypto.py
@@ -1,0 +1,53 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+# encryption/decryption utilities for storing secrets at rest
+
+import base64
+import hashlib
+import json
+import logging
+from functools import lru_cache
+
+from cryptography.fernet import Fernet, InvalidToken
+from django.conf import settings
+
+logger = logging.getLogger(__name__)
+
+ENCRYPTED_PREFIX = "enc::"
+
+
+@lru_cache(maxsize=1)
+def _get_fernet() -> Fernet:
+    key_material = settings.SECRET_KEY.encode()
+    # Fernet needs a 32-byte url-safe base64-encoded key
+    derived = hashlib.pbkdf2_hmac(
+        "sha256",
+        key_material,
+        salt=b"intelowl-secrets-encryption",
+        iterations=100_000,
+    )
+    fernet_key = base64.urlsafe_b64encode(derived[:32])
+    return Fernet(fernet_key)
+
+
+def encrypt_secret(value) -> str:
+    if isinstance(value, str) and value.startswith(ENCRYPTED_PREFIX):
+        return value
+
+    plaintext = json.dumps(value).encode()
+    token = _get_fernet().encrypt(plaintext)
+    return ENCRYPTED_PREFIX + token.decode()
+
+
+def decrypt_secret(value):
+    if not isinstance(value, str) or not value.startswith(ENCRYPTED_PREFIX):
+        return value
+
+    token = value[len(ENCRYPTED_PREFIX) :].encode()
+    try:
+        plaintext = _get_fernet().decrypt(token)
+        return json.loads(plaintext)
+    except (InvalidToken, json.JSONDecodeError):
+        logger.error("failed to decrypt secret, returning raw value")
+        return value

--- a/api_app/migrations/0073_encrypt_existing_secrets.py
+++ b/api_app/migrations/0073_encrypt_existing_secrets.py
@@ -1,0 +1,37 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.db import migrations
+
+
+def encrypt_existing_secrets(apps, schema_editor):
+    from api_app.crypto import ENCRYPTED_PREFIX, encrypt_secret
+
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    for pc in PluginConfig.objects.filter(parameter__is_secret=True):
+        if pc.value is not None and not (isinstance(pc.value, str) and pc.value.startswith(ENCRYPTED_PREFIX)):
+            pc.value = encrypt_secret(pc.value)
+            pc.save(update_fields=["value"])
+
+
+def decrypt_existing_secrets(apps, schema_editor):
+    from api_app.crypto import ENCRYPTED_PREFIX, decrypt_secret
+
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    for pc in PluginConfig.objects.filter(parameter__is_secret=True):
+        if pc.value is not None and isinstance(pc.value, str) and pc.value.startswith(ENCRYPTED_PREFIX):
+            pc.value = decrypt_secret(pc.value)
+            pc.save(update_fields=["value"])
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("api_app", "0071_delete_last_elastic_report"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            encrypt_existing_secrets,
+            reverse_code=decrypt_existing_secrets,
+        ),
+    ]

--- a/api_app/models.py
+++ b/api_app/models.py
@@ -1020,6 +1020,21 @@ class PluginConfig(OwnershipAbstractModel):
         return self.parameter.is_secret
 
     @property
+    def decrypted_value(self):
+        if self.is_secret():
+            from api_app.crypto import decrypt_secret
+
+            return decrypt_secret(self.value)
+        return self.value
+
+    def save(self, *args, **kwargs):
+        if self.parameter_id and self.parameter.is_secret and self.value is not None:
+            from api_app.crypto import encrypt_secret
+
+            self.value = encrypt_secret(self.value)
+        super().save(*args, **kwargs)
+
+    @property
     def plugin_name(self):
         """Returns the name of the plugin associated with this configuration."""
         return self.config.name

--- a/api_app/serializers/plugin.py
+++ b/api_app/serializers/plugin.py
@@ -67,6 +67,8 @@ class PluginConfigSerializer(ModelWithOwnershipSerializer, rfs.ModelSerializer):
                 )
             ):
                 return "redacted"
+            if instance.is_secret():
+                return instance.decrypted_value
             return super().get_attribute(instance)
 
         def to_representation(self, value):
@@ -198,6 +200,10 @@ class ParameterSerializer(rfs.ModelSerializer):
         if hasattr(param, "value") and hasattr(param, "is_from_org"):
             if param.is_secret and param.is_from_org:
                 return "redacted"
+            if param.is_secret and param.value is not None:
+                from api_app.crypto import decrypt_secret
+
+                return decrypt_secret(param.value)
             return param.value
 
 

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -111,6 +111,9 @@ defusedxml==0.7.1
 # required by MalwareBazaar Ingestor -> https://bazaar.abuse.ch/api/#download (read the warning)
 pyzipper==0.3.6
 
+# encryption for secrets at rest (issue #1639)
+cryptography>=42.0.0
+
 # others
 dateparser==1.2.0
 DeepDiff==8.6.1

--- a/tests/api_app/test_crypto.py
+++ b/tests/api_app/test_crypto.py
@@ -1,0 +1,105 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.choices import PythonModuleBasePaths
+from api_app.crypto import ENCRYPTED_PREFIX, decrypt_secret, encrypt_secret
+from api_app.models import Parameter, PluginConfig
+from tests import CustomTestCase
+
+
+class EncryptDecryptTestCase(CustomTestCase):
+    def test_roundtrip(self):
+        for value in ["abc123", 42, ["a", "b"], {"k": "v"}]:
+            enc = encrypt_secret(value)
+            self.assertTrue(enc.startswith(ENCRYPTED_PREFIX))
+            self.assertEqual(decrypt_secret(enc), value)
+
+    def test_prefix(self):
+        self.assertTrue(encrypt_secret("x").startswith(ENCRYPTED_PREFIX))
+
+    def test_plain_passthrough(self):
+        for val in ["hello", 0, None, [], {}]:
+            self.assertEqual(decrypt_secret(val), val)
+
+    def test_no_double_encrypt(self):
+        enc = encrypt_secret("test")
+        self.assertEqual(encrypt_secret(enc), enc)
+
+
+class PluginConfigEncryptionTestCase(CustomTestCase):
+    def _get_analyzer_config(self):
+        return AnalyzerConfig.objects.filter(
+            python_module__base_path=PythonModuleBasePaths.FileAnalyzer.value,
+        ).first()
+
+    def test_secret_is_encrypted_on_save(self):
+        ac = self._get_analyzer_config()
+        param = Parameter.objects.create(
+            name="test_enc",
+            python_module=ac.python_module,
+            is_secret=True,
+            required=False,
+            type="str",
+        )
+        pc = PluginConfig.objects.create(
+            owner=self.user,
+            for_organization=False,
+            parameter=param,
+            value="s3cret",
+            analyzer_config=ac,
+        )
+        try:
+            pc.refresh_from_db()
+            self.assertTrue(pc.value.startswith(ENCRYPTED_PREFIX))
+            self.assertEqual(pc.decrypted_value, "s3cret")
+        finally:
+            pc.delete()
+            param.delete()
+
+    def test_non_secret_stays_plain(self):
+        ac = self._get_analyzer_config()
+        param = Parameter.objects.create(
+            name="test_plain",
+            python_module=ac.python_module,
+            is_secret=False,
+            required=False,
+            type="str",
+        )
+        pc = PluginConfig.objects.create(
+            owner=self.user,
+            for_organization=False,
+            parameter=param,
+            value="visible",
+            analyzer_config=ac,
+        )
+        try:
+            pc.refresh_from_db()
+            self.assertEqual(pc.value, "visible")
+            self.assertEqual(pc.decrypted_value, "visible")
+        finally:
+            pc.delete()
+            param.delete()
+
+    def test_decrypted_value(self):
+        ac = self._get_analyzer_config()
+        param = Parameter.objects.create(
+            name="test_dec",
+            python_module=ac.python_module,
+            is_secret=True,
+            required=False,
+            type="str",
+        )
+        pc = PluginConfig.objects.create(
+            owner=self.user,
+            for_organization=False,
+            parameter=param,
+            value="tok3n",
+            analyzer_config=ac,
+        )
+        try:
+            pc.refresh_from_db()
+            self.assertEqual(pc.decrypted_value, "tok3n")
+        finally:
+            pc.delete()
+            param.delete()


### PR DESCRIPTION
Closes #1639

# Description
Please include a summary of the change and fix in the related issue.
Secrets stored in `PluginConfig.value` are now encrypted at rest using Fernet symmetric encryption. The encryption key is derived from `SECRET_KEY` via PBKDF2-HMAC-SHA256. Existing plain-text secrets are migrated automatically via a data migration.

# Summary
1. Added a new crypto.py utility to handle secret encryption and decryption using Fernet, with an enc:: prefix to distinguish encrypted values
2. Modified PluginConfig.save() so that any secret values are automatically encrypted before being stored in the database
3. Introduced a decrypted_value property in PluginConfig to seamlessly decrypt values when accessed
4. Updated serializers and plugin configuration logic to ensure secrets are decrypted only for authorized users
5. Created a reversible data migration (0073) to encrypt any existing plain-text secrets
6. Added cryptography>=42.0.0 as a dependency
7. Wrote 7 unit tests covering encryption/decryption flow, backward compatibility, and integration with the model

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute].(https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project.
- [x] The pull request is for the branch `develop`.
- [x] I have added tests for the changes I made (if applicable).
- [x] The tests I have added pass locally with my changes.
- [x] I have added the required documentation (if applicable).