### PR TITLE
fix(auth): validate google oauth token payload fields. Closes #3602

### DIFF
--- a/authentication/views.py
+++ b/authentication/views.py
@@ -295,8 +295,12 @@ class GoogleLoginCallbackView(LoginView):
             # Not giving out the actual error as we risk exposing the client secret
             raise AuthenticationFailed("OAuth authentication error.")
         user = token.get("userinfo")
+        if not isinstance(user, dict):
+            raise AuthenticationFailed("OAuth authentication error.")
         user_email = user.get("email")
-        user_name = user.get("name")
+        if not user_email:
+            raise AuthenticationFailed("OAuth authentication error.")
+        user_name = user.get("name") or user_email
         try:
             return User.objects.get(email=user_email)
         except User.DoesNotExist:

--- a/tests/auth/test_oauth.py
+++ b/tests/auth/test_oauth.py
@@ -72,3 +72,19 @@ class TestOAuth(CustomOAuthTestCase):
         self.assertIsNotNone(session_data)
         self.assertIn("_auth_user_id", session_data.keys())
         self.assertEqual(str(self.user.pk), session_data["_auth_user_id"])
+
+    @patch("authentication.views.oauth.google.authorize_access_token")
+    def test_google_callback_missing_userinfo(self, mock_authorize_access_token: Mock):
+        mock_authorize_access_token.return_value = {}
+        response = self.client.get(self.google_auth_callback_uri, follow=False)
+        msg = response.content
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, msg)
+        self.assertEqual(response.json(), {"detail": "OAuth authentication error."}, msg)
+
+    @patch("authentication.views.oauth.google.authorize_access_token")
+    def test_google_callback_missing_email(self, mock_authorize_access_token: Mock):
+        mock_authorize_access_token.return_value = {"userinfo": {"name": "No Email User"}}
+        response = self.client.get(self.google_auth_callback_uri, follow=False)
+        msg = response.content
+        self.assertEqual(response.status_code, status.HTTP_403_FORBIDDEN, msg)
+        self.assertEqual(response.json(), {"detail": "OAuth authentication error."}, msg)


### PR DESCRIPTION
# Description

Adds defensive validation for Google OAuth callback token payloads:
- verify `userinfo` is present and is a dict
- verify `email` is present
- keep consistent `OAuth authentication error.` response for malformed payloads

Also adds regression tests for missing `userinfo` and missing `email` cases.

Closes #3602.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
