### PR TITLE
[Connectors] Fix before_run to fail on partial analyer failures when run_on_failure is False

### DIFF
--- a/api_app/connectors_manager/classes.py
+++ b/api_app/connectors_manager/classes.py
@@ -51,7 +51,7 @@ class Connector(Plugin, metaclass=abc.ABCMeta):
         if (
             self._config.run_on_failure
             or not self._job.analyzerreports.count()
-            or self._job.analyzerreports.exclude(status=ReportStatus.FAILED.value).exists()
+            or not self._job.analyzerreports.filter(status=ReportStatus.FAILED.value).exists()
         ):
             logger.info(
                 f"Running connector {self.__class__.__name__} "

--- a/tests/api_app/connectors_manager/test_classes.py
+++ b/tests/api_app/connectors_manager/test_classes.py
@@ -138,3 +138,52 @@ class ConnectorTestCase(CustomTestCase):
                     signal.alarm(0)
         job.delete()
         an1.delete()
+
+    def test_before_run_partial_failure(self):
+        # run_on_failure=False + partial failure (mix of FAILED and SUCCESS) should raise ConnectorRunException
+        class MockUpConnector(Connector):
+            def run(self) -> dict:
+                return {}
+
+        an = Analyzable.objects.create(
+            name="test.com",
+            classification=Classification.DOMAIN,
+        )
+
+        job = Job.objects.create(
+            analyzable=an,
+            status=Job.STATUSES.CONNECTORS_RUNNING.value,
+        )
+        AnalyzerReport.objects.create(
+            report={},
+            job=job,
+            config=AnalyzerConfig.objects.first(),
+            status=AnalyzerReport.STATUSES.FAILED.value,
+            task_id=str(uuid()),
+            parameters={},
+        )
+        AnalyzerReport.objects.create(
+            report={},
+            job=job,
+            config=AnalyzerConfig.objects.last(),
+            status=AnalyzerReport.STATUSES.SUCCESS.value,
+            task_id=str(uuid()),
+            parameters={},
+        )
+        cc = ConnectorConfig.objects.create(
+            name="test",
+            python_module=PythonModule.objects.get(
+                base_path=PythonModuleBasePaths.Connector.value, module="misp.MISP"
+            ),
+            description="test",
+            disabled=True,
+            maximum_tlp="CLEAR",
+            run_on_failure=False,
+        )
+        with self.assertRaises(ConnectorRunException):
+            muc = MockUpConnector(cc)
+            muc.job_id = job.pk
+            muc.before_run()
+        cc.delete()
+        job.delete()
+        an.delete()


### PR DESCRIPTION
Closes #3705 

# Description
- Connectors execute incorrectly when partial analyzer failures occur and run_on_failure is set to False
- This PR adds a test to confirm that and fixes the issue. 

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.