### PR TITLE
fix: correct typo in ValidationError message. Closes #3392

### DIFF
--- a/api_app/models.py
+++ b/api_app/models.py
@@ -963,7 +963,7 @@ class PluginConfig(OwnershipAbstractModel):
         """
         if self.config.python_module != self.parameter.python_module:
             raise ValidationError(
-                f"Missmatch between config python module {self.config.python_module}"
+                f"Mismatch between config python module {self.config.python_module}"
                 f" and parameter python module {self.parameter.python_module}"
             )
 


### PR DESCRIPTION
# Description

Fixes a typo in the `ValidationError` message in `api_app/models.py`.

Closes #3392

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed pre-commit, it does these checks and adjustments on your behalf.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.

### Important Rules
- If you miss to compile the Checklist properly, your PR won't be reviewed by the maintainers.
- Everytime you make changes to the PR and you think the work is done, you should explicitly ask for a review by using GitHub's reviewing system detailed [here](https://docs.github.com/en/pull-requests/collaborating-with-pull-requests/proposing-changes-to-your-work-with-pull-requests/requesting-a-pull-request-review).