### PR TITLE
fix(frontend): show JobIsRunningAlert only for active jobs (#3586)

### DIFF
--- a/frontend/src/components/jobs/result/JobInfoCard.jsx
+++ b/frontend/src/components/jobs/result/JobInfoCard.jsx
@@ -218,7 +218,7 @@ export function JobInfoCard({ job }) {
               </ListGroupItem>
             ))}
           </ListGroup>
-          {Object.values(JobFinalStatuses).includes(job.status) && (
+          {!Object.values(JobFinalStatuses).includes(job.status) && (
             <div
               className="my-4 d-flex justify-content-center"
               style={{ width: "100%" }}

--- a/frontend/tests/components/jobs/result/JobInfoCard.test.jsx
+++ b/frontend/tests/components/jobs/result/JobInfoCard.test.jsx
@@ -75,7 +75,7 @@ describe("test JobInfoCard (job report)", () => {
             observable_classification: "domain",
             file_name: "",
             file_mimetype: "",
-            status: "reported_without_fails",
+            status: "running",
             runtime_configuration: {
               analyzers: {},
               connectors: {},
@@ -175,9 +175,7 @@ describe("test JobInfoCard (job report)", () => {
     expect(JobInfoCardDropDownButton).toBeInTheDocument();
     // metadata - first line
     expect(within(JobInfoCardSection).getByText("Status")).toBeInTheDocument();
-    expect(
-      within(JobInfoCardSection).getByText("REPORTED WITHOUT FAILS"),
-    ).toBeInTheDocument();
+    expect(within(JobInfoCardSection).getByText("RUNNING")).toBeInTheDocument();
     expect(within(JobInfoCardSection).getByText("TLP")).toBeInTheDocument();
     expect(within(JobInfoCardSection).getByText("AMBER")).toBeInTheDocument();
     expect(within(JobInfoCardSection).getByText("User")).toBeInTheDocument();


### PR DESCRIPTION
Fixes #3586

# Description
The `JobIsRunningAlert` (flow diagram + Kill button) was incorrectly displayed on completed jobs inside the `JobInfoCard` component. The condition at line 221 in `JobInfoCard.jsx` was missing a `!` (NOT operator), causing the alert to render for final statuses instead of active ones.

**Changes:**
- Added `!` to the condition: `!Object.values(JobFinalStatuses).includes(job.status)` now matches the pattern used in `JobOverview.jsx` and `JobIsRunningAlert.jsx`
- Updated test to use `"running"` status instead of `"reported_without_fails"` to match the corrected logic

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have a provided a screenshot of the result in the PR.