### PR TITLE
[GSoC 2026] Add LangChain ReAct agent with job tools and REST endpoint (refs #3720)

### DIFF
--- a/api_app/chatbot_manager/agent/__init__.py
+++ b/api_app/chatbot_manager/agent/__init__.py
@@ -1,0 +1,2 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.

--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -1,0 +1,65 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.conf import settings
+from langchain.agents import AgentExecutor, create_react_agent
+from langchain_core.messages import AIMessage, HumanMessage
+from langchain_core.prompts import PromptTemplate
+from langchain_ollama import ChatOllama
+
+from .tools import build_tools
+
+_SYSTEM_PROMPT = """\
+You are IntelOwl AI, an intelligent assistant for the IntelOwl threat intelligence platform.
+You help security analysts query and interpret threat intelligence data.
+Only access data belonging to the current user. Never reveal other users' data.
+
+You have access to the following tools:
+
+{tools}
+
+Use the following format:
+
+Question: the input question you must answer
+Thought: you should always think about what to do
+Action: the action to take, should be one of [{tool_names}]
+Action Input: the input to the action
+Observation: the result of the action
+... (this Thought/Action/Action Input/Observation can repeat N times)
+Thought: I now know the final answer
+Final Answer: the final answer to the original input question
+
+Previous conversation:
+{chat_history}
+
+Question: {input}
+{agent_scratchpad}"""
+
+REACT_PROMPT = PromptTemplate.from_template(_SYSTEM_PROMPT)
+
+
+def build_agent_executor(user) -> AgentExecutor:
+    llm = ChatOllama(
+        model=settings.OLLAMA_MODEL,
+        base_url=settings.OLLAMA_BASE_URL,
+        temperature=0,
+    )
+    tools = build_tools(user=user)
+    agent = create_react_agent(llm, tools, REACT_PROMPT)
+    return AgentExecutor(
+        agent=agent,
+        tools=tools,
+        verbose=False,
+        handle_parsing_errors=True,
+    )
+
+
+def format_history(messages: list) -> str:
+    """Serialize LangChain message list to plain text for prompt injection."""
+    lines = []
+    for msg in messages:
+        if isinstance(msg, HumanMessage):
+            lines.append(f"User: {msg.content}")
+        elif isinstance(msg, AIMessage):
+            lines.append(f"Assistant: {msg.content}")
+    return "\n".join(lines) if lines else ""

--- a/api_app/chatbot_manager/agent/memory.py
+++ b/api_app/chatbot_manager/agent/memory.py
@@ -1,0 +1,35 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.chat_history import BaseChatMessageHistory
+from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
+
+
+class DjangoChatMessageHistory(BaseChatMessageHistory):
+    """LangChain chat history backed by Django ChatMessage model."""
+
+    def __init__(self, session):
+        self.session = session
+
+    @property
+    def messages(self) -> list[BaseMessage]:
+        from api_app.chatbot_manager.models import ChatMessage
+
+        result = []
+        for msg in ChatMessage.objects.filter(session=self.session).order_by("timestamp"):
+            if msg.role == ChatMessage.Role.USER:
+                result.append(HumanMessage(content=msg.content))
+            else:
+                result.append(AIMessage(content=msg.content))
+        return result
+
+    def add_message(self, message: BaseMessage) -> None:
+        from api_app.chatbot_manager.models import ChatMessage
+
+        role = ChatMessage.Role.USER if isinstance(message, HumanMessage) else ChatMessage.Role.ASSISTANT
+        ChatMessage.objects.create(session=self.session, role=role, content=message.content)
+
+    def clear(self) -> None:
+        from api_app.chatbot_manager.models import ChatMessage
+
+        ChatMessage.objects.filter(session=self.session).delete()

--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -1,0 +1,14 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from .get_job_details import make_get_job_details_tool
+from .search_jobs import make_search_jobs_tool
+from .summarize_job import make_summarize_job_tool
+
+
+def build_tools(user) -> list:
+    return [
+        make_search_jobs_tool(user),
+        make_get_job_details_tool(user),
+        make_summarize_job_tool(user),
+    ]

--- a/api_app/chatbot_manager/agent/tools/get_job_details.py
+++ b/api_app/chatbot_manager/agent/tools/get_job_details.py
@@ -1,0 +1,60 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import json
+
+
+def make_get_job_details_tool(user):
+    from langchain_core.tools import tool
+
+    @tool("get_job_details")
+    def get_job_details(job_id: int) -> str:
+        """Get full details of an IntelOwl job by its numeric ID.
+
+        Args:
+            job_id: The numeric ID of the job to retrieve.
+        """
+        from api_app.models import Job
+
+        try:
+            job = (
+                Job.objects.select_related("analyzable")
+                .prefetch_related("analyzer_reports", "analyzers_to_execute", "tags")
+                .get(pk=job_id, user=user)
+            )
+        except Job.DoesNotExist:
+            return f"Job with ID {job_id} not found or not accessible."
+
+        analyzer_reports = []
+        for report in job.analyzer_reports.all():
+            analyzer_reports.append(
+                {
+                    "name": report.config.name,
+                    "status": report.status,
+                    "report": report.report if isinstance(report.report, dict) else str(report.report)[:500],
+                }
+            )
+
+        return json.dumps(
+            {
+                "id": job.pk,
+                "observable_name": job.analyzable.name,
+                "observable_classification": job.analyzable.classification,
+                "md5": job.analyzable.md5,
+                "status": job.status,
+                "tlp": job.tlp,
+                "received_request_time": str(job.received_request_time),
+                "finished_analysis_time": str(job.finished_analysis_time)
+                if job.finished_analysis_time
+                else None,
+                "process_time": job.process_time,
+                "analyzers_to_execute": list(job.analyzers_to_execute.values_list("name", flat=True)),
+                "tags": list(job.tags.values_list("label", flat=True)),
+                "errors": job.errors,
+                "warnings": job.warnings,
+                "analyzer_reports": analyzer_reports,
+            },
+            indent=2,
+        )
+
+    return get_job_details

--- a/api_app/chatbot_manager/agent/tools/search_jobs.py
+++ b/api_app/chatbot_manager/agent/tools/search_jobs.py
@@ -1,0 +1,57 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import json
+
+from django.db import models
+from langchain_core.tools import tool
+
+
+def make_search_jobs_tool(user):
+    @tool("search_jobs")
+    def search_jobs(query: str = "", status: str = "", limit: int = 10) -> str:
+        """Search IntelOwl jobs by observable name, MD5, or status.
+
+        Args:
+            query: Observable name or MD5 hash to search for (partial match supported).
+            status: Filter by job status. Valid values: pending, running,
+                    reported_without_fails, reported_with_fails, failed, killed.
+            limit: Maximum number of results to return (default 10, max 50).
+        """
+        from api_app.models import Job
+
+        limit = min(int(limit), 50)
+        qs = Job.objects.select_related("analyzable").filter(user=user)
+
+        if query:
+            qs = qs.filter(
+                models.Q(analyzable__name__icontains=query) | models.Q(analyzable__md5__iexact=query)
+            )
+        if status:
+            qs = qs.filter(status=status)
+
+        qs = qs.order_by("-received_request_time")[:limit]
+
+        results = []
+        for job in qs:
+            results.append(
+                {
+                    "id": job.pk,
+                    "observable_name": job.analyzable.name,
+                    "observable_classification": job.analyzable.classification,
+                    "md5": job.analyzable.md5,
+                    "status": job.status,
+                    "tlp": job.tlp,
+                    "received_request_time": str(job.received_request_time),
+                    "finished_analysis_time": str(job.finished_analysis_time)
+                    if job.finished_analysis_time
+                    else None,
+                    "analyzers_to_execute": list(job.analyzers_to_execute.values_list("name", flat=True)),
+                }
+            )
+
+        if not results:
+            return "No jobs found matching the given criteria."
+        return json.dumps(results, indent=2)
+
+    return search_jobs

--- a/api_app/chatbot_manager/agent/tools/summarize_job.py
+++ b/api_app/chatbot_manager/agent/tools/summarize_job.py
@@ -1,0 +1,50 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+
+def make_summarize_job_tool(user):
+    from langchain_core.tools import tool
+
+    @tool("summarize_job")
+    def summarize_job(job_id: int) -> str:
+        """Return a concise human-readable summary of an IntelOwl job.
+
+        Args:
+            job_id: The numeric ID of the job to summarize.
+        """
+        from api_app.models import Job
+
+        try:
+            job = (
+                Job.objects.select_related("analyzable")
+                .prefetch_related("analyzer_reports", "analyzers_to_execute")
+                .get(pk=job_id, user=user)
+            )
+        except Job.DoesNotExist:
+            return f"Job with ID {job_id} not found or not accessible."
+
+        analyzers = list(job.analyzers_to_execute.values_list("name", flat=True))
+        failed_reports = [
+            r.config.name
+            for r in job.analyzer_reports.all()
+            if r.status not in ("success", "reported_without_fails")
+        ]
+
+        lines = [
+            f"Job #{job.pk}",
+            f"  Observable : {job.analyzable.name} ({job.analyzable.classification})",
+            f"  MD5        : {job.analyzable.md5}",
+            f"  Status     : {job.status}",
+            f"  TLP        : {job.tlp}",
+            f"  Received   : {job.received_request_time}",
+            f"  Finished   : {job.finished_analysis_time or 'N/A'}",
+            f"  Analyzers  : {', '.join(analyzers) or 'none'}",
+        ]
+        if job.errors:
+            lines.append(f"  Errors     : {'; '.join(job.errors[:3])}")
+        if failed_reports:
+            lines.append(f"  Failed     : {', '.join(failed_reports)}")
+
+        return "\n".join(lines)
+
+    return summarize_job

--- a/api_app/chatbot_manager/serializers.py
+++ b/api_app/chatbot_manager/serializers.py
@@ -1,0 +1,31 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from rest_framework import serializers
+
+from .models import ChatMessage, ChatSession
+
+
+class ChatSessionSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChatSession
+        fields = ["id", "created_at", "updated_at"]
+        read_only_fields = ["id", "created_at", "updated_at"]
+
+
+class ChatMessageSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = ChatMessage
+        fields = ["id", "role", "content", "timestamp"]
+        read_only_fields = ["id", "timestamp"]
+
+
+class MessageRequestSerializer(serializers.Serializer):
+    session_id = serializers.IntegerField(required=False, allow_null=True)
+    message = serializers.CharField(max_length=4096)
+
+
+class MessageResponseSerializer(serializers.Serializer):
+    session_id = serializers.IntegerField()
+    response = serializers.CharField()
+    message_id = serializers.IntegerField()

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -1,0 +1,12 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from celery import shared_task
+
+from intel_owl.tasks import FailureLoggedTask
+
+
+@shared_task(base=FailureLoggedTask, soft_time_limit=300)
+def process_chat_message(session_id: int, user_message: str, user_id: int) -> str:
+    # Stub — full async implementation added in W6 with WebSocket consumer.
+    raise NotImplementedError

--- a/api_app/chatbot_manager/urls.py
+++ b/api_app/chatbot_manager/urls.py
@@ -1,4 +1,11 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-urlpatterns = []
+from rest_framework.routers import DefaultRouter
+
+from .views import ChatSessionViewSet
+
+router = DefaultRouter(trailing_slash=False)
+router.register(r"sessions", ChatSessionViewSet, basename="chat-sessions")
+
+urlpatterns = router.urls

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -1,2 +1,72 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
+
+from rest_framework import status
+from rest_framework.decorators import action
+from rest_framework.generics import get_object_or_404
+from rest_framework.permissions import IsAuthenticated
+from rest_framework.response import Response
+from rest_framework.viewsets import ModelViewSet
+
+from .agent.agent import build_agent_executor, format_history
+from .agent.memory import DjangoChatMessageHistory
+from .models import ChatMessage, ChatSession
+from .serializers import (
+    ChatSessionSerializer,
+    MessageRequestSerializer,
+    MessageResponseSerializer,
+)
+
+
+class ChatSessionViewSet(ModelViewSet):
+    serializer_class = ChatSessionSerializer
+    permission_classes = [IsAuthenticated]
+    http_method_names = ["get", "post", "delete", "head", "options"]
+
+    def get_queryset(self):
+        return ChatSession.objects.filter(user=self.request.user)
+
+    def perform_create(self, serializer):
+        serializer.save(user=self.request.user)
+
+    @action(detail=False, methods=["post"], url_path="message")
+    def message(self, request):
+        req = MessageRequestSerializer(data=request.data)
+        req.is_valid(raise_exception=True)
+
+        session_id = req.validated_data.get("session_id")
+        user_message = req.validated_data["message"]
+
+        if session_id:
+            session = get_object_or_404(ChatSession, pk=session_id, user=request.user)
+        else:
+            session = ChatSession.objects.create(user=request.user)
+
+        history = DjangoChatMessageHistory(session=session)
+        chat_history_text = format_history(history.messages)
+
+        executor = build_agent_executor(user=request.user)
+        result = executor.invoke({"input": user_message, "chat_history": chat_history_text})
+        response_text = result.get("output", "")
+
+        ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.Role.USER,
+            content=user_message,
+        )
+        ai_msg = ChatMessage.objects.create(
+            session=session,
+            role=ChatMessage.Role.ASSISTANT,
+            content=response_text,
+        )
+
+        return Response(
+            MessageResponseSerializer(
+                {
+                    "session_id": session.pk,
+                    "response": response_text,
+                    "message_id": ai_msg.pk,
+                }
+            ).data,
+            status=status.HTTP_200_OK,
+        )

--- a/api_app/urls.py
+++ b/api_app/urls.py
@@ -56,6 +56,7 @@ urlpatterns = [
     path("", include("api_app.pivots_manager.urls")),
     path("", include("api_app.playbooks_manager.urls")),
     path("", include("api_app.investigations_manager.urls")),
+    path("chatbot/", include("api_app.chatbot_manager.urls")),
     path("data_model/", include("api_app.data_model_manager.urls")),
     path("user_event/", include("api_app.user_events_manager.urls")),
     path("", include("api_app.analyzables_manager.urls")),

--- a/intel_owl/settings/celery.py
+++ b/intel_owl/settings/celery.py
@@ -18,7 +18,9 @@ DEFAULT_QUEUE = "default"
 BROADCAST_QUEUE = "broadcast"
 CONFIG_QUEUE = "config"
 
+CHATBOT_QUEUE = "chatbot"
+
 CELERY_QUEUES = get_secret("CELERY_QUEUES", DEFAULT_QUEUE).split(",")
-for queue in [DEFAULT_QUEUE, CONFIG_QUEUE]:
+for queue in [DEFAULT_QUEUE, CONFIG_QUEUE, CHATBOT_QUEUE]:
     if queue not in CELERY_QUEUES:
         CELERY_QUEUES.append(queue)

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -5,3 +5,4 @@ from intel_owl import secrets
 
 OLLAMA_BASE_URL = secrets.get_secret("OLLAMA_BASE_URL", "http://ollama:11434")
 OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "mistral")
+CHATBOT_QUEUE = secrets.get_secret("CHATBOT_QUEUE", "chatbot")

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -111,6 +111,11 @@ defusedxml==0.7.1
 # required by MalwareBazaar Ingestor -> https://bazaar.abuse.ch/api/#download (read the warning)
 pyzipper==0.3.6
 
+# LangChain / Ollama
+langchain==0.3.25
+langchain-ollama==0.3.3
+langchain-core==0.3.59
+
 # others
 dateparser==1.2.0
 DeepDiff==8.6.1

--- a/tests/api_app/chatbot_manager/__init__.py
+++ b/tests/api_app/chatbot_manager/__init__.py
@@ -1,0 +1,2 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -1,0 +1,77 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import json
+
+from django.test import TestCase
+
+from api_app.analyzables_manager.models import Analyzable
+from api_app.chatbot_manager.agent.tools import build_tools
+from api_app.choices import Classification
+from api_app.models import Job
+from certego_saas.apps.user.models import User
+
+
+class SearchJobsToolTestCase(TestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_tool_user")
+        self.other_user, _ = User.objects.get_or_create(username="chatbot_other_user")
+        self.analyzable, _ = Analyzable.objects.get_or_create(
+            name="malware.example.com",
+            classification=Classification.DOMAIN,
+        )
+        self.job = Job.objects.create(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+            tlp="GREEN",
+        )
+        self.other_job = Job.objects.create(
+            user=self.other_user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+            tlp="GREEN",
+        )
+        tools = build_tools(user=self.user)
+        self.search_jobs = next(t for t in tools if t.name == "search_jobs")
+        self.get_job_details = next(t for t in tools if t.name == "get_job_details")
+        self.summarize_job = next(t for t in tools if t.name == "summarize_job")
+
+    def test_search_jobs_returns_matching(self):
+        result = self.search_jobs.invoke({"query": "malware.example.com"})
+        data = json.loads(result)
+        self.assertEqual(len(data), 1)
+        self.assertEqual(data[0]["id"], self.job.pk)
+
+    def test_search_jobs_respects_user_isolation(self):
+        other_tools = build_tools(user=self.other_user)
+        search = next(t for t in other_tools if t.name == "search_jobs")
+        result = search.invoke({"query": "malware.example.com"})
+        data = json.loads(result)
+        ids = [d["id"] for d in data]
+        self.assertIn(self.other_job.pk, ids)
+        self.assertNotIn(self.job.pk, ids)
+
+    def test_search_jobs_no_results(self):
+        result = self.search_jobs.invoke({"query": "nonexistent999"})
+        self.assertIn("No jobs found", result)
+
+    def test_get_job_details_returns_data(self):
+        result = self.get_job_details.invoke({"job_id": self.job.pk})
+        data = json.loads(result)
+        self.assertEqual(data["id"], self.job.pk)
+        self.assertIn("observable_name", data)
+        self.assertIn("status", data)
+
+    def test_get_job_details_forbidden_other_user(self):
+        result = self.get_job_details.invoke({"job_id": self.other_job.pk})
+        self.assertIn("not found or not accessible", result)
+
+    def test_summarize_job_formats_output(self):
+        result = self.summarize_job.invoke({"job_id": self.job.pk})
+        self.assertIn(f"Job #{self.job.pk}", result)
+        self.assertIn("malware.example.com", result)
+        self.assertIn("Status", result)
+
+    def tearDown(self):
+        Job.objects.filter(user__in=[self.user, self.other_user]).delete()

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -1,0 +1,94 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api_app.chatbot_manager.models import ChatMessage, ChatSession
+from certego_saas.apps.user.models import User
+
+MOCK_AGENT_OUTPUT = {"output": "Here are your recent jobs."}
+
+
+class ChatSessionViewSetTestCase(APITestCase):
+    URL = "/api/chatbot/sessions"
+    MESSAGE_URL = "/api/chatbot/sessions/message"
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_view_user")
+        self.client.force_authenticate(user=self.user)
+
+    @patch(
+        "api_app.chatbot_manager.views.build_agent_executor",
+        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
+    )
+    def test_message_creates_session_when_none_provided(self, mock_executor):
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Show me recent jobs"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn("session_id", data)
+        self.assertIn("response", data)
+        self.assertIn("message_id", data)
+        self.assertEqual(data["response"], MOCK_AGENT_OUTPUT["output"])
+        self.assertTrue(ChatSession.objects.filter(pk=data["session_id"]).exists())
+
+    @patch(
+        "api_app.chatbot_manager.views.build_agent_executor",
+        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
+    )
+    def test_message_reuses_existing_session(self, mock_executor):
+        session = ChatSession.objects.create(user=self.user)
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello", "session_id": session.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json()["session_id"], session.pk)
+
+    @patch(
+        "api_app.chatbot_manager.views.build_agent_executor",
+        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
+    )
+    def test_message_saves_user_and_assistant_messages(self, mock_executor):
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        session_id = response.json()["session_id"]
+        msgs = list(ChatMessage.objects.filter(session_id=session_id).order_by("timestamp"))
+        self.assertEqual(len(msgs), 2)
+        self.assertEqual(msgs[0].role, ChatMessage.Role.USER)
+        self.assertEqual(msgs[0].content, "Hello")
+        self.assertEqual(msgs[1].role, ChatMessage.Role.ASSISTANT)
+        self.assertEqual(msgs[1].content, MOCK_AGENT_OUTPUT["output"])
+
+    def test_message_returns_404_for_other_users_session(self):
+        other_user, _ = User.objects.get_or_create(username="chatbot_other_view_user")
+        other_session = ChatSession.objects.create(user=other_user)
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello", "session_id": other_session.pk},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_message_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def tearDown(self):
+        ChatSession.objects.filter(user=self.user).delete()


### PR DESCRIPTION
Refs #3720.

## Summary
- Add `langchain`, `langchain-ollama`, `langchain-core` to requirements (`langchain-community` excluded per mentor feedback)
- Add `CHATBOT_QUEUE = "chatbot"` dedicated Celery queue to settings
- Implement `DjangoChatMessageHistory` — LangChain `BaseChatMessageHistory` backed by `ChatMessage` ORM
- Implement three user-scoped tools (ORM-direct, multi-tenancy enforced via closure):
  - `search_jobs` — filter by observable name / MD5 / status
  - `get_job_details` — full job with analyzer reports
  - `summarize_job` — human-readable summary
- Implement `build_agent_executor(user)` using `ChatOllama` + `create_react_agent` with inline ReAct prompt (no external hub pull)
- Implement `ChatSessionViewSet` with `POST /api/chatbot/sessions/message` synchronous REST endpoint
- Add `process_chat_message` Celery task stub (full async impl in W6 with WebSocket consumer)
- Register chatbot URLs at `/api/chatbot/`
- Unit tests for all three tools and the message endpoint (LLM mocked in CI)

## Test plan
- [ ] `search_jobs` returns only the requesting user's jobs
- [ ] `get_job_details` returns 404-equivalent for jobs belonging to other users
- [ ] `POST /api/chatbot/sessions/message` creates a session if none provided
- [ ] `POST /api/chatbot/sessions/message` persists user + assistant messages to DB
- [ ] Unauthenticated requests return 401
- [ ] All existing tests pass: `docker exec -it intelowl_uwsgi python3 manage.py test`