### PR TITLE
fix: avoid double call to _base_attr_obj in MISP connector. Closes #3545

### DIFF
--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -109,14 +109,15 @@ class MISP(Connector):
 
         # get event and attributes
         event = self._event_obj
+        base_attr = self._base_attr_obj
         attributes = [
-            self._base_attr_obj,
+            base_attr,
             *self._secondary_attr_objs,
             self._link_attr_obj,
         ]
 
         # append attribute name to event info
-        event.info += f": {self._base_attr_obj.value}"
+        event.info += f": {base_attr.value}"
 
         # add event to MISP Instance
         misp_event = misp_instance.add_event(event, pythonify=True)


### PR DESCRIPTION
# Description
Closes #3545

`_base_attr_obj` is a `@property` that hits the DB via 
`.analyzers_to_execute.all()` each time it is accessed. In `run()` it was 
called twice — once when building the attributes list and again to append 
`.value` to `event.info`. The second object was immediately discarded.

Fixed by storing the result in a local variable and reusing it.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
(https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
