### PR TITLE
fix: replace custom regex password validation with Django's built-in validators

### DIFF
--- a/authentication/serializers.py
+++ b/authentication/serializers.py
@@ -193,7 +193,7 @@ class RegistrationSerializer(rest_email_auth.serializers.RegistrationSerializer)
 
     def validate_password(self, password):
         """
-        Validate the user's password against a regex pattern.
+        Validate the user's password using Django's built-in validators.
 
         Args:
             password (str): The password to validate.
@@ -202,10 +202,18 @@ class RegistrationSerializer(rest_email_auth.serializers.RegistrationSerializer)
             str: The validated password.
 
         Raises:
-            ValidationError: If the password does not match the regex pattern.
+            ValidationError: If the password fails validation.
         """
         super().validate_password(password)
-        validate_password_strength(password)
+        # Create a temporary user instance with initial data for UserAttributeSimilarityValidator
+        # This allows checking if password is too similar to username, email, etc.
+        temp_user = User(
+            username=self.initial_data.get("username", ""),
+            email=self.initial_data.get("email", ""),
+            first_name=self.initial_data.get("first_name", ""),
+            last_name=self.initial_data.get("last_name", ""),
+        )
+        validate_password_strength(password, user=temp_user)
         return password
 
     def create(self, validated_data):

--- a/authentication/views.py
+++ b/authentication/views.py
@@ -184,14 +184,22 @@ class ChangePasswordView(APIView):
         old_password = request.data.get("old_password")
         new_password = request.data.get("new_password")
 
-        # Validate new password strength
+        # Check if old password is provided
+        if not old_password:
+            return Response({"error": "Old password is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Check if new password is provided
+        if not new_password:
+            return Response({"error": "New password is required"}, status=status.HTTP_400_BAD_REQUEST)
+
+        # Validate new password strength with user context for UserAttributeSimilarityValidator
+        user = request.user
         try:
-            validate_password_strength(new_password)
+            validate_password_strength(new_password, user=user)
         except ValidationError as e:
-            return Response({"error": e.message}, status=status.HTTP_400_BAD_REQUEST)
+            return Response({"error": str(e.message)}, status=status.HTTP_400_BAD_REQUEST)
 
         # Check if the old password matches the user's current password
-        user = request.user
         uname = user.username
         if not check_password(old_password, user.password):
             logger.info(f"'{uname}' has inputted invalid old password.")

--- a/intel_owl/consts.py
+++ b/intel_owl/consts.py
@@ -1,19 +1,29 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import re
-
+from django.contrib.auth.password_validation import validate_password as django_validate_password
 from django.core.exceptions import ValidationError
 
 REGEX_EMAIL = r"^[\w\.\+\-]+\@[\w]+\.[a-z]{2,3}$"
 REGEX_CVE = r"CVE-\d{4}-\d{4,7}"
-REGEX_PASSWORD = r"^[a-zA-Z0-9]{12,}$"
 
 
-def validate_password_strength(password: str) -> None:
-    """Validate password against REGEX_PASSWORD. Raises ValidationError if invalid."""
-    if not re.match(REGEX_PASSWORD, password):
-        raise ValidationError("Invalid password")
+def validate_password_strength(password: str, user=None) -> None:
+    """Validate password using Django's built-in validators.
+
+    Uses AUTH_PASSWORD_VALIDATORS from settings which includes:
+    - UserAttributeSimilarityValidator (requires user context)
+    - MinimumLengthValidator (12 characters)
+    - CommonPasswordValidator
+    - NumericPasswordValidator
+
+    Raises ValidationError if password is invalid.
+    """
+    try:
+        django_validate_password(password, user=user)
+    except ValidationError as e:
+        # Re-raise with combined error messages
+        raise ValidationError("; ".join(e.messages))
 
 
 DEFAULT_SOFT_TIME_LIMIT = 300

--- a/intel_owl/settings/auth.py
+++ b/intel_owl/settings/auth.py
@@ -19,6 +19,7 @@ AUTH_PASSWORD_VALIDATORS = [
     {"NAME": "django.contrib.auth.password_validation.UserAttributeSimilarityValidator"},
     {
         "NAME": "django.contrib.auth.password_validation.MinimumLengthValidator",
+        "OPTIONS": {"min_length": 12},
     },
     {
         "NAME": "django.contrib.auth.password_validation.CommonPasswordValidator",

--- a/tests/auth/__init__.py
+++ b/tests/auth/__init__.py
@@ -10,7 +10,7 @@ class CustomOAuthTestCase(APITestCase):
         # test data
         username = "john.doe"
         email = "john.doe@example.com"
-        password = "hunter2"
+        password = "verySecureTestPassword123"
         try:
             cls.user = User.objects.get(
                 username=username,

--- a/tests/auth/test_auth.py
+++ b/tests/auth/test_auth.py
@@ -27,13 +27,16 @@ change_password_uri = reverse("auth_changepassword")
 @tag("api", "user")
 class TestUserAuth(CustomOAuthTestCase):
     def setUp(self):
+        # Reset user password before each test to ensure independence
+        self.user.set_password("verySecureTestPassword123")
+        self.user.save()
         # test data
         self.testregisteruser = {
             "email": "testregisteruser@test.com",
             "username": "testregisteruser",
             "first_name": "testregisteruser",
             "last_name": "testregisteruser",
-            "password": "testregisteruser",
+            "password": "MyComplexP@ssw0rd!",
             "profile": {
                 "company_name": "companytest",
                 "company_role": "intelowl test",
@@ -41,8 +44,6 @@ class TestUserAuth(CustomOAuthTestCase):
                 "discover_from": "other",
             },
         }
-        self.user.set_password("hunter2")
-        self.user.save()
         mail.outbox = []
 
     def tearDown(self):  # skipcq: PYL-R0201
@@ -233,7 +234,7 @@ class TestUserAuth(CustomOAuthTestCase):
         self.assertTrue(user.check_password(new_password), msg=msg)
 
     def test_change_password_200(self):
-        new_password = "veryStrongPassword123"
+        new_password = "veryStrongPassword456"
         from rest_framework.authtoken.models import Token
 
         # Setup token
@@ -252,7 +253,7 @@ class TestUserAuth(CustomOAuthTestCase):
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": new_password,
             },
         )
@@ -279,12 +280,16 @@ class TestUserAuth(CustomOAuthTestCase):
         protected_url = reverse("system-update-check")
 
         # 1. Log in with Client 1 (Session 1)
-        response1 = self.client.post(login_url, {"username": self.user.username, "password": "hunter2"})
+        response1 = self.client.post(
+            login_url, {"username": self.user.username, "password": "verySecureTestPassword123"}
+        )
         self.assertEqual(200, response1.status_code, msg="Client 1 should log in successfully")
 
         # 2. Log in with Client 2 (Session 2) - simulate another device
         client2 = APIClient()
-        response2 = client2.post(login_url, {"username": self.user.username, "password": "hunter2"})
+        response2 = client2.post(
+            login_url, {"username": self.user.username, "password": "verySecureTestPassword123"}
+        )
         self.assertEqual(200, response2.status_code, msg="Client 2 should log in successfully")
 
         # 2b. Verify Client 2 is authenticated before password change
@@ -299,7 +304,7 @@ class TestUserAuth(CustomOAuthTestCase):
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": new_password,
             },
         )
@@ -318,7 +323,7 @@ class TestUserAuth(CustomOAuthTestCase):
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": "weak",
             },
         )
@@ -326,27 +331,62 @@ class TestUserAuth(CustomOAuthTestCase):
         msg = (response, content)
 
         self.assertEqual(400, response.status_code, msg=msg)
-        self.assertIn("Invalid password", content["error"], msg=msg)
+        self.assertIn("too short", content["error"], msg=msg)
 
-    def test_change_password_special_chars_400(self):
+    def test_change_password_special_chars_200(self):
+        """Test that passwords with special characters are now allowed."""
         self.client.force_authenticate(user=self.user)
         response = self.client.post(
             change_password_uri,
             {
-                "old_password": "hunter2",
+                "old_password": "verySecureTestPassword123",
                 "new_password": "intelowlintelowl$",
             },
         )
         content = response.json()
         msg = (response, content)
 
+        self.assertEqual(200, response.status_code, msg=msg)
+        self.user.refresh_from_db()
+        self.assertTrue(
+            self.user.check_password("intelowlintelowl$"),
+            msg="Password with special characters should be accepted",
+        )
+
+    def test_change_password_missing_new_password_400(self):
+        """Test that missing new_password returns 400."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            change_password_uri,
+            {
+                "old_password": "verySecureTestPassword123",
+            },
+        )
+        content = response.json()
+        msg = (response, content)
+
         self.assertEqual(400, response.status_code, msg=msg)
-        self.assertIn("Invalid password", content["error"], msg=msg)
+        self.assertIn("New password is required", content["error"], msg=msg)
+
+    def test_change_password_missing_old_password_400(self):
+        """Test that missing old_password returns 400."""
+        self.client.force_authenticate(user=self.user)
+        response = self.client.post(
+            change_password_uri,
+            {
+                "new_password": "veryStrongPassword456",
+            },
+        )
+        content = response.json()
+        msg = (response, content)
+
+        self.assertEqual(400, response.status_code, msg=msg)
+        self.assertIn("Old password is required", content["error"], msg=msg)
 
     def test_min_password_lenght_400(self):
         current_users = User.objects.count()
 
-        # register new user with invalid password
+        # register new user with invalid password (too short)
         body = {
             **self.creds,
             "email": self.testregisteruser["email"],
@@ -362,35 +402,78 @@ class TestUserAuth(CustomOAuthTestCase):
         # response assertions
         self.assertEqual(400, response.status_code)
         self.assertIn(
-            "Invalid password",
-            content["errors"]["password"],
+            "too short",
+            content["errors"]["password"][0],
         )
 
         # db assertions
         self.assertEqual(User.objects.count(), current_users, msg="no new user was created")
 
-    def test_special_characters_password_400(self):
+    def test_special_characters_password_201(self):
+        """Test that passwords with special characters are now allowed during registration."""
         current_users = User.objects.count()
 
-        # register new user with invalid password
         body = {
-            **self.creds,
-            "email": self.testregisteruser["email"],
-            "username": "blahblah",
-            "first_name": "blahblah",
-            "last_name": "blahblah",
+            "email": "specialchars@test.com",
+            "username": "specialcharsuser",
+            "first_name": "SpecialChars",
+            "last_name": "User",
             "password": "intelowlintelowl$",
+            "profile": self.testregisteruser["profile"],
         }
 
-        response = self.client.post(register_uri, body)
+        response = self.client.post(register_uri, body, format="json")
         content = response.json()
 
-        # response assertions
+        # response assertions - special characters should now be allowed
+        self.assertEqual(201, response.status_code)
+        self.assertEqual(content["username"], body["username"])
+
+        # db assertions
+        self.assertEqual(User.objects.count(), current_users + 1, msg="new user was created")
+
+    def test_password_similar_to_username_400(self):
+        """Test that passwords too similar to username are rejected."""
+        current_users = User.objects.count()
+
+        body = {
+            "email": "similarpass@test.com",
+            "username": "mysecureusername",
+            "first_name": "Test",
+            "last_name": "User",
+            "password": "mysecureusername",  # Same as username
+            "profile": self.testregisteruser["profile"],
+        }
+
+        response = self.client.post(register_uri, body, format="json")
+        content = response.json()
+
+        # response assertions - password too similar to username should be rejected
         self.assertEqual(400, response.status_code)
-        self.assertIn(
-            "Invalid password",
-            content["errors"]["password"],
-        )
+        self.assertIn("too similar", content["errors"]["password"][0])
+
+        # db assertions
+        self.assertEqual(User.objects.count(), current_users, msg="no new user was created")
+
+    def test_common_password_400(self):
+        """Test that common passwords are rejected."""
+        current_users = User.objects.count()
+
+        body = {
+            "email": "commonpass@test.com",
+            "username": "commonpassuser",
+            "first_name": "Test",
+            "last_name": "User",
+            "password": "password1234",  # Common password
+            "profile": self.testregisteruser["profile"],
+        }
+
+        response = self.client.post(register_uri, body, format="json")
+        content = response.json()
+
+        # response assertions - common password should be rejected
+        self.assertEqual(400, response.status_code)
+        self.assertIn("too common", content["errors"]["password"][0])
 
         # db assertions
         self.assertEqual(User.objects.count(), current_users, msg="no new user was created")


### PR DESCRIPTION
## Description
This PR replaces the overly permissive `REGEX_PASSWORD` with Django's built-in `AUTH_PASSWORD_VALIDATORS` to enforce robust password policies while allowing secure special characters. This addresses the feedback provided in the previously closed PRs and cleanly resolves the issue.

### Changes Included:
- **Removed `REGEX_PASSWORD`**: Eliminated the restrictive custom regex from `intel_owl/consts.py` that was blocking valid special characters.
- **Implemented Django Validators**: Updated `validate_password_strength` to utilize `django.contrib.auth.password_validation.validate_password`.
- **Configured `MinimumLengthValidator`**: Ensured backward compatibility strictly maintaining the `min_length=12` policy natively via `intel_owl/settings/auth.py`. 
- **Passed User Context for Similarity Validation**: Properly instantiated a temporary `User` object during registration inside `RegistrationSerializer` and updated `ChangePasswordView` so `UserAttributeSimilarityValidator` correctly blocks passwords that are identical or far too similar to the user's username/email.
- **Improved View Error Handling**: Added explicit null checks for `old_password` and `new_password` in `ChangePasswordView` and normalized the error message strings to adhere strictly to the project’s standard JSON error response formatting.
- **Comprehensive Test Suite Updates**: 
  - Passed all existing tests cleanly.
  - Added coverage for missing `old_password`/`new_password` edge cases.
  - Modified tests to accurately reflect that special characters are now allowed and similarity checks/common passwords will rightfully return a `400` validation error response.

Closes #3385
