### PR TITLE
[GSoC 2026] Add optional Ollama service via docker override (refs #3711)

### DIFF
--- a/docker/entrypoints/ollama.sh
+++ b/docker/entrypoints/ollama.sh
@@ -1,0 +1,39 @@
+#!/bin/sh
+# Start the Ollama server and ensure the default chat model is pulled.
+# The model is configured via the OLLAMA_MODEL env var (set in env_file_app).
+
+set -e
+
+DEFAULT_MODEL="mistral:7b-instruct-v0.3-q4_K_M"
+MODEL="${OLLAMA_MODEL:-$DEFAULT_MODEL}"
+
+echo "[ollama] Starting server..."
+ollama serve &
+SERVER_PID=$!
+
+echo "[ollama] Waiting for server to accept connections..."
+until ollama list >/dev/null 2>&1; do
+    sleep 1
+done
+
+echo "[ollama] Server ready. Checking for model '${MODEL}'..."
+if ollama list | awk 'NR>1 {print $1}' | grep -Fxq "${MODEL}"; then
+    echo "[ollama] Model '${MODEL}' already present, skipping pull."
+else
+    echo "[ollama] Pulling model '${MODEL}'..."
+    PULL_OK=false
+    for attempt in 1 2 3; do
+        if ollama pull "${MODEL}"; then
+            PULL_OK=true
+            break
+        fi
+        echo "[ollama] Pull attempt ${attempt}/3 failed; retrying in 10s..."
+        sleep 10
+    done
+    if [ "${PULL_OK}" != "true" ]; then
+        echo "[ollama] WARN: pull of '${MODEL}' failed after 3 attempts. Server will continue running without it."
+    fi
+fi
+
+echo "[ollama] Ready. PID=${SERVER_PID}"
+wait "${SERVER_PID}"

--- a/docker/ollama.override.yml
+++ b/docker/ollama.override.yml
@@ -1,0 +1,25 @@
+services:
+  ollama:
+    image: ollama/ollama:0.5.0
+    container_name: intelowl_ollama
+    hostname: ollama
+    restart: unless-stopped
+    volumes:
+      - ollama_data:/root/.ollama
+      - ./entrypoints/ollama.sh:/usr/local/bin/intelowl-ollama-entrypoint.sh:ro
+    expose:
+      - "11434"
+    env_file:
+      - env_file_app
+    entrypoint:
+      - /bin/sh
+      - /usr/local/bin/intelowl-ollama-entrypoint.sh
+    healthcheck:
+      test: ["CMD-SHELL", "ollama list >/dev/null 2>&1"]
+      interval: 30s
+      timeout: 10s
+      retries: 5
+      start_period: 180s
+
+volumes:
+  ollama_data:

--- a/start
+++ b/start
@@ -9,7 +9,7 @@ declare -A env_arguments=(["prod"]=1 ["test"]=1 ["ci"]=1)
 declare -A test_mode=(["test"]=1 ["ci"]=1)
 declare -A cmd_arguments=(["build"]=1 ["up"]=1 ["start"]=1 ["restart"]=1 ["down"]=1 ["stop"]=1 ["kill"]=1 ["logs"]=1 ["ps"]=1)
 
-declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml")
+declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml" ["ollama"]="docker/ollama.override.yml")
 print_synopsis () {
   echo "SYNOPSIS"
   echo -e "    start <env> <command> [OPTIONS]"
@@ -47,6 +47,8 @@ print_help () {
   echo "    --use-external-redis        Do NOT use redis.override.yml compose file."
   echo "    --rabbitmq                  Uses the rabbitmq.override.yml compose file."
   echo "    --flower                    Uses the flower.override.yml compose file."
+  echo "    --ollama                    Uses the ollama.override.yml compose file"
+  echo "                                to enable the local LLM chatbot service."
   echo "    --custom                    Uses custom.override.yml to leverage your"
   echo "                                customized configuration."
   echo "    --debug-build               See more verbose output from the build."
@@ -213,6 +215,10 @@ while [[ $# -gt 0 ]]; do
   ;;
   --flower)
     params["flower"]=true
+    shift 1
+  ;;
+  --ollama)
+    params["ollama"]=true
     shift 1
   ;;
   --custom)


### PR DESCRIPTION
Refs #3711

# Description

Adds Ollama as an **opt-in** service that operators can enable with a new `--ollama` flag on the `start` script. Per maintainer guidance on #3711, the service is delivered as `docker/ollama.override.yml` rather than baked into the base compose — deployments without LLM hardware keep working unchanged.

## What's in this PR

- **`docker/ollama.override.yml`** — defines the `ollama` service:
  - Image: `ollama/ollama:0.5.0` (pinned per Q9 guidance from the open-questions thread)
  - Exposes port `11434` internally
  - Named volume `ollama_data` for persistent model storage
  - Healthcheck via `ollama list`
  - Custom entrypoint script
- **`docker/entrypoints/ollama.sh`** — startup script:
  - Launches `ollama serve` in background
  - Waits for the server to accept connections
  - Pulls the configured model if not already present, with **3 retry attempts** + 10s backoff on transient failures
  - Falls back to a pinned `mistral:7b-instruct-v0.3-q4_K_M` if `OLLAMA_MODEL` is unset
  - Gracefully degrades (server keeps running) if pull ultimately fails
- **`start`** — `--ollama` flag wired into `path_mapping`, the argument parser, and the help output. Mirrors the patterns of `--flower` and `--https`.

## Out of scope (deferred)

- **GPU passthrough** (#3717) — Per the open-questions thread, the maintainer prioritized CPU-first ("as low as possible" hardware target). GPU support is tracked as a separate follow-up.
- End-to-end test with the Django chatbot app — requires PR #3715 (skeleton) to merge first.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Test plan

Verified manually on the contributor's local Kali Linux machine:

- [x] `./start --help` shows the new `--ollama` flag with description
- [x] `docker compose ... config` validates the merged YAML across all override files
- [x] Without `--ollama`: stack boots with 7 containers, no `intelowl_ollama` running (regression check)
- [x] With `--ollama`: stack boots with 8 containers, `intelowl_ollama` reaches `healthy` status
- [x] `docker inspect intelowl_ollama --format '{{.State.Health.Status}}'` returns `healthy`
- [x] `/api/tags` endpoint reachable from `intelowl_uwsgi` via internal DNS `http://ollama:11434`
- [x] Model auto-pull works: `ollama list` inside the container shows the configured model after first boot
- [x] Volume `ollama_data` persists models across container recreations (verified by inspection)
- [x] Entrypoint logs are clean (no errors/warnings; only normal pull progress)

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project
- [x] The pull request is for the branch `gsoc-2026/llm-chatbot` (umbrella for GSoC 2026; merged into `develop` at midterm and at end of GSoC)
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed — N/A
- [x] Please avoid adding new libraries as requirements whenever possible — no new pip libraries in this PR (only a new Docker image)
- [ ] If external libraries/packages with restrictive licenses were added — N/A (Ollama is MIT-licensed)
- [x] Linters (`Ruff`) gave 0 errors — N/A for shell/yaml, but no Python changes in this PR
- [ ] I have added tests for the feature/bug I solved — manual verification documented in the test plan above; automated tests for the Ollama integration belong with the chatbot app code (W2-3) where mocked LLM calls can be added
- [ ] If the GUI has been modified — N/A