### PR TITLE
fix: resolve list parsing error in passive_dns visualizer

### DIFF
--- a/api_app/visualizers_manager/visualizers/passive_dns/analyzer_extractor.py
+++ b/api_app/visualizers_manager/visualizers/passive_dns/analyzer_extractor.py
@@ -156,8 +156,18 @@ def extract_robtex_reports(analyzer_reports: QuerySet, job: Job) -> List[PDNSRep
     robtex_analyzer = _extract_analyzer(analyzer_reports, Robtex.python_module, job)
     if robtex_analyzer:
         robtex_reports = robtex_analyzer.report
-        pdns_reports = []
+        
+        # Normalize the incoming JSON to handle intermittent array responses.
+        # The API can return a dict or a list directly. We flatten it to a list of dicts.
+        normalized_reports = []
         for report in robtex_reports:
+            if isinstance(report, list):
+                normalized_reports.extend(report)
+            elif isinstance(report, dict):
+                normalized_reports.append(report)
+
+        pdns_reports = []
+        for report in normalized_reports:
             if "rrdata" in report.keys():
                 pdns_report = PDNSReport(
                     datetime.datetime.fromtimestamp(report.get("time_last")).strftime("%Y-%m-%d"),

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,0 +1,6 @@
+{
+  "name": "IntelOwl-Honeynet-Project-GSoC-2026",
+  "lockfileVersion": 3,
+  "requires": true,
+  "packages": {}
+}

--- a/tests/api_app/visualizers_manager/passive_dns/test_analyzer_extractor.py
+++ b/tests/api_app/visualizers_manager/passive_dns/test_analyzer_extractor.py
@@ -448,6 +448,54 @@ class TestRobtex(CustomTestCase):
             report,
         )
 
+    def test_array_response_bug(self):
+        # Edge case: The API returns a nested JSON array instead of a JSON object/list of objects
+        self.robtex_report = AnalyzerReport.objects.create(
+            parameters={},
+            report=[
+                [
+                    {
+                        "count": 2,
+                        "rrdata": "mx.spamexperts.com",
+                        "rrname": "test.com",
+                        "rrtype": "MX",
+                        "time_last": 1582215078,
+                        "time_first": 1441363932,
+                    }
+                ]
+            ],
+            job=self.job,
+            task_id=uuid(),
+            config=AnalyzerConfig.objects.get(name="Robtex"),
+        )
+        report = extract_robtex_reports(AnalyzerReport.objects.filter(job=self.job), self.job)
+        self.assertEqual(
+            [
+                PDNSReport(
+                    last_view="2020-02-20",
+                    first_view="2015-09-04",
+                    rrtype="MX",
+                    rdata="mx.spamexperts.com",
+                    rrname="test.com",
+                    source="Robtex",
+                    source_description="scan a domain/IP against the Robtex Passive DNS DB",  # noqa: E501
+                ),
+            ],
+            report,
+        )
+
+    def test_empty_array_response_bug(self):
+        # Edge case: The API returns an empty nested array
+        self.robtex_report = AnalyzerReport.objects.create(
+            parameters={},
+            report=[[]],
+            job=self.job,
+            task_id=uuid(),
+            config=AnalyzerConfig.objects.get(name="Robtex"),
+        )
+        report = extract_robtex_reports(AnalyzerReport.objects.filter(job=self.job), self.job)
+        self.assertEqual([], report)
+
 
 class TestMnemonicPDNS(CustomTestCase):
     @classmethod


### PR DESCRIPTION
## Description
While testing the visualizers for my GSoC 2026 proposal (Self-Deployed LLM Chatbot), I encountered an edge case where the `Passive_DNS` visualizer crashes with a `'list' object has no attribute 'keys'` error. 

This happens when the external API returns a JSON array instead of a JSON object. This PR adds a defensive type guard to check if the incoming JSON is a list or a dict, preventing the `.keys()` method from failing and crashing the React frontend render.

## Steps to Reproduce
1. Run a scan on an IP that returns a list format for Passive DNS (e.g., `159.65.101.136`).
2. Attempt to view the `Passive_DNS` visualizer in the UI.

## Changes Made
- Added type validation before calling `.keys()` on the response data.
- Ensured consistent data shape is passed to the frontend.

## Here are some images of the error.
<img width="1916" height="941" alt="Screenshot 2026-03-30 220435" src="https://github.com/user-attachments/assets/b000dce4-fabf-4598-b068-a694e1b712d0" />
<img width="1919" height="941" alt="Screenshot 2026-03-30 220354" src="https://github.com/user-attachments/assets/535440dc-9bd3-40d8-b0e5-63090dea4516" />
