### PR TITLE
share S3 cached files across analyzers. Closes #3459

### DIFF
--- a/api_app/analyzers_manager/classes.py
+++ b/api_app/analyzers_manager/classes.py
@@ -241,17 +241,9 @@ class FileAnalyzer(BaseAnalyzerMixin, metaclass=ABCMeta):
 
     def after_run(self):
         super().after_run()
-        # We delete the file only if we have single copy for analyzer
-        # and the file has been saved locally.
-        # Otherwise we would remove the single file that we have on the server
-        if not settings.LOCAL_STORAGE and self.filepath is not None:
-            import os
-
-            try:
-                os.remove(self.filepath)
-            except OSError:
-                logger.warning(f"Filepath {self.filepath} does not exists")
-
+        # When using S3 storage, cached files are now stored in a shared
+        # directory and reused by all analyzers, so we must NOT delete them
+        # here — another analyzer may still be reading the same file.
         logger.info(f"FINISHED analyzer: {self.__repr__()} -> File: ({self.filename}, md5: {self.md5})")
 
 

--- a/intel_owl/settings/storage.py
+++ b/intel_owl/settings/storage.py
@@ -33,25 +33,26 @@ else:
     from storages.backends.s3boto3 import S3Boto3Storage
 
     class S3Boto3StorageWrapper(S3Boto3Storage):
-        def retrieve(self, file, analyzer):
-            # FIXME we can optimize this a lot.
-            #  Right now we are doing an http request FOR analyzer. We can have a
-            #  proxy that will store the content and then save it locally
+        # Shared cache directory where files are downloaded once and
+        # reused by every analyzer that needs them.
+        _CACHE_DIR = os.path.join(MEDIA_ROOT, "_s3_cache")
 
-            # The idea is to download the file in MEDIA_ROOT/analyzer/namefile
-            # if it does not exist
-            path_dir = os.path.join(MEDIA_ROOT, analyzer)
+        def retrieve(self, file, analyzer):
             name = file.name
-            _path = os.path.join(path_dir, name)
+            _path = os.path.join(self._CACHE_DIR, name)
             if not os.path.exists(_path):
-                os.makedirs(path_dir, exist_ok=True)
+                os.makedirs(os.path.dirname(_path), exist_ok=True)
                 if not self.exists(name):
                     raise AssertionError
+                # Write to a temp file first, then rename for atomicity.
+                # This prevents a concurrent worker from reading a half-written file.
+                tmp_path = _path + ".tmp"
                 with self.open(name) as s3_file_object:
                     content = s3_file_object.read()
-                    s3_file_object.seek(0)
-                    with open(_path, "wb") as local_file_object:
+                    with open(tmp_path, "wb") as local_file_object:
                         local_file_object.write(content)
+                # atomic on the same filesystem
+                os.replace(tmp_path, _path)
             return _path
 
     DEFAULT_FILE_STORAGE = "intel_owl.settings.S3Boto3StorageWrapper"


### PR DESCRIPTION
# Description

Closes #3459.

In the past, the `S3Boto3StorageWrapper` would download the same file from S3 several times, once for each analyzer that was running on it, and then save multiple copies of the file in different folders, which was unnecessary and redundant.

I've made some changes to the `retrieve()` function so that it stores a copy of the file in the shared `MEDIA_ROOT` folder. This way, when the first analyzer needs the file, it downloads it and the others can just use that same copy. This should really cut down on unnecessary internet requests and free up some disk space.

## Type of change

- [x] Fixing a bug, which is a small change that solves a problem, without affecting other parts of the system.
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

# Checklist

I've read and understood the rules for contributing to this project, which are outlined in the [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) section.
The pull request is intended for the develop branch.
I have added the copyright notice at the beginning of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
Try to use what's already available instead of adding new libraries whenever possible.
If external libraries or packages with restrictive licenses are used, you can find them listed in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section. This is where we keep track of any external components that have limitations on how they can be used.
- [x] Linters (`Ruff`) gave 0 errors.
I've added tests to cover the feature or bug I've fixed - you can find them in the `tests` folder. When I ran all the tests, including the new and existing ones, I didn't get any errors.

