### PR TITLE
fix: patch peframe tostring() for Python 3.9+ compatibility (#3621)

### DIFF
--- a/integrations/malware_tools_analyzers/Dockerfile
+++ b/integrations/malware_tools_analyzers/Dockerfile
@@ -63,7 +63,8 @@ COPY requirements/peframe-requirements.txt ./
 RUN python3 -m venv venv \
     && . venv/bin/activate \
     && pip3 install --no-cache-dir --upgrade pip \
-    && pip3 install --no-cache-dir -r peframe-requirements.txt --no-cache-dir
+    && pip3 install --no-cache-dir -r peframe-requirements.txt --no-cache-dir \
+    && sed -i 's/\.tostring()/\.tobytes()/g' venv/lib/python3.*/site-packages/peframe/modules/features.py
 
 # Install guelfo's artifacts
 # there is no version management on this project so we just pull the most recent changes

--- a/integrations/malware_tools_analyzers/Dockerfile
+++ b/integrations/malware_tools_analyzers/Dockerfile
@@ -60,6 +60,7 @@ RUN if [[ $TARGETARCH == "amd64" ]]; then \
 # Build guelfo's PEFrame
 WORKDIR ${PROJECT_PATH}/peframe
 COPY requirements/peframe-requirements.txt ./
+# peframe-ds 6.1.0 uses array.tostring() which was removed in Python 3.9+, patch it after install
 RUN python3 -m venv venv \
     && . venv/bin/activate \
     && pip3 install --no-cache-dir --upgrade pip \


### PR DESCRIPTION
Closes #3621

# Description

The PeFrame analyzer was failing on PE file analysis because `peframe-ds==6.1.0` uses `array.array.tostring()` in its `features.py` module, which was removed in Python 3.9+. Since the `malware_tools_analyzers` container runs Python 3.11, PeFrame crashes with `AttributeError: 'array.array' object has no attribute 'tostring'` whenever it tries to analyze a valid PE file.

The issue is on the analyzer side, not specific to any sample.

Fixed by adding a `sed` patch in the Dockerfile to replace `.tostring()` with `.tobytes()` after pip install.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Run`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/How-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
