### PR TITLE
fix(api): validate recent_scans_user limit and is_sample. Closes #3598

### DIFF
--- a/api_app/views.py
+++ b/api_app/views.py
@@ -431,9 +431,25 @@ class JobViewSet(ReadAndDeleteOnlyViewSet, SerializerActionMixin):
         - List of recent jobs for the user.
         """
         limit = request.data.get("limit", 5)
+        try:
+            limit = int(limit)
+        except (TypeError, ValueError):
+            raise ValidationError({"detail": "limit must be an integer"})
+        if limit <= 0:
+            raise ValidationError({"detail": "limit must be > 0"})
         if "is_sample" not in request.data:
             raise ValidationError({"detail": "is_sample is required"})
         is_sample = request.data["is_sample"]
+        if isinstance(is_sample, str):
+            value = is_sample.strip().lower()
+            if value in {"true", "1"}:
+                is_sample = True
+            elif value in {"false", "0"}:
+                is_sample = False
+            else:
+                raise ValidationError({"detail": "is_sample must be a boolean"})
+        elif not isinstance(is_sample, bool):
+            raise ValidationError({"detail": "is_sample must be a boolean"})
         jobs = Job.objects.filter(user__pk=request.user.pk)
         if is_sample is True:
             jobs = jobs.filter(analyzable__classification=Classification.FILE)

--- a/tests/api_app/test_views.py
+++ b/tests/api_app/test_views.py
@@ -230,6 +230,20 @@ class JobViewSetTests(CustomViewSetTestCase):
         j1.delete()
         j2.delete()
 
+    def test_recent_scan_user_invalid_limit(self):
+        response = self.client.post(self.jobs_recent_scans_user_uri, data={"is_sample": False, "limit": "x"})
+        content = response.json()
+        msg = (response, content)
+        self.assertEqual(400, response.status_code, msg=msg)
+        self.assertIn("limit must be an integer", str(content), msg=msg)
+
+    def test_recent_scan_user_invalid_is_sample(self):
+        response = self.client.post(self.jobs_recent_scans_user_uri, data={"is_sample": "maybe"})
+        content = response.json()
+        msg = (response, content)
+        self.assertEqual(400, response.status_code, msg=msg)
+        self.assertIn("is_sample must be a boolean", str(content), msg=msg)
+
     def test_list_200(self):
         response = self.client.get(self.jobs_list_uri)
         content = response.json()


### PR DESCRIPTION
# Description

Adds explicit input validation for `recent_scans_user`:
- `limit` must be a positive integer
- `is_sample` must be a boolean (supports common string values `true/false`, `1/0`)

Also adds regression tests for invalid `limit` and invalid `is_sample`.

Closes #3598.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
