### PR TITLE
fix(frontend): render markdown in plugin descriptions (closes #2717)

### DIFF
--- a/frontend/src/components/plugins/flows/CustomPlaybookNode.jsx
+++ b/frontend/src/components/plugins/flows/CustomPlaybookNode.jsx
@@ -4,6 +4,7 @@ import { Handle, Position, NodeToolbar } from "reactflow";
 import "reactflow/dist/style.css";
 import { Badge } from "reactstrap";
 import { IoMdWarning } from "react-icons/io";
+import { markdownToHtml } from "../../common/markdownToHtml";
 
 function CustomPlaybookNode({ data }) {
   return (
@@ -34,7 +35,7 @@ function CustomPlaybookNode({ data }) {
           }`}
           style={{ maxWidth: "25vh" }}
         >
-          <span>{data?.description}</span>
+          <span>{markdownToHtml(data?.description)}</span>
         </small>
       </NodeToolbar>
       <div

--- a/frontend/src/components/plugins/forms/PluginConfigForm.jsx
+++ b/frontend/src/components/plugins/forms/PluginConfigForm.jsx
@@ -31,6 +31,7 @@ import {
 import { useOrganizationStore } from "../../../stores/useOrganizationStore";
 import { usePluginConfigurationStore } from "../../../stores/usePluginConfigurationStore";
 import { JsonEditor } from "../../common/JsonEditor";
+import { markdownToHtml } from "../../common/markdownToHtml";
 
 function CustomInput({ formik, config, configType, disabledInputField }) {
   switch (config.type) {
@@ -417,7 +418,7 @@ export function PluginConfigForm({
               <Row>
                 <Col className="offset-2 col-9">
                   <small className="mt-1 fst-italic">
-                    {config.description}
+                    {markdownToHtml(config.description)}
                   </small>
                 </Col>
               </Row>


### PR DESCRIPTION
Closes #2717

# Description
Noticed that plugin descriptions with markdown (links, bold, etc.) were showing up as plain text instead of rendered HTML. For example, analyzer names like "AILTypoSquatting" had links in their descriptions but they weren't clickable.
Fixed it by importing the already existing [markdownToHtml] utility in the two files that were missing it:
- [PluginConfigForm.jsx] - for plugin config modal descriptions
- [CustomPlaybookNode.jsx] - for playbook flow node tooltips

No new dependencies added just reused what was already there.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist
- [x] I have read and understood the rules about [How to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors.
- [x] All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified: