### PR TITLE
fix: set job to FAILED on exception in job_pipeline

### DIFF
--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -248,6 +248,7 @@ def job_pipeline(
     job_id: int,
 ):
     from api_app.models import Job
+    from api_app.websocket import JobConsumer
 
     job = Job.objects.get(pk=job_id)
     try:
@@ -262,6 +263,14 @@ def job_pipeline(
         ):
             report.status = report.STATUSES.FAILED.value
             report.save()
+        # mark job as failed and notify; job_set_final_status won't run since the pipeline never started
+        job.status = Job.STATUSES.FAILED.value
+        job.errors.append(str(e))
+        job.finished_analysis_time = now()
+        job.save(update_fields=["status", "errors", "finished_analysis_time"])
+        if root_investigation := job.get_root().investigation:
+            root_investigation.set_correct_status(save=True)
+        JobConsumer.serialize_and_send_job(job)
 
 
 @shared_task(base=FailureLoggedTask, name="run_plugin", soft_time_limit=500)

--- a/tests/test_crons.py
+++ b/tests/test_crons.py
@@ -19,7 +19,7 @@ from api_app.analyzers_manager.observable_analyzers import (
 )
 from api_app.choices import Classification
 from api_app.models import Job
-from intel_owl.tasks import check_stuck_analysis, remove_old_jobs
+from intel_owl.tasks import check_stuck_analysis, job_pipeline, remove_old_jobs
 
 from . import CustomTestCase, get_logger
 from .mock_utils import MockUpResponse, if_mock_connections, patch, skip
@@ -55,6 +55,44 @@ class CronTests(CustomTestCase):
         _job.status = Job.STATUSES.ANALYZERS_RUNNING.value
         _job.save()
         self.assertCountEqual(check_stuck_analysis(check_pending=False), [_job.pk])
+        _job.delete()
+        an.delete()
+
+    def test_job_pipeline_exception_sets_job_to_failed(self):
+        """
+        Regression test for GitHub issue #3653.
+        When job.execute() raises an exception inside job_pipeline,
+        the Job object must be marked as FAILED (not left stuck in RUNNING),
+        finished_analysis_time must be set, and the error must be recorded.
+        """
+        an = Analyzable.objects.create(
+            name="8.8.8.8",
+            classification=Classification.IP,
+        )
+        _job = Job.objects.create(
+            user=self.user,
+            status=Job.STATUSES.PENDING.value,
+            analyzable=an,
+        )
+        error_message = "Simulated broker failure"
+        with (
+            patch.object(
+                _job.__class__,
+                "execute",
+                side_effect=Exception(error_message),
+            ),
+            patch("api_app.websocket.JobConsumer.serialize_and_send_job"),
+            patch(
+                "api_app.models.Job.objects.get",
+                return_value=_job,
+            ),
+        ):
+            job_pipeline(_job.pk)
+
+        _job.refresh_from_db()
+        self.assertEqual(_job.status, Job.STATUSES.FAILED.value)
+        self.assertIsNotNone(_job.finished_analysis_time)
+        self.assertIn(error_message, _job.errors)
         _job.delete()
         an.delete()
 


### PR DESCRIPTION
Closes #3653

# Description
When `job.execute()` throws an exception inside `job_pipeline`, the except block only marks individual plugin reports as FAILED but never updates the Job object itself. Since `execute()` sets `status = RUNNING` before building the pipeline, any failure after that point leaves the job stuck in RUNNING forever.

This adds the missing cleanup to the except block setting the job status to FAILED, recording the error, setting `finished_analysis_time`, updating the parent investigation, and sending a WebSocket notification. This mirrors the same pattern already used in `run_plugin` and `set_final_status`.

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).


# Checklist
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute) to this project
- [x] The pull request is for the branch `develop`.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.

