### PR TITLE
fix(auth): redirect oauth callback to WEB_CLIENT_URL. Closes #3596

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -312,7 +312,7 @@ class GoogleLoginCallbackView(LoginView):
         login(request, user)
         # Uncomment this for local testing
         # return redirect("http://localhost/login")
-        return redirect(self.request.build_absolute_uri("/login"))
+        return redirect(f"{settings.WEB_CLIENT_URL}/login")
 
 
 @api_view(["get"])

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -4,6 +4,7 @@
 from unittest.mock import Mock, patch
 from urllib.parse import parse_qs, urlparse
 
+from django.conf import settings
 from django.contrib.auth import get_user_model
 from django.contrib.sessions.models import Session
 from django.test import tag
@@ -65,7 +66,7 @@ class TestOAuth(CustomOAuthTestCase):
         response = self.client.get(self.google_auth_callback_uri, follow=False)
         msg = response.url
         self.assertEqual(response.status_code, 302, msg)
-        urlparse(response.url)
+        self.assertEqual(response.url, f"{settings.WEB_CLIENT_URL}/login", msg)
         self.assertEqual(Session.objects.count(), 1)
         session = Session.objects.all().first()
         session_data = session.get_decoded()


### PR DESCRIPTION
# Description

Fixes Google OAuth callback redirect target by using `settings.WEB_CLIENT_URL` instead of backend `build_absolute_uri`.

Also updates OAuth callback test to assert the redirect destination.

Closes #3596.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
