### PR TITLE
fix: normalize hash type in MISP connector. Closes #3537

### DIFF
--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -62,8 +62,8 @@ class MISP(Connector):
             value = self._job.analyzable.name
             if _type == Classification.HASH:
                 matched_type = helpers.get_hash_type(value)
-                matched_type.replace("-", "")  # convert sha-x to shax
-                _type = matched_type if matched_type is not None else "text"
+                # convert sha-x to shax
+                _type = matched_type.replace("-", "") if matched_type is not None else "text"
             else:
                 _type = INTELOWL_MISP_TYPE_MAP[_type]
 


### PR DESCRIPTION
# Description

Closes #3537

In `_base_attr_obj`, `str.replace()` was called but its return value was 
never assigned. Since strings are immutable in Python, `matched_type` 
remained unchanged — so a hash like `sha-256` was never converted to 
`sha256`, which is the format MISP expects as a valid attribute type.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).


# Checklist

- [x] I have read and understood the rules about [how to Contribute]
- [x] The pull request is for the branch `develop`
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit]