### PR TITLE
fix(validin): add missing continue statement in _run_all_queries

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/validin.py
+++ b/api_app/analyzers_manager/observable_analyzers/validin.py
@@ -36,6 +36,7 @@ class Validin(classes.ObservableAnalyzer):
                         logger.error(f"Query {query_name} failed")
 
                         # we wont stop other quries from executing if one fails
+                        continue
                     final_response[f"{query_name}"] = response.json()
                 except requests.RequestException as e:
                     raise AnalyzerRunException(e)


### PR DESCRIPTION
Closes #3642. 
If your PR is made by a single commit, please add that clause in the commit too.

# Description

Added a missing `continue` statement in the `_run_all_queries` method of the Validin analyzer. 

When an API endpoint returned a non-200 status code, the error was logged but execution continued to `response.json()`, which would throw a `JSONDecodeError` if the response body was HTML instead of JSON. This broke the entire loop and crashed the analyzer, violating the intended behavior described in the existing comment: `# we wont stop other quries from executing if one fails`.

The fix simply adds `continue` after the error log so the loop skips to the next endpoint gracefully.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`