### PR TITLE
fix(ci): replace deprecated set-output with GITHUB_OUTPUT. Closes #3600

### DIFF
--- a/.github/workflows/pull_request_automation.yml
+++ b/.github/workflows/pull_request_automation.yml
@@ -26,7 +26,7 @@ jobs:
         run: |
           git branch -a --list | cat
           FRONTEND_CHANGES=$(git diff --compact-summary origin/${{ github.base_ref }} -- frontend/* | wc -l)
-          echo "::set-output name=frontend::$FRONTEND_CHANGES"
+          echo "frontend=$FRONTEND_CHANGES" >> "$GITHUB_OUTPUT"
         id: diff_check
 
   linters:


### PR DESCRIPTION
# Description

Replaces deprecated `::set-output` usage in `pull_request_automation.yml` with `$GITHUB_OUTPUT`.

Closes #3600.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
