### PR TITLE
fix yara scan logic.  Closes #1711

### DIFF
--- a/api_app/analyzers_manager/file_analyzers/yara_scan.py
+++ b/api_app/analyzers_manager/file_analyzers/yara_scan.py
@@ -5,8 +5,10 @@ import io
 import logging
 import math
 import os
+import shutil
+import tempfile
 import zipfile
-from pathlib import PosixPath
+from pathlib import Path, PosixPath
 from typing import Dict, List, Optional, Tuple, Union
 from urllib.parse import urlparse
 
@@ -86,8 +88,10 @@ class YaraRepo:
 
     def update(self):
         logger.info(f"Starting update of {self.url}")
-        if self.is_zip():
-            # private url not supported at the moment for private
+
+        if self.is_unprotect_api():
+            self._update_unprotect_api()
+        elif self.is_zip():
             self._update_zip()
         else:
             self._update_git()
@@ -149,9 +153,111 @@ class YaraRepo:
                 if settings.GIT_KEY_PATH.exists():
                     os.remove(settings.GIT_KEY_PATH)
 
+    @staticmethod
+    def _write_rule_to_temp(rule, temp_dir):
+        """Helper to write an individual rule to the temp directory."""
+        try:
+            # Check for YARA rule content in multiple possible fields
+            yara_rule = rule.get("yara_rule") or rule.get("yara_rules") or rule.get("rule")
+
+            if not yara_rule or not isinstance(yara_rule, str):
+                return False
+
+            # Sanitize filename: Remove spaces and non-alphanumeric chars
+            rule_name = rule.get("name") or "unprotect_rule"
+            clean_name = "".join(filter(str.isalnum, str(rule_name))) or "unprotect_rule"
+            rule_id = rule.get("id", "unknown")
+
+            filename = f"{clean_name}_{rule_id}.yar"
+            # Ensure temp_dir is treated as a Path object
+            save_path = Path(temp_dir) / filename
+
+            with open(save_path, "w", encoding="utf-8") as f:
+                f.write(yara_rule)
+            return True
+        except Exception as e:
+            logger.error(f"Error writing rule {rule.get('id')}: {e}")
+            return False
+
+    def _update_unprotect_api(self):
+        logger.info(f"Fetching Unprotect rules from {self.url}")
+
+        # Setup temporary workspace
+        os.makedirs(self.directory.parent, exist_ok=True)
+        temp_dir_raw = tempfile.mkdtemp(prefix="unprotect_tmp_", dir=str(self.directory.parent))
+        temp_dir_path = Path(temp_dir_raw)
+
+        current_url = self.url
+        valid_rules = 0
+
+        try:
+            while current_url:
+                try:
+                    response = requests.get(current_url, timeout=30)
+                    response.raise_for_status()
+                    data = response.json()
+                except (requests.RequestException, ValueError) as e:
+                    logger.error(f"Failed fetching/decoding Unprotect page {current_url}: {e}")
+                    break
+
+                results = data.get("results", [])
+                if not results:
+                    break
+
+                for rule in results:
+                    # Call it via the class name or just remove 'self.'
+                    YaraRepo._write_rule_to_temp(rule, temp_dir_path)
+
+                current_url = data.get("next")
+
+            # --- VALIDATION BLOCK ---
+            for rule_file in temp_dir_path.glob("*.yar"):
+                try:
+                    yara.compile(filepath=str(rule_file))
+                    valid_rules += 1
+                except (yara.SyntaxError, yara.Error) as e:
+                    logger.error(
+                        "Invalid YARA rule in temp file %s: %s. Discarding.",
+                        rule_file,
+                        e,
+                    )
+                    rule_file.unlink(missing_ok=True)
+
+            if valid_rules > 0:
+                self._finalize_rules(temp_dir_path, valid_rules)
+            else:
+                logger.warning("No valid YARA rules were fetched; keeping existing rules.")
+
+        except Exception:
+            logger.exception("Unexpected error during Unprotect rules ingestion")
+        finally:
+            shutil.rmtree(temp_dir_raw, ignore_errors=True)
+
+    def _finalize_rules(self, temp_dir, count):
+        """Moves rules from temp to final destination and cleans up old rules."""
+        os.makedirs(self.directory, exist_ok=True)
+
+        # First, move all new rules into place, keeping track of their names.
+        new_rule_names = set()
+        for new_file in temp_dir.glob("*.yar"):
+            destination = self.directory / new_file.name
+            shutil.move(str(new_file), str(destination))
+            new_rule_names.add(new_file.name)
+
+        # Only after successfully moving new rules, remove any stale old rules.
+        for old_file in self.directory.glob("*.yar"):
+            if old_file.name not in new_rule_names:
+                old_file.unlink(missing_ok=True)
+
+        logger.info(
+            "Successfully updated Unprotect repository with %d rules in %s",
+            count,
+            self.directory,
+        )
+
     def delete_lock_file(self):
         lock_file_path = self.directory / ".git" / "index.lock"
-        lock_file_path.unlink(missing_ok=False)
+        lock_file_path.unlink(missing_ok=True)
 
     @property
     def compiled_file_name(self):
@@ -172,6 +278,18 @@ class YaraRepo:
 
     def is_zip(self):
         return self.url.endswith(".zip")
+
+    def is_unprotect_api(self):
+        """
+        Return True if the configured URL points to the Unprotect.it
+        detection rules API endpoint.
+        """
+        parsed = urlparse(self.url)
+        netloc = parsed.netloc.lower()
+
+        # Normalize path to handle optional leading/trailing slash
+        path = parsed.path.strip("/")
+        return netloc == "unprotect.it" and path.startswith("api/detection_rules")
 
     @cached_property
     def head_branch(self) -> str:
@@ -206,29 +324,47 @@ class YaraRepo:
         logger.info(f"Starting compile for {self}")
         compiled_rules = []
 
+        # We check the specific repo directory and any first-level subdirectories
         for directory in self.first_level_directories + [self.directory]:
             if directory != self.directory:
-                # recursive
-                rules = directory.rglob("*")
+                rules = directory.rglob("*")  # recursive for subfolders
             else:
-                # not recursive
-                rules = directory.glob("*")
+                rules = directory.glob("*")  # non-recursive for main folder
+
             valid_rules_path = []
             for rule in rules:
-                if rule.stem.endswith("index") or rule.stem.startswith("index"):
+                if rule.stem.lower().startswith("index") or rule.stem.lower().endswith("index"):
                     continue
                 if rule.suffix in [".yara", ".yar", ".rule"]:
                     try:
-                        yara.compile(str(rule))
-                    except yara.SyntaxError:
+                        yara.compile(filepath=str(rule))
+                        valid_rules_path.append(rule)
+                    except yara.SyntaxError as e:
+                        logger.warning(f"Syntax error in YARA rule: {rule}: {e}")
                         continue
-                    else:
-                        valid_rules_path.append(str(rule))
+                    except yara.Error as e:
+                        logger.warning(f"Error compiling YARA rule: {rule}: {e}")
+                        continue
+
+            if not valid_rules_path:
+                continue
+
             logger.info(f"Compiling {len(valid_rules_path)} rules for {self} at {directory}")
-            compiled_rule = yara.compile(filepaths={str(path): str(path) for path in valid_rules_path})
-            compiled_rule.save(str(directory / self.compiled_file_name))
-            compiled_rules.append(compiled_rule)
-            logger.info(f"Rules {self} saved on file")
+
+            try:
+                compiled_rule = yara.compile(filepaths={str(path): str(path) for path in valid_rules_path})
+
+                # Ensure the path exists before saving to avoid "could not open file" error
+                directory.mkdir(parents=True, exist_ok=True)
+
+                save_path = str(directory / self.compiled_file_name)
+                compiled_rule.save(save_path)
+
+                compiled_rules.append(compiled_rule)
+                logger.info(f"Rules for {self} compiled and saved to {save_path}")
+            except Exception:
+                logger.exception("Failed to compile or save YARA rules in %s", directory)
+
         return compiled_rules
 
     def analyze(self, file_path: str, filename: str) -> List[Dict]:

--- a/tests/api_app/analyzers_manager/unit_tests/file_analyzers/test_yara_scan.py
+++ b/tests/api_app/analyzers_manager/unit_tests/file_analyzers/test_yara_scan.py
@@ -1,6 +1,8 @@
-from unittest.mock import patch
+import tempfile
+from pathlib import Path
+from unittest.mock import MagicMock, patch
 
-from api_app.analyzers_manager.file_analyzers.yara_scan import YaraScan
+from api_app.analyzers_manager.file_analyzers.yara_scan import YaraRepo, YaraScan
 
 from .base_test_class import BaseFileAnalyzerTest
 
@@ -32,3 +34,69 @@ class TestYaraScan(BaseFileAnalyzerTest):
                 ],
             )
         ]
+
+    def setUp(self):
+        super().setUp()
+
+        self.analyzer = YaraScan(
+            {
+                "repositories": [],
+                "local_rules": "",
+                "_private_repositories": {},
+            }
+        )
+
+    @patch("api_app.analyzers_manager.file_analyzers.yara_scan.requests.get")
+    def test_unprotect_update_downloads_yara_rules(self, mock_get):
+        """
+        Ensure Unprotect API repository downloads YARA rules with a non-empty
+        yara_rule field and creates .yar files correctly.
+        """
+
+        # Mock API response
+        mock_response = MagicMock()
+        mock_response.raise_for_status.return_value = None
+        mock_response.json.return_value = {
+            "results": [
+                {
+                    "id": 1,
+                    "name": "Test Rule",
+                    "yara_rule": "rule test_rule { condition: true }",
+                },
+                {
+                    "id": 2,
+                    "name": "CAPA Rule",
+                    "yara_rule": None,
+                },
+            ],
+            "next": None,
+        }
+
+        mock_get.return_value = mock_response
+
+        with tempfile.TemporaryDirectory() as tmpdir:
+            base_dir = Path(tmpdir)
+
+            unprotect_repo = YaraRepo(url="https://unprotect.it/api/detection_rules/", directory=base_dir)
+
+            # Call update on the correct repo
+            unprotect_repo.update()
+
+            # Verify HTTP request was made correctly
+            mock_get.assert_called()
+            called_url = mock_get.call_args[0][0]
+            self.assertIn("unprotect.it/api/detection_rules/", called_url)
+
+            # Verify .yar file was created
+            created_files = list(base_dir.iterdir())
+            self.assertEqual(len(created_files), 1)
+
+            created_file = created_files[0]
+            self.assertEqual(created_file.suffix, ".yar")
+            self.assertEqual(created_file.name, "TestRule_1.yar")
+
+            #  Verify file content
+            with open(created_file, "r", encoding="utf-8") as f:
+                content = f.read()
+
+            self.assertEqual(content, "rule test_rule { condition: true }")


### PR DESCRIPTION

# Description
This PR adds support for downloading YARA detection rules from the
Unprotect API: "https://unprotect.it/api/detection_rules/".

The implementation extends the existing YARA repository update logic to
support API-based rule ingestion in addition to Git repositories.

When the repository URL matches the Unprotect API endpoint, IntelOwl will:

- Fetch detection rules from the API
- Validate rule syntax before saving
- Store valid rules locally as `.yar` files
- Skip invalid or malformed rules safely

This improves rule coverage by allowing IntelOwl to automatically ingest
community-maintained detection rules from Unprotect.

Closes https://github.com/intelowlproject/IntelOwl/issues/1711

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Bug Fix
# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [x] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [ ] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [x] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [ ] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

## Screenshots
1.Test execution showing all tests passing
<img width="941" height="176" alt="1. Test execution showing all tests passing" src="https://github.com/user-attachments/assets/c246a252-6117-47b6-b5a9-79dbca2fd510" />

2'.yar` files from Unprotect API 
<img width="947" height="301" alt=" '.yar' files from Unprotect API " src="https://github.com/user-attachments/assets/07048255-32c2-4302-840a-9bd482505d32" />

3. Content of a downloaded YARA rule file
<img width="943" height="328" alt="3. Content of a downloaded YARA rule file" src="https://github.com/user-attachments/assets/d39c53b2-ccd6-4e54-b615-4b7b2149360f" />