### PR TITLE
fix: clean up orphaned analyzable rows in remove_old_jobs (#3610)

### DIFF
--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -89,13 +89,17 @@ def remove_old_jobs():
     num_jobs_to_delete = old_jobs.count()
     logger.info(f"found {num_jobs_to_delete} old jobs to delete")
     for old_job in old_jobs.iterator():
+        analyzable = old_job.analyzable
         # if the job that we are going to delete is the last one, and it has a file
-        if old_job.analyzable.jobs.count() == 1 and old_job.analyzable.file:
-            old_job.analyzable.file.delete()
+        if analyzable.jobs.count() == 1 and analyzable.file:
+            analyzable.file.delete()
         try:
             old_job.delete()
         except Job.DoesNotExist as e:
             logger.warning(f"job {old_job.id} does not exist. Err: {e}", stack_info=True)
+        # clean up orphaned analyzable if no jobs reference it anymore
+        if not analyzable.jobs.exists():
+            analyzable.delete()
 
     logger.info("finished remove_old_jobs")
     return num_jobs_to_delete

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -79,10 +79,10 @@ class CronTests(CustomTestCase):
 
         _job.finished_analysis_time = now() - datetime.timedelta(days=10)
         _job.save()
+        an_pk = an.pk
         self.assertEqual(remove_old_jobs(), 1)
-
-        _job.delete()
-        an.delete()
+        # verify orphaned analyzable is also cleaned up
+        self.assertFalse(Analyzable.objects.filter(pk=an_pk).exists())
 
     @if_mock_connections(skip("not working without connection"))
     def test_maxmind_updater(self):


### PR DESCRIPTION
Closes #3610

# Description

The `remove_old_jobs` cron deletes old jobs and their files but was leaving the `Analyzable` row behind in the DB. When the same file gets re-analyzed, it picks up the old row (same md5) which no longer has a file attached, causing `ValueError: The 'file' attribute has no file associated with it.`

Fixed by deleting the orphaned `Analyzable` after its last job is removed, as suggested by @sanjib2006 in the issue discussion.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute) to this project
- [x] This pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder).
