### PR TITLE
Disable Feodo_Tracker analyzer

### DIFF
--- a/api_app/analyzers_manager/migrations/0176_disable_feodo_tracker.py
+++ b/api_app/analyzers_manager/migrations/0176_disable_feodo_tracker.py
@@ -1,3 +1,6 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
 from django.db import migrations
 
 
@@ -31,7 +34,6 @@ def reverse_migrate(apps, schema_editor):
 
 class Migration(migrations.Migration):
     dependencies = [
-        ("api_app", "0062_alter_parameter_type"),
         ("analyzers_manager", "0175_analyzer_config_cleanbrowsing_malicious_detector"),
     ]
 

--- a/api_app/playbooks_manager/migrations/0063_remove_feodo_tracker_from_free_to_use.py
+++ b/api_app/playbooks_manager/migrations/0063_remove_feodo_tracker_from_free_to_use.py
@@ -1,3 +1,6 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
 from django.db import migrations
 
 


### PR DESCRIPTION
Feodo Tracker's blocklist has been mostly discontinued — last I checked, it was returning just 5 IPs total. This PR disables the analyzer and removes it from the FREE_TO_USE_ANALYZERS playbook, as discussed in #3507.

**Changes:**
- New migration (`0176`) sets `disabled=True` on the Feodo_Tracker AnalyzerConfig
- New playbook migration (`0063`) removes it from FREE_TO_USE_ANALYZERS
- Both migrations include reverse functions in case we need to re-enable it

The analyzer code and tests are kept intact so it can be re-enabled if the data source comes back.

Closes #3540