### PR TITLE
feat: Optimize UserEvent decay by refactoring for ForeignKey and GenericForeignKey relationships, and adding reliability safeguards.

### DIFF
--- a/api_app/user_events_manager/queryset.py
+++ b/api_app/user_events_manager/queryset.py
@@ -1,5 +1,7 @@
 import datetime
+from collections import defaultdict
 
+from django.db import transaction
 from django.db.models import F, Q, QuerySet, Value
 from django.db.models.lookups import IRegex, Range
 from django.utils.timezone import now
@@ -11,10 +13,6 @@ from api_app.user_events_manager.choices import DecayProgressionEnum
 
 class UserEventQuerySet(QuerySet):
     def decay(self):
-        from collections import defaultdict
-
-        from django.db import transaction
-
         objects = (
             self.exclude(decay_progression=DecayProgressionEnum.FIXED.value)
             .exclude(next_decay__isnull=True)
@@ -22,44 +20,106 @@ class UserEventQuerySet(QuerySet):
                 next_decay__lte=now(),
             )
         )
+
+        if not objects.exists():
+            return 0
+
         # ForeignKey appears in _meta.fields (wildcard models) -> use JOIN.
         # GenericForeignKey does not (UserAnalyzableEvent) -> use prefetch.
         model_fields = {field.name for field in self.model._meta.fields}
         if "data_model" in model_fields:
-            objects = objects.select_related("data_model")
+            return self._decay_with_fk(objects)
         else:
-            objects = objects.prefetch_related("data_model")
+            return self._decay_with_gfk(objects)
 
-        # Load into memory so we can mutate fields and bulk-write back.
-        events = list(objects)
+    def _decay_with_fk(self, objects):
+        """
+        Decay for wildcard events whose data_model is a real ForeignKey.
+        Uses select_related + bulk_update for efficiency.
+        """
+        events = list(objects.select_related("data_model"))
         if not events:
             return 0
 
-        # Group by concrete class since bulk_update works per-table.
-        data_models_by_class = defaultdict(list)
+        # Deduplicate by PK: select_related yields distinct objects per event;
+        # this ensures shared DB rows decrement exactly once per cycle.
+        data_models_by_pk = {}
 
-        for obj in events:
-            obj.decay_times += 1
-            data_model = obj.data_model
+        for event in events:
+            event.decay_times += 1
+            data_model = event.data_model
 
             if data_model is not None:
-                data_model.reliability -= 1
+                if data_model.pk not in data_models_by_pk:
+                    data_models_by_pk[data_model.pk] = data_model
+                    if data_model.reliability > 0:
+                        data_model.reliability -= 1
+                else:
+                    # Reuse the already-decremented object so bulk_update
+                    # writes the correct value.
+                    data_model = data_models_by_pk[data_model.pk]
 
-            if data_model is None or data_model.reliability == 0:
-                obj.next_decay = None
+            # Use <= 0 to guard against reliability that is already 0
+            if data_model is None or data_model.reliability <= 0:
+                event.next_decay = None
             else:
-                if obj.decay_progression == DecayProgressionEnum.LINEAR.value:
-                    obj.next_decay += datetime.timedelta(days=obj.decay_timedelta_days)
-                elif obj.decay_progression == DecayProgressionEnum.INVERSE_EXPONENTIAL.value:
-                    obj.next_decay += datetime.timedelta(
-                        days=obj.decay_timedelta_days ** (obj.decay_times + 1)
+                if event.decay_progression == DecayProgressionEnum.LINEAR.value:
+                    event.next_decay += datetime.timedelta(days=event.decay_timedelta_days)
+                elif event.decay_progression == DecayProgressionEnum.INVERSE_EXPONENTIAL.value:
+                    event.next_decay += datetime.timedelta(
+                        days=event.decay_timedelta_days ** (event.decay_times + 1)
                     )
 
-            if data_model is not None:
-                data_models_by_class[data_model.__class__].append(data_model)
+        with transaction.atomic():
+            if data_models_by_pk:
+                type(next(iter(data_models_by_pk.values()))).objects.bulk_update(
+                    data_models_by_pk.values(), ["reliability"]
+                )
+            self.model.objects.bulk_update(events, ["decay_times", "next_decay"])
 
-        # Bulk-write instead of per-object .save() to avoid O(N) queries.
-        # Atomic so partial failures don't leave inconsistent state.
+        return len(events)
+
+    def _decay_with_gfk(self, objects):
+        """
+        Decay for analyzable events whose data_model is a GenericForeignKey.
+        GenericForeignKey cannot be traversed by F() expressions in SQL,
+        so we use prefetch_related and bulk_update grouped by concrete class.
+        """
+        events = list(objects.prefetch_related("data_model"))
+        if not events:
+            return 0
+
+        # Deduplicate by (class, pk): prefetch_related yields distinct objects
+        # per event; this ensures shared DB rows decrement exactly once.
+        data_models_by_class_pk = {}  # {(class, pk): data_model_obj}
+        data_models_by_class = defaultdict(list)
+
+        for event in events:
+            event.decay_times += 1
+            data_model = event.data_model
+
+            if data_model is not None:
+                key = (data_model.__class__, data_model.pk)
+                if key not in data_models_by_class_pk:
+                    data_models_by_class_pk[key] = data_model
+                    if data_model.reliability > 0:
+                        data_model.reliability -= 1
+                    data_models_by_class[data_model.__class__].append(data_model)
+                else:
+                    # Reuse the already-decremented object.
+                    data_model = data_models_by_class_pk[key]
+
+            # Use <= 0 to guard against reliability that is already 0.
+            if data_model is None or data_model.reliability <= 0:
+                event.next_decay = None
+            else:
+                if event.decay_progression == DecayProgressionEnum.LINEAR.value:
+                    event.next_decay += datetime.timedelta(days=event.decay_timedelta_days)
+                elif event.decay_progression == DecayProgressionEnum.INVERSE_EXPONENTIAL.value:
+                    event.next_decay += datetime.timedelta(
+                        days=event.decay_timedelta_days ** (event.decay_times + 1)
+                    )
+
         with transaction.atomic():
             for model_class, models_list in data_models_by_class.items():
                 unique_models = {m.pk: m for m in models_list}.values()

--- a/tests/api_app/user_events_manager/test_queryset.py
+++ b/tests/api_app/user_events_manager/test_queryset.py
@@ -1,5 +1,7 @@
 import datetime
 
+from django.db import connection
+from django.test.utils import CaptureQueriesContext
 from django.utils.timezone import now
 
 from api_app.analyzables_manager.models import Analyzable
@@ -230,6 +232,128 @@ class TestUserAnalyzableEventQuerySet(CustomTestCase):
     def test_decay_no_events(self):
         number = UserAnalyzableEvent.objects.none().decay()
         self.assertEqual(number, 0)
+
+    def test_decay_reliability_zero_does_not_crash(self):
+        an = Analyzable.objects.create(
+            name="test_reliability_crash.com",
+            classification=Classification.DOMAIN,
+        )
+        ue = UserAnalyzableEventSerializer(
+            data={
+                "analyzable": {"name": an.name},
+                "decay_progression": DecayProgressionEnum.LINEAR.value,
+                "decay_timedelta_days": 7,
+                "data_model_content": {"evaluation": "malicious", "reliability": 1},
+            },
+            context={"request": MockUpRequest(self.user)},
+        )
+        ue.is_valid(raise_exception=True)
+        ua = ue.save()
+        ua.next_decay = now() - datetime.timedelta(days=1)
+        ua.save()
+
+        # First decay: reliability 1 -> 0, next_decay -> None
+        ua.__class__.objects.filter(pk=ua.pk).decay()
+        ua.refresh_from_db()
+        self.assertEqual(ua.data_model.reliability, 0)
+        self.assertIsNone(ua.next_decay)
+
+        # Simulate race: reliability=0 but next_decay re-activated
+        ua.next_decay = now() - datetime.timedelta(days=1)
+        ua.save()
+
+        # Should NOT raise IntegrityError; should safely null next_decay
+        ua.__class__.objects.filter(pk=ua.pk).decay()
+
+        ua.refresh_from_db()
+        self.assertIsNone(ua.next_decay)
+        self.assertGreaterEqual(ua.data_model.reliability, 0)
+
+        ua.delete()
+        an.delete()
+
+
+class TestUserDomainWildCardEventQuerySetQueryCount(CustomTestCase):
+    def test_decay_query_count_is_constant(self):
+        # Ensures decay() uses bulk queries (O(1)), not per-object .save() (O(N)).
+        events = []
+        for i in range(3):
+            ue = UserDomainWildCardEventSerializer(
+                data={
+                    "query": rf".*\.querycount{i}\.com",
+                    "decay_progression": DecayProgressionEnum.LINEAR.value,
+                    "decay_timedelta_days": 7,
+                    "data_model_content": {"evaluation": "malicious", "reliability": 5},
+                },
+                context={"request": MockUpRequest(self.user)},
+            )
+            ue.is_valid(raise_exception=True)
+            ua = ue.save()
+            ua.next_decay = now() - datetime.timedelta(days=1)
+            ua.save()
+            events.append(ua)
+
+        pks = [e.pk for e in events]
+
+        with CaptureQueriesContext(connection) as ctx:
+            count = UserDomainWildCardEvent.objects.filter(pk__in=pks).decay()
+
+        real_queries = [q for q in ctx.captured_queries if not q["sql"].strip().upper().startswith("EXPLAIN")]
+        num_queries = len(real_queries)
+        update_queries = [q for q in real_queries if q["sql"].strip().upper().startswith("UPDATE")]
+
+        self.assertEqual(count, 3)
+        # O(1): expect at most 6 queries (generous bound for savepoint variants)
+        self.assertLessEqual(
+            num_queries,
+            6,
+            f"decay() used {num_queries} queries for N=3 events. "
+            f"N+1 approach would use 7. Queries: " + "; ".join(q["sql"][:80] for q in real_queries),
+        )
+        # Specifically: at most 2 UPDATEs (one per bulk_update call)
+        self.assertLessEqual(
+            len(update_queries),
+            2,
+            f"Expected at most 2 UPDATE queries (bulk), got {len(update_queries)}. "
+            f"Per-object .save() would produce {3 * 2} UPDATEs.",
+        )
+
+        for ua in events:
+            ua.delete()
+
+    def test_decay_shared_data_model_reliability_decrements_correctly(self):
+        # Shared data_model should decrement exactly once per decay cycle, not once per event.
+        ue1 = UserDomainWildCardEventSerializer(
+            data={
+                "query": r".*\.shared1\.com",
+                "decay_progression": DecayProgressionEnum.LINEAR.value,
+                "decay_timedelta_days": 7,
+                "data_model_content": {"evaluation": "malicious", "reliability": 5},
+            },
+            context={"request": MockUpRequest(self.user)},
+        )
+        ue1.is_valid(raise_exception=True)
+        ua1 = ue1.save()
+
+        # Create ua2 directly, sharing ua1's data_model from the start
+        ua2 = UserDomainWildCardEvent(
+            user=self.user,
+            query=r".*\.shared2\.com",
+            decay_progression=DecayProgressionEnum.LINEAR.value,
+            decay_timedelta_days=7,
+            data_model=ua1.data_model,
+        )
+        ua2.save()
+
+        for ua in [ua1, ua2]:
+            ua.next_decay = now() - datetime.timedelta(days=1)
+            ua.save()
+
+        UserDomainWildCardEvent.objects.filter(pk__in=[ua1.pk, ua2.pk]).decay()
+
+        ua1.refresh_from_db()
+        # After dedup fix: one shared row decrements exactly once (5 -> 4)
+        self.assertEqual(ua1.data_model.reliability, 4)
 
 
 class TestUserDomainWildCardEventQuerySet(CustomTestCase):


### PR DESCRIPTION
Closes #3316 
# Description

**Fixes:**

1. **`reliability` crash fix** : Only decrement if `reliability > 0`. The old `== 0` check missed the `-1` case, causing `bulk_update` to write `-1` and crash with `IntegrityError` (DB `CHECK` constraint).

2. **Shared `data_model` dedup**:  Track data models by PK so two events sharing the same row decrement it exactly once per cycle, not twice (previously the last write won, under-decrementing).

3. **Refactored into `_decay_with_fk()` / `_decay_with_gfk()`** : Cleanly separates the FK path (`select_related`) from the GFK path (`prefetch_related` + grouped `bulk_update`).

4. **`exists()` guard** : Short-circuits early when no events are eligible.

**Tests added:**
- `test_decay_reliability_zero_does_not_crash` : regression for IntegrityError crash
- `test_decay_query_count_is_constant` : asserts O(1) bulk queries via `CaptureQueriesContext`
- `test_decay_shared_data_model_reliability_decrements_correctly` : verifies shared rows decrement once

---

**Test results:**

```
test_decay_linear ... ok
test_decay_multiple_events ... ok
test_decay_no_events ... ok
test_decay_reliability_reaches_zero ... ok
test_decay_reliability_zero_does_not_crash ... ok
test_decay_linear ... ok
test_matches ... ok
test_decay_query_count_is_constant ... ok
test_decay_shared_data_model_reliability_decrements_correctly ... ok
test_decay_linear ... ok
test_matches ... ok

----------------------------------------------------------------------
Ran 13 tests in 3.214s

OK
```

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
 type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] Linters (`Ruff`) gave 0 errors. 
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.

