### PR TITLE
fix(api): validate recent_scans max_temporal_distance input. Closes #3594

### DIFF
--- a/api_app/views.py
+++ b/api_app/views.py
@@ -409,6 +409,12 @@ class JobViewSet(ReadAndDeleteOnlyViewSet, SerializerActionMixin):
         if "md5" not in request.data:
             raise ValidationError({"detail": "md5 is required"})
         max_temporal_distance = request.data.get("max_temporal_distance", 14)
+        try:
+            max_temporal_distance = int(max_temporal_distance)
+        except (TypeError, ValueError):
+            raise ValidationError({"detail": "max_temporal_distance must be an integer"})
+        if max_temporal_distance < 0:
+            raise ValidationError({"detail": "max_temporal_distance must be >= 0"})
         jobs = (
             Job.objects.filter(analyzable__md5=request.data["md5"])
             .visible_for_user(self.request.user)

--- a/tests/api_app/test_views.py
+++ b/tests/api_app/test_views.py
@@ -203,6 +203,16 @@ class JobViewSetTests(CustomViewSetTestCase):
         j1.delete()
         j2.delete()
 
+    def test_recent_scan_invalid_temporal_distance(self):
+        response = self.client.post(
+            self.jobs_recent_scans_uri,
+            data={"md5": self.analyzable.md5, "max_temporal_distance": "not-an-int"},
+        )
+        content = response.json()
+        msg = (response, content)
+        self.assertEqual(400, response.status_code, msg=msg)
+        self.assertIn("max_temporal_distance must be an integer", str(content), msg=msg)
+
     def test_recent_scan_user(self):
         j1 = Job.objects.create(
             **{


### PR DESCRIPTION
# Description

Adds input validation for `max_temporal_distance` in `recent_scans`:
- enforce integer conversion
- reject negative values
- return explicit 400 validation errors

Also adds a regression test for non-integer input.

Closes #3594.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
