### PR TITLE
[GSoC 2026] Add investigation LLM tools to the chatbot agent (refs #3728)

### DIFF
--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -1,8 +1,11 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from .get_investigation_tree import make_get_investigation_tree_tool
 from .get_job_details import make_get_job_details_tool
+from .list_investigations import make_list_investigations_tool
 from .search_jobs import make_search_jobs_tool
+from .summarize_investigation import make_summarize_investigation_tool
 from .summarize_job import make_summarize_job_tool
 
 
@@ -11,11 +14,16 @@ def build_tools(user) -> list:
 
     Each tool is produced by a factory that closes over `user`, so every ORM query the
     agent can run is hard-scoped to that user's data: multi-tenancy is enforced at build
-    time and cannot be widened by anything the LLM emits. Every tool returns a string
-    (LangChain feeds it back as the ReAct "Observation"); see each tool for its shape.
+    time and cannot be widened by anything the LLM emits. Job tools scope on `user=user`;
+    investigation tools scope on `visible_for_user` (owned + organization-shared). Every
+    tool returns a string (LangChain feeds it back as the ReAct "Observation"); see each
+    tool for its shape.
     """
     return [
         make_search_jobs_tool(user),
         make_get_job_details_tool(user),
         make_summarize_job_tool(user),
+        make_list_investigations_tool(user),
+        make_get_investigation_tree_tool(user),
+        make_summarize_investigation_tool(user),
     ]

--- a/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
+++ b/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
@@ -1,0 +1,109 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.tools import tool
+
+# Bounds for the LLM-facing tree: keep the serialized payload small enough not to blow up
+# the prompt regardless of how large an investigation is.
+_MAX_DEPTH = 10
+_MAX_NODES = 200
+
+
+def _compact_node(job) -> dict:
+    """Minimal LLM-facing view of a job node: id, observable, status, children."""
+    return {
+        "id": job.pk,
+        "observable": getattr(job.analyzable, "name", None),
+        "status": job.status,
+        "children": [],
+    }
+
+
+def _build_tree(investigation) -> dict:
+    """Assemble a compact nested tree for an investigation, avoiding the treebeard N+1.
+
+    A Job is a treebeard ``MP_Node``; walking it with ``get_children()`` recursively would
+    fire one query per node. Instead we fetch each root's whole subtree with a single
+    ``get_descendants()`` call and rebuild the nesting in Python from treebeard's
+    materialized ``path`` (a child's parent path is its own path minus the last step), so
+    there are no per-node queries. Depth and node count are capped to bound the payload.
+    """
+    payload = {
+        "id": investigation.pk,
+        "name": investigation.name,
+        "status": investigation.status,
+        "jobs": [],
+    }
+    remaining = _MAX_NODES
+    truncated = False
+
+    # `investigation.jobs` are the root jobs; their descendants live only in the tree.
+    for root in investigation.jobs.select_related("analyzable"):
+        if remaining <= 0:
+            truncated = True
+            break
+        root_node = _compact_node(root)
+        payload["jobs"].append(root_node)
+        remaining -= 1
+        # Map path -> node for every kept node, to link children to parents in O(1).
+        by_path = {root.path: root_node}
+
+        # One query for the whole subtree, in path order (treebeard pre-order DFS), so a
+        # parent is always processed before its children.
+        for job in root.get_descendants().select_related("analyzable").order_by("path"):
+            if (job.depth - root.depth) > _MAX_DEPTH:
+                continue
+            parent = by_path.get(job.path[: -job.steplen])
+            if parent is None:
+                # Ancestor was capped out (depth/budget); skip to avoid orphaning.
+                continue
+            if remaining <= 0:
+                truncated = True
+                break
+            node = _compact_node(job)
+            by_path[job.path] = node
+            parent["children"].append(node)
+            remaining -= 1
+
+    if truncated:
+        payload["truncated"] = True
+    return payload
+
+
+def make_get_investigation_tree_tool(user):
+    # Built per-request and closed over `user`. The lookup is scoped with
+    # `visible_for_user` (owned + organization-shared investigations), so the LLM cannot
+    # reach an investigation the user can't see. Returns a string for the ReAct
+    # "Observation": a JSON-serialized envelope.
+    @tool("get_investigation_tree")
+    def get_investigation_tree(investigation_id: int) -> str:
+        """Get the job tree of an IntelOwl investigation by its numeric ID.
+
+        Returns the investigation with its jobs as a nested tree (each node: id,
+        observable, status, children). Depth and node count are capped for large trees
+        (a `"truncated": true` flag is added when the cap is hit).
+
+        Args:
+            investigation_id: The numeric ID of the investigation.
+
+        Returns:
+            JSON string with shape {"errors": [...], "investigation": {...} | null}.
+        """
+        from api_app.chatbot_manager.serializers import InvestigationTreeResultSerializer
+        from api_app.investigations_manager.models import Investigation
+
+        try:
+            investigation = Investigation.objects.visible_for_user(user).get(pk=investigation_id)
+        except Investigation.DoesNotExist:
+            return InvestigationTreeResultSerializer(
+                {
+                    "errors": [f"Investigation with ID {investigation_id} not found or not accessible."],
+                    "investigation": None,
+                }
+            ).to_json()
+
+        return InvestigationTreeResultSerializer(
+            {"errors": [], "investigation": _build_tree(investigation)}
+        ).to_json()
+
+    return get_investigation_tree

--- a/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
+++ b/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
@@ -1,7 +1,13 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from dataclasses import asdict, dataclass, field
+from typing import List, Optional
+
 from langchain_core.tools import tool
+
+from api_app.chatbot_manager.serializers import InvestigationTreeResultSerializer
+from api_app.investigations_manager.models import Investigation
 
 # Bounds for the LLM-facing tree: keep the serialized payload small enough not to blow up
 # the prompt regardless of how large an investigation is.
@@ -9,18 +15,33 @@ _MAX_DEPTH = 10
 _MAX_NODES = 200
 
 
-def _compact_node(job) -> dict:
-    """Minimal LLM-facing view of a job node: id, observable, status, children."""
-    return {
-        "id": job.pk,
-        "observable": getattr(job.analyzable, "name", None),
-        "status": job.status,
-        "children": [],
-    }
+@dataclass
+class _JobNode:
+    """One job in the LLM-facing tree: id, observable, status and its children."""
+
+    id: int
+    observable: Optional[str]
+    status: str
+    children: List["_JobNode"] = field(default_factory=list)
 
 
-def _build_tree(investigation) -> dict:
-    """Assemble a compact nested tree for an investigation, avoiding the treebeard N+1.
+@dataclass
+class _InvestigationTree:
+    """Compact job tree for an investigation. `truncated` is True when a cap was hit."""
+
+    id: int
+    name: str
+    status: str
+    jobs: List[_JobNode] = field(default_factory=list)
+    truncated: bool = False
+
+
+def _node(job) -> _JobNode:
+    return _JobNode(id=job.pk, observable=getattr(job.analyzable, "name", None), status=job.status)
+
+
+def _build_tree(investigation) -> _InvestigationTree:
+    """Assemble a compact job tree for an investigation, avoiding the treebeard N+1.
 
     A Job is a treebeard ``MP_Node``; walking it with ``get_children()`` recursively would
     fire one query per node. Instead we fetch each root's whole subtree with a single
@@ -28,24 +49,22 @@ def _build_tree(investigation) -> dict:
     materialized ``path`` (a child's parent path is its own path minus the last step), so
     there are no per-node queries. Depth and node count are capped to bound the payload.
     """
-    payload = {
-        "id": investigation.pk,
-        "name": investigation.name,
-        "status": investigation.status,
-        "jobs": [],
-    }
+    tree = _InvestigationTree(
+        id=investigation.pk,
+        name=investigation.name,
+        status=investigation.status,
+    )
     remaining = _MAX_NODES
-    truncated = False
 
     # `investigation.jobs` are the root jobs; their descendants live only in the tree.
     for root in investigation.jobs.select_related("analyzable"):
         if remaining <= 0:
-            truncated = True
+            tree.truncated = True
             break
-        root_node = _compact_node(root)
-        payload["jobs"].append(root_node)
+        root_node = _node(root)
+        tree.jobs.append(root_node)
         remaining -= 1
-        # Map path -> node for every kept node, to link children to parents in O(1).
+        # Index path -> node for every kept node, to link children to parents in O(1).
         by_path = {root.path: root_node}
 
         # One query for the whole subtree, in path order (treebeard pre-order DFS), so a
@@ -58,16 +77,14 @@ def _build_tree(investigation) -> dict:
                 # Ancestor was capped out (depth/budget); skip to avoid orphaning.
                 continue
             if remaining <= 0:
-                truncated = True
+                tree.truncated = True
                 break
-            node = _compact_node(job)
+            node = _node(job)
             by_path[job.path] = node
-            parent["children"].append(node)
+            parent.children.append(node)
             remaining -= 1
 
-    if truncated:
-        payload["truncated"] = True
-    return payload
+    return tree
 
 
 def make_get_investigation_tree_tool(user):
@@ -81,7 +98,7 @@ def make_get_investigation_tree_tool(user):
 
         Returns the investigation with its jobs as a nested tree (each node: id,
         observable, status, children). Depth and node count are capped for large trees
-        (a `"truncated": true` flag is added when the cap is hit).
+        (the `truncated` flag is set to true when the cap is hit).
 
         Args:
             investigation_id: The numeric ID of the investigation.
@@ -89,9 +106,6 @@ def make_get_investigation_tree_tool(user):
         Returns:
             JSON string with shape {"errors": [...], "investigation": {...} | null}.
         """
-        from api_app.chatbot_manager.serializers import InvestigationTreeResultSerializer
-        from api_app.investigations_manager.models import Investigation
-
         try:
             investigation = Investigation.objects.visible_for_user(user).get(pk=investigation_id)
         except Investigation.DoesNotExist:
@@ -103,7 +117,7 @@ def make_get_investigation_tree_tool(user):
             ).to_json()
 
         return InvestigationTreeResultSerializer(
-            {"errors": [], "investigation": _build_tree(investigation)}
+            {"errors": [], "investigation": asdict(_build_tree(investigation))}
         ).to_json()
 
     return get_investigation_tree

--- a/api_app/chatbot_manager/agent/tools/list_investigations.py
+++ b/api_app/chatbot_manager/agent/tools/list_investigations.py
@@ -3,6 +3,14 @@
 
 from langchain_core.tools import tool
 
+from api_app.chatbot_manager.serializers import InvestigationsResultSerializer
+from api_app.investigations_manager.choices import InvestigationStatusChoices
+from api_app.investigations_manager.models import Investigation
+
+# Hard cap on the number of results returned to the LLM (mirrors the job tools), so a
+# single call can't pull an unbounded list into the prompt.
+_MAX_RESULTS = 50
+
 
 def make_list_investigations_tool(user):
     # Built per-request and closed over `user`: the queryset is scoped with
@@ -24,10 +32,6 @@ def make_list_investigations_tool(user):
         Returns:
             JSON string with shape {"errors": [...], "investigations": [...]}.
         """
-        from api_app.chatbot_manager.serializers import InvestigationsResultSerializer
-        from api_app.investigations_manager.choices import InvestigationStatusChoices
-        from api_app.investigations_manager.models import Investigation
-
         errors = []
         qs = Investigation.objects.visible_for_user(user)
 
@@ -43,7 +47,7 @@ def make_list_investigations_tool(user):
                 valid = ", ".join(InvestigationStatusChoices.values)
                 errors.append(f"Unknown status '{status}'; valid values are: {valid}.")
 
-        limit = min(int(limit), 50)
+        limit = min(int(limit), _MAX_RESULTS)
         qs = qs.order_by("-start_time")[:limit]
 
         return InvestigationsResultSerializer({"errors": errors, "investigations": qs}).to_json()

--- a/api_app/chatbot_manager/agent/tools/list_investigations.py
+++ b/api_app/chatbot_manager/agent/tools/list_investigations.py
@@ -1,0 +1,51 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.tools import tool
+
+
+def make_list_investigations_tool(user):
+    # Built per-request and closed over `user`: the queryset is scoped with
+    # `visible_for_user`, which returns the investigations the user owns AND those shared
+    # with their organization (`for_organization=True`). This is wider than the job tools'
+    # `user=user` scope on purpose -- investigations have an explicit org-sharing flag --
+    # and the LLM can never widen it. LangChain feeds a tool's return value back as the
+    # ReAct "Observation", so it must be a string: we return a JSON-serialized envelope.
+    @tool("list_investigations")
+    def list_investigations(query: str = "", status: str = "", limit: int = 10) -> str:
+        """List IntelOwl investigations visible to you (owned or shared with your org).
+
+        Args:
+            query: Filter by investigation name (case-insensitive partial match).
+            status: Filter by investigation status. Valid values: created, running,
+                    concluded. An unknown value is ignored and reported in `errors`.
+            limit: Maximum number of results to return (default 10, max 50).
+
+        Returns:
+            JSON string with shape {"errors": [...], "investigations": [...]}.
+        """
+        from api_app.chatbot_manager.serializers import InvestigationsResultSerializer
+        from api_app.investigations_manager.choices import InvestigationStatusChoices
+        from api_app.investigations_manager.models import Investigation
+
+        errors = []
+        qs = Investigation.objects.visible_for_user(user)
+
+        if query:
+            qs = qs.filter(name__icontains=query)
+        if status:
+            # The status string comes from the LLM; validate it against the enum so an
+            # invalid value surfaces a message instead of silently returning 0 results.
+            normalized = status.strip().lower()
+            if normalized in set(InvestigationStatusChoices.values):
+                qs = qs.filter(status=normalized)
+            else:
+                valid = ", ".join(InvestigationStatusChoices.values)
+                errors.append(f"Unknown status '{status}'; valid values are: {valid}.")
+
+        limit = min(int(limit), 50)
+        qs = qs.order_by("-start_time")[:limit]
+
+        return InvestigationsResultSerializer({"errors": errors, "investigations": qs}).to_json()
+
+    return list_investigations

--- a/api_app/chatbot_manager/agent/tools/summarize_investigation.py
+++ b/api_app/chatbot_manager/agent/tools/summarize_investigation.py
@@ -5,6 +5,9 @@ from collections import Counter
 
 from langchain_core.tools import tool
 
+from api_app.chatbot_manager.serializers import SummarizeInvestigationResultSerializer
+from api_app.investigations_manager.models import Investigation
+
 
 def make_summarize_investigation_tool(user):
     # Built per-request and closed over `user`. Scoped with `visible_for_user` (owned +
@@ -23,9 +26,6 @@ def make_summarize_investigation_tool(user):
         Returns:
             JSON string with shape {"errors": [...], "summary": "..." | null}.
         """
-        from api_app.chatbot_manager.serializers import SummarizeInvestigationResultSerializer
-        from api_app.investigations_manager.models import Investigation
-
         try:
             investigation = Investigation.objects.visible_for_user(user).get(pk=investigation_id)
         except Investigation.DoesNotExist:

--- a/api_app/chatbot_manager/agent/tools/summarize_investigation.py
+++ b/api_app/chatbot_manager/agent/tools/summarize_investigation.py
@@ -1,0 +1,69 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from collections import Counter
+
+from langchain_core.tools import tool
+
+
+def make_summarize_investigation_tool(user):
+    # Built per-request and closed over `user`. Scoped with `visible_for_user` (owned +
+    # organization-shared investigations). The payload is human-readable prose wrapped in
+    # the same envelope as the other tools (LangChain needs a string Observation).
+    @tool("summarize_investigation")
+    def summarize_investigation(investigation_id: int) -> str:
+        """Return a concise human-readable summary of an IntelOwl investigation.
+
+        Includes the status, total jobs, a per-status breakdown of the jobs, TLP, tags and
+        the start/end times.
+
+        Args:
+            investigation_id: The numeric ID of the investigation to summarize.
+
+        Returns:
+            JSON string with shape {"errors": [...], "summary": "..." | null}.
+        """
+        from api_app.chatbot_manager.serializers import SummarizeInvestigationResultSerializer
+        from api_app.investigations_manager.models import Investigation
+
+        try:
+            investigation = Investigation.objects.visible_for_user(user).get(pk=investigation_id)
+        except Investigation.DoesNotExist:
+            return SummarizeInvestigationResultSerializer(
+                {
+                    "errors": [f"Investigation with ID {investigation_id} not found or not accessible."],
+                    "summary": None,
+                }
+            ).to_json()
+
+        # Count jobs by status across the whole tree. `investigation.jobs` are the roots;
+        # the rest live in the treebeard tree, so we walk each subtree once (one query per
+        # root, status column only) rather than per node.
+        status_counts = Counter()
+        for root in investigation.jobs.all():
+            status_counts[root.status] += 1
+            for child_status in root.get_descendants().values_list("status", flat=True):
+                status_counts[child_status] += 1
+
+        # The total equals Investigation.total_jobs but is derived from the counts we
+        # already gathered, so we don't re-query the tree.
+        total_jobs = sum(status_counts.values())
+        tags = [label for label in investigation.tags if label]
+
+        lines = [
+            f"Investigation #{investigation.pk}: {investigation.name}",
+            f"  Status     : {investigation.status}",
+            f"  Total jobs : {total_jobs}",
+            f"  TLP        : {investigation.tlp}",
+        ]
+        if status_counts:
+            breakdown = ", ".join(f"{status}: {count}" for status, count in sorted(status_counts.items()))
+            lines.append(f"  Job status : {breakdown}")
+        if tags:
+            lines.append(f"  Tags       : {', '.join(tags)}")
+        lines.append(f"  Started    : {investigation.start_time}")
+        lines.append(f"  Ended      : {investigation.end_time or 'N/A'}")
+
+        return SummarizeInvestigationResultSerializer({"errors": [], "summary": "\n".join(lines)}).to_json()
+
+    return summarize_investigation

--- a/api_app/chatbot_manager/serializers.py
+++ b/api_app/chatbot_manager/serializers.py
@@ -6,6 +6,7 @@ import json
 from rest_framework import serializers
 
 from api_app.analyzers_manager.models import AnalyzerReport
+from api_app.investigations_manager.models import Investigation
 from api_app.models import Job
 
 from .models import ChatMessage, ChatSession
@@ -90,6 +91,35 @@ class JobDetailResultSerializer(ToolResultSerializer):
 
 
 class SummarizeJobResultSerializer(ToolResultSerializer):
+    summary = serializers.CharField(allow_null=True)
+
+
+class InvestigationToolSerializer(serializers.ModelSerializer):
+    """Compact, LLM-facing Investigation view for list results (no owner/PII fields).
+
+    Deliberately exposes only DB columns. `Investigation.tlp`, `.tags` and `.total_jobs`
+    are @properties that each query the `jobs` relation, so including them here would fire
+    extra queries for every row (N+1 across a list). Those aggregate fields are surfaced
+    instead by `summarize_investigation` / `get_investigation_tree`, which operate on a
+    single investigation where the cost is bounded.
+    """
+
+    class Meta:
+        model = Investigation
+        fields = ["id", "name", "status", "start_time", "end_time"]
+
+
+class InvestigationsResultSerializer(ToolResultSerializer):
+    investigations = InvestigationToolSerializer(many=True)
+
+
+class InvestigationTreeResultSerializer(ToolResultSerializer):
+    # The tree is assembled in Python (in the tool) to avoid the treebeard per-node N+1,
+    # so the payload is already a plain nested dict; the envelope only JSON-serializes it.
+    investigation = serializers.DictField(read_only=True, allow_null=True)
+
+
+class SummarizeInvestigationResultSerializer(ToolResultSerializer):
     summary = serializers.CharField(allow_null=True)
 
 

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -10,7 +10,10 @@ from api_app.analyzables_manager.models import Analyzable
 from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.chatbot_manager.agent.tools import build_tools
 from api_app.choices import Classification
+from api_app.investigations_manager.models import Investigation
 from api_app.models import Job
+from certego_saas.apps.organization.membership import Membership
+from certego_saas.apps.organization.organization import Organization
 from certego_saas.apps.user.models import User
 
 
@@ -111,3 +114,143 @@ class SearchJobsToolTestCase(TestCase):
 
     def tearDown(self):
         Job.objects.filter(user__in=[self.user, self.other_user]).delete()
+
+
+class InvestigationToolsTestCase(TestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="inv_tool_user")
+        # Same organization as self.user: used to test that org-shared investigations are
+        # visible (visible_for_user) while another member's private ones are not.
+        self.org_member, _ = User.objects.get_or_create(username="inv_tool_org_member")
+        self.org, _ = Organization.objects.get_or_create(name="inv tool organization")
+        Membership.objects.get_or_create(user=self.user, organization=self.org, is_owner=True)
+        Membership.objects.get_or_create(user=self.org_member, organization=self.org, is_owner=False)
+
+        self.analyzable, _ = Analyzable.objects.get_or_create(
+            name="inv.example.com",
+            classification=Classification.DOMAIN,
+        )
+
+        self.inv_created = Investigation.objects.create(
+            owner=self.user,
+            name="alpha investigation",
+            status=Investigation.STATUSES.CREATED.value,
+        )
+        self.inv_running = Investigation.objects.create(
+            owner=self.user,
+            name="beta investigation",
+            status=Investigation.STATUSES.RUNNING.value,
+        )
+        # Owned by another member of the same org and shared at org level -> visible.
+        self.inv_org_shared = Investigation.objects.create(
+            owner=self.org_member,
+            name="gamma investigation",
+            status=Investigation.STATUSES.CONCLUDED.value,
+            for_organization=True,
+        )
+        # Owned by another member but NOT shared -> must stay invisible to self.user.
+        self.inv_private = Investigation.objects.create(
+            owner=self.org_member,
+            name="delta investigation",
+            status=Investigation.STATUSES.CREATED.value,
+            for_organization=False,
+        )
+
+        # A small job tree on inv_created: root1 -> child1 (different status) + root2,
+        # so the tree has nesting and the status breakdown spans >= 2 statuses.
+        self.root1 = Job.objects.create(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+        )
+        self.child1 = self.root1.add_child(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.FAILED,
+        )
+        self.root2 = Job.objects.create(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.RUNNING,
+        )
+        self.inv_created.jobs.add(self.root1, self.root2)
+
+        tools_by_name = {t.name: t for t in build_tools(user=self.user)}
+        self.list_investigations = tools_by_name["list_investigations"]
+        self.get_investigation_tree = tools_by_name["get_investigation_tree"]
+        self.summarize_investigation = tools_by_name["summarize_investigation"]
+
+    def tearDown(self):
+        Job.objects.filter(user__in=[self.user, self.org_member]).delete()
+        Investigation.objects.filter(owner__in=[self.user, self.org_member]).delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()
+
+    def test_list_investigations_status_filter(self):
+        data = json.loads(self.list_investigations.invoke({"status": "running"}))
+        self.assertEqual(data["errors"], [])
+        ids = [i["id"] for i in data["investigations"]]
+        self.assertIn(self.inv_running.pk, ids)
+        self.assertNotIn(self.inv_created.pk, ids)
+
+    def test_list_investigations_name_filter(self):
+        data = json.loads(self.list_investigations.invoke({"query": "beta"}))
+        ids = [i["id"] for i in data["investigations"]]
+        self.assertEqual(ids, [self.inv_running.pk])
+
+    def test_list_investigations_limit(self):
+        data = json.loads(self.list_investigations.invoke({"limit": 1}))
+        self.assertEqual(len(data["investigations"]), 1)
+
+    def test_list_investigations_isolation_and_org_shared(self):
+        data = json.loads(self.list_investigations.invoke({}))
+        ids = [i["id"] for i in data["investigations"]]
+        # owned + org-shared are visible
+        self.assertIn(self.inv_created.pk, ids)
+        self.assertIn(self.inv_running.pk, ids)
+        self.assertIn(self.inv_org_shared.pk, ids)
+        # another member's private investigation is NOT visible
+        self.assertNotIn(self.inv_private.pk, ids)
+
+    def test_list_investigations_invalid_status(self):
+        data = json.loads(self.list_investigations.invoke({"status": "bogus"}))
+        # invalid status is reported and the filter is ignored (results still returned)
+        self.assertTrue(data["errors"])
+        self.assertIn("Unknown status", data["errors"][0])
+        ids = [i["id"] for i in data["investigations"]]
+        self.assertIn(self.inv_created.pk, ids)
+
+    def test_get_investigation_tree_structure(self):
+        data = json.loads(self.get_investigation_tree.invoke({"investigation_id": self.inv_created.pk}))
+        self.assertEqual(data["errors"], [])
+        tree = data["investigation"]
+        self.assertEqual(tree["id"], self.inv_created.pk)
+        nodes = {n["id"]: n for n in tree["jobs"]}
+        self.assertIn(self.root1.pk, nodes)
+        self.assertIn(self.root2.pk, nodes)
+        self.assertEqual(nodes[self.root1.pk]["observable"], "inv.example.com")
+        child_ids = [c["id"] for c in nodes[self.root1.pk]["children"]]
+        self.assertEqual(child_ids, [self.child1.pk])
+        self.assertEqual(nodes[self.root2.pk]["children"], [])
+
+    def test_get_investigation_tree_not_visible(self):
+        data = json.loads(self.get_investigation_tree.invoke({"investigation_id": self.inv_private.pk}))
+        self.assertIsNone(data["investigation"])
+        self.assertTrue(data["errors"])
+        self.assertIn("not found or not accessible", data["errors"][0])
+
+    def test_summarize_investigation_breakdown(self):
+        summary = json.loads(self.summarize_investigation.invoke({"investigation_id": self.inv_created.pk}))[
+            "summary"
+        ]
+        self.assertIn(f"Investigation #{self.inv_created.pk}", summary)
+        self.assertIn("Total jobs : 3", summary)
+        # breakdown must span the distinct job statuses, not just one branch
+        self.assertIn(Job.STATUSES.REPORTED_WITHOUT_FAILS.value, summary)
+        self.assertIn(Job.STATUSES.FAILED.value, summary)
+        self.assertIn(Job.STATUSES.RUNNING.value, summary)
+
+    def test_summarize_investigation_not_visible(self):
+        data = json.loads(self.summarize_investigation.invoke({"investigation_id": self.inv_private.pk}))
+        self.assertIsNone(data["summary"])
+        self.assertTrue(data["errors"])


### PR DESCRIPTION
# Description

Refs #3728.

Adds three tools to the chatbot's LangChain ReAct agent that wrap IntelOwl's Investigation
API, so an analyst can query investigations in natural language:

- `list_investigations(query, status, limit)` -> lists investigations visible to the user
  (optional name and status filters). An invalid `status` is reported in `errors` instead
  of silently returning no results.
- `get_investigation_tree(investigation_id)` -> returns the investigation's jobs as a
  compact nested tree.
- `summarize_investigation(investigation_id)` -> returns a human-readable summary (status,
  total jobs, per-status job breakdown, TLP, tags, start/end).

Each tool is built per-request and closes over the requesting `user`, so multi-tenancy is
enforced in the closure and cannot be widened by anything the LLM emits. Investigations are
scoped with `Investigation.objects.visible_for_user(user)` (owner + organization-shared,
`for_organization=True`) -> the same scope as `InvestigationViewSet` -> which is intentionally
wider than the existing job tools' `user=user` scope, because investigations carry an
explicit org-sharing flag.

The tree is assembled in Python to avoid a treebeard per-node N+1: one `get_descendants()`
query per root job, with the nesting rebuilt from the materialized `path`; depth and node
count are capped (a `truncated` flag is set when the cap is hit). Descendant jobs in the
investigation tree are gated at the investigation level via `visible_for_user` (UI parity
with `InvestigationViewSet`), not re-scoped per-job. Tree nodes expose only
id/observable/status — no PII.

Outputs reuse the existing `ToolResultSerializer` envelope (`{"errors": [...], <payload>}`)
with purpose-built lightweight DRF serializers (no owner/PII). The list serializer
deliberately exposes only DB columns: `Investigation.tlp/tags/total_jobs` are properties
that each hit the `jobs` relation, so listing them per row would be an N+1; those aggregate
fields are surfaced by `summarize_investigation`/`get_investigation_tree` on a single
investigation instead.

No new dependencies, no new env vars, no migrations.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop` _(targets the `gsoc-2026/llm-chatbot` umbrella branch)_
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. _(no new libraries added)_
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
- [x] I have addressed raised Copilot issues. In case of FPs, I have commented the Copilot issue and proved that it is wrong before having the comment resolved.
- [x] I have reviewed and verified any LLM-generated code included in this PR. Also, I have explicitly stated that I have used LLMs in this PR.
