### PR TITLE
fix(hudsonrock): raise exception for non-email GENERIC observables. Closes #3647

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/hudsonrock.py
+++ b/api_app/analyzers_manager/observable_analyzers/hudsonrock.py
@@ -103,6 +103,11 @@ class HudsonRock(classes.ObservableAnalyzer):
                     + self.get_param_url(["sortby", "page", "installed_software"])
                 )
                 response = requests.post(url, headers=headers, json={"login": self.observable_name})
+            else:
+                raise AnalyzerConfigurationException(
+                    f"observable '{self.observable_name}' is not a valid email. "
+                    f"GENERIC type only supports email observables for HudsonRock"
+                )
         else:
             raise AnalyzerConfigurationException(
                 f"Invalid observable type {self.observable_classification}"

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_hudsonrock.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_hudsonrock.py
@@ -1,3 +1,4 @@
+from api_app.analyzers_manager.exceptions import AnalyzerConfigurationException
 from api_app.analyzers_manager.observable_analyzers.hudsonrock import HudsonRock
 from tests.api_app.analyzers_manager.unit_tests.observable_analyzers.base_test_class import (
     BaseAnalyzerTest,
@@ -37,3 +38,25 @@ class HudsonRockTestCase(BaseAnalyzerTest):
                 200,
             ),
         )
+
+    def test_generic_non_email_raises_exception(self):
+        """Test that non-email GENERIC observable raises AnalyzerConfigurationException."""
+        analyzer = HudsonRock.__new__(HudsonRock)
+        analyzer._api_key_name = "dummy-api-key"
+        analyzer.observable_classification = "generic"
+        analyzer.observable_name = "johndoe123"
+        analyzer.url = "https://cavalier.hudsonrock.com/api/json/v2"
+        analyzer.compromised_since = None
+        analyzer.compromised_until = None
+        analyzer.page = None
+        analyzer.added_since = None
+        analyzer.added_until = None
+        analyzer.installed_software = None
+        analyzer.sort_by = None
+        analyzer.domain_cred_type = None
+        analyzer.domain_filtered = None
+        analyzer.third_party_domains = None
+
+        with self.assertRaises(AnalyzerConfigurationException) as context:
+            analyzer.run()
+        self.assertIn("not a valid email", str(context.exception))


### PR DESCRIPTION
# Description
Fixes #3647

When the HudsonRock analyzer receives a GENERIC observable that isn't an email (e.g., a username like johndoe123), response stays as an empty dict {} and calling response.raise_for_status() on it crashes with AttributeError: 'dict' object has no attribute 'raise_for_status'.

Added an else clause in the Classification.GENERIC branch so that non-email observables raise an AnalyzerConfigurationException instead of silently falling through to response.raise_for_status().

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.