### PR TITLE
[GSoC 2026] Add endpoint to retrieve a chat session's messages (refs #3725)

### DIFF
--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -13,5 +13,5 @@ from intel_owl.tasks import FailureLoggedTask
 # and it bounds a hung Ollama call so it can't occupy a worker indefinitely.
 @shared_task(base=FailureLoggedTask, soft_time_limit=300)
 def process_chat_message(session_id: int, user_message: str, user_id: int) -> str:
-    # TODO: full async implementation added in W6 with the WebSocket consumer.
+    # TODO: full async implementation via the WebSocket consumer + Celery task.
     raise NotImplementedError

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -12,6 +12,7 @@ from .agent.agent import build_agent_executor, format_history
 from .agent.memory import DjangoChatMessageHistory
 from .models import ChatMessage, ChatSession
 from .serializers import (
+    ChatMessageSerializer,
     ChatSessionSerializer,
     MessageRequestSerializer,
     MessageResponseSerializer,
@@ -67,3 +68,29 @@ class ChatSessionViewSet(ModelViewSet):
             MessageResponseSerializer(ai_msg).data,
             status=status.HTTP_200_OK,
         )
+
+    @action(detail=True, methods=["get"], url_path="messages")
+    def messages(self, request, pk=None):
+        """Return a chat session's messages, oldest first, paginated.
+
+        `self.get_object()` resolves the session through `get_queryset()`, which is
+        already scoped to `request.user`, so another user's session yields a 404 for
+        free (no manual ownership check). Messages are ordered by `timestamp` ascending
+        so the frontend can render the conversation top-to-bottom when a chat is reopened.
+
+        Pagination is not automatic inside a custom @action (DRF only paginates the
+        default `list`), so it is driven explicitly via `paginate_queryset` /
+        `get_paginated_response`, mirroring the project's CustomPageNumberPagination
+        default. The `page is None` branch is the idiomatic fallback for when pagination
+        is disabled.
+        """
+        session = self.get_object()
+        queryset = session.messages.order_by("timestamp")
+
+        page = self.paginate_queryset(queryset)
+        if page is not None:
+            serializer = ChatMessageSerializer(page, many=True)
+            return self.get_paginated_response(serializer.data)
+
+        serializer = ChatMessageSerializer(queryset, many=True)
+        return Response(serializer.data)

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -1,8 +1,10 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.utils.timezone import now
 from rest_framework import status
 from rest_framework.test import APITestCase
 
@@ -92,3 +94,81 @@ class ChatSessionViewSetTestCase(APITestCase):
 
     def tearDown(self):
         ChatSession.objects.filter(user=self.user).delete()
+
+
+class ChatSessionMessagesActionTestCase(APITestCase):
+    """Tests for GET /api/chatbot/sessions/{id}/messages."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_messages_user")
+        self.client.force_authenticate(user=self.user)
+        self.session = ChatSession.objects.create(user=self.user)
+
+    @staticmethod
+    def _url(pk):
+        return f"/api/chatbot/sessions/{pk}/messages"
+
+    def test_returns_messages_ordered_by_timestamp(self):
+        # Persist in reverse chronological order to prove the endpoint sorts by
+        # timestamp ascending rather than echoing insertion order.
+        base = now()
+        ChatMessage.objects.create(
+            session=self.session,
+            role=ChatMessage.Role.ASSISTANT,
+            content="second",
+            timestamp=base + timedelta(seconds=2),
+        )
+        ChatMessage.objects.create(
+            session=self.session,
+            role=ChatMessage.Role.USER,
+            content="first",
+            timestamp=base + timedelta(seconds=1),
+        )
+        response = self.client.get(self._url(self.session.pk))
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual([m["content"] for m in results], ["first", "second"])
+        self.assertEqual([m["role"] for m in results], ["user", "assistant"])
+
+    def test_paginated_shape_and_page_size(self):
+        base = now()
+        for i in range(12):
+            ChatMessage.objects.create(
+                session=self.session,
+                role=ChatMessage.Role.USER,
+                content=f"m{i}",
+                timestamp=base + timedelta(seconds=i),
+            )
+        response = self.client.get(self._url(self.session.pk))
+        content = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIn("count", content)
+        self.assertIn("total_pages", content)
+        self.assertIn("results", content)
+        self.assertEqual(content["count"], 12)
+        self.assertEqual(content["total_pages"], 2)
+        self.assertEqual(len(content["results"]), 10)  # PAGE_SIZE default
+
+        page2 = self.client.get(self._url(self.session.pk), {"page": 2}).json()
+        self.assertEqual(len(page2["results"]), 2)
+
+    def test_empty_session_returns_empty_results(self):
+        response = self.client.get(self._url(self.session.pk))
+        content = response.json()
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(content["count"], 0)
+        self.assertEqual(content["results"], [])
+
+    def test_returns_404_for_other_users_session(self):
+        other_user, _ = User.objects.get_or_create(username="chatbot_messages_other_user")
+        other_session = ChatSession.objects.create(user=other_user)
+        response = self.client.get(self._url(other_session.pk))
+        self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
+
+    def test_requires_authentication(self):
+        self.client.force_authenticate(user=None)
+        response = self.client.get(self._url(self.session.pk))
+        self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
+
+    def tearDown(self):
+        ChatSession.objects.filter(user__username__startswith="chatbot_messages_").delete()


### PR DESCRIPTION
# Description

Adds `GET /api/chatbot/sessions/{id}/messages`, a detail action on `ChatSessionViewSet` that returns a chat session's messages ordered by `timestamp` (oldest first), paginated with the project default `CustomPageNumberPagination`. The session is resolved via `self.get_object()`, so the queryset is already scoped to the requesting user and another user's session returns a 404. Reuses the existing (so far unused) `ChatMessageSerializer`. The React chat panel will need this to reload the conversation history when a chat is reopened.

Also a small cleanup: removed an internal week-label from a `# TODO` comment in `chatbot_manager/tasks.py`.

Refs #3725

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop` _(targets the `gsoc-2026/llm-chatbot` umbrella branch instead — the umbrella merges into `develop` at midterm and at the end of GSoC)_
- [x] I have inserted the copyright banner at the start of the file _(no new files added; the edited files already carry it)_
- [x] Please avoid adding new libraries as requirements whenever it is possible _(no new libraries added)_
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature I solved (see `tests/api_app/chatbot_manager/test_views.py`). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
- [x] I have addressed raised Copilot issues. In case of FPs, I have commented the Copilot issue and proved that it is wrong before having the comment resolved.
- [x] I have reviewed and verified any LLM-generated code included in this PR. Parts of this code were developed with AI assistance and have been reviewed, tested, and validated by me.
