### PR TITLE
[GSoC 2026] Add get_data_model LLM tool to the chatbot agent (refs #3728)

### DIFF
--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from .get_data_model import make_get_data_model_tool
 from .get_investigation_tree import make_get_investigation_tree_tool
 from .get_job_details import make_get_job_details_tool
 from .list_investigations import make_list_investigations_tool
@@ -26,4 +27,5 @@ def build_tools(user) -> list:
         make_list_investigations_tool(user),
         make_get_investigation_tree_tool(user),
         make_summarize_investigation_tool(user),
+        make_get_data_model_tool(user),
     ]

--- a/api_app/chatbot_manager/agent/tools/get_data_model.py
+++ b/api_app/chatbot_manager/agent/tools/get_data_model.py
@@ -1,0 +1,42 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.tools import tool
+
+from api_app.chatbot_manager.serializers import DataModelResultSerializer
+from api_app.models import Job
+
+
+def make_get_data_model_tool(user):
+    # Built per-request and closed over `user`, so the lookup is hard-scoped to that user's
+    # jobs (multi-tenancy enforced here), matching the other job tools' `user=user` scope.
+    # LangChain feeds a tool's return value back as the ReAct "Observation", so it must be a
+    # string: we return a JSON-serialized envelope.
+    @tool("get_data_model")
+    def get_data_model(job_id: int) -> str:
+        """Get the aggregated data model of an IntelOwl job by its numeric ID.
+
+        The data model is IntelOwl's normalized, analyzer-agnostic view of a job's
+        observable (evaluation, reliability, tags, kill-chain phase, plus type-specific
+        fields for domains/IPs/files). It is empty until the analysis pipeline has built
+        it, so an empty object is a valid result.
+
+        Args:
+            job_id: The numeric ID of the job.
+
+        Returns:
+            JSON string with shape {"errors": [...], "data_model": {...}}.
+        """
+        try:
+            job = Job.objects.get(pk=job_id, user=user)
+        except Job.DoesNotExist:
+            return DataModelResultSerializer(
+                {"errors": [f"Job with ID {job_id} not found or not accessible."], "data_model": {}}
+            ).to_json()
+
+        # Mirror the public JobSerializer.get_data_model: the model serializes itself
+        # (polymorphic across Domain/IP/File); `data_model` is a nullable GenericForeignKey.
+        data_model = job.data_model.serialize() if job.data_model else {}
+        return DataModelResultSerializer({"errors": [], "data_model": data_model}).to_json()
+
+    return get_data_model

--- a/api_app/chatbot_manager/serializers.py
+++ b/api_app/chatbot_manager/serializers.py
@@ -123,6 +123,13 @@ class SummarizeInvestigationResultSerializer(ToolResultSerializer):
     summary = serializers.CharField(allow_null=True)
 
 
+class DataModelResultSerializer(ToolResultSerializer):
+    # `data_model` is already produced by the model's own DRF serializer
+    # (`BaseDataModel.serialize()`, polymorphic across Domain/IP/File), so the envelope
+    # just carries that dict (empty `{}` when the job has no data model).
+    data_model = serializers.DictField(read_only=True)
+
+
 class ChatSessionSerializer(serializers.ModelSerializer):
     class Meta:
         model = ChatSession

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -10,6 +10,7 @@ from api_app.analyzables_manager.models import Analyzable
 from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.chatbot_manager.agent.tools import build_tools
 from api_app.choices import Classification
+from api_app.data_model_manager.models import DomainDataModel
 from api_app.investigations_manager.models import Investigation
 from api_app.models import Job
 from certego_saas.apps.organization.membership import Membership
@@ -254,3 +255,56 @@ class InvestigationToolsTestCase(TestCase):
         data = json.loads(self.summarize_investigation.invoke({"investigation_id": self.inv_private.pk}))
         self.assertIsNone(data["summary"])
         self.assertTrue(data["errors"])
+
+
+class DataModelToolTestCase(TestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="dm_tool_user")
+        self.other_user, _ = User.objects.get_or_create(username="dm_tool_other_user")
+        self.analyzable, _ = Analyzable.objects.get_or_create(
+            name="dm.example.com",
+            classification=Classification.DOMAIN,
+        )
+        # Job with an aggregated data model attached (as the analysis pipeline would set it).
+        self.job_with_dm = Job.objects.create(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+        )
+        self.data_model = DomainDataModel.objects.create()
+        self.job_with_dm.data_model = self.data_model
+        self.job_with_dm.save()
+        # Job without a data model.
+        self.job_without_dm = Job.objects.create(
+            user=self.user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+        )
+        # Another user's job (must stay inaccessible).
+        self.other_job = Job.objects.create(
+            user=self.other_user,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+        )
+        self.get_data_model = {t.name: t for t in build_tools(user=self.user)}["get_data_model"]
+
+    def tearDown(self):
+        Job.objects.filter(user__in=[self.user, self.other_user]).delete()
+        self.data_model.delete()
+
+    def test_get_data_model_returns_serialized(self):
+        data = json.loads(self.get_data_model.invoke({"job_id": self.job_with_dm.pk}))
+        self.assertEqual(data["errors"], [])
+        self.assertTrue(data["data_model"])
+        self.assertIn("reliability", data["data_model"])
+
+    def test_get_data_model_empty_when_absent(self):
+        data = json.loads(self.get_data_model.invoke({"job_id": self.job_without_dm.pk}))
+        self.assertEqual(data["errors"], [])
+        self.assertEqual(data["data_model"], {})
+
+    def test_get_data_model_forbidden_other_user(self):
+        data = json.loads(self.get_data_model.invoke({"job_id": self.other_job.pk}))
+        self.assertEqual(data["data_model"], {})
+        self.assertTrue(data["errors"])
+        self.assertIn("not found or not accessible", data["errors"][0])


### PR DESCRIPTION
# Description

Refs #3728. Follow-up to #3729 (investigation tools); soft-depends on it for the shared
touchpoints (`build_tools` in `agent/tools/__init__.py` and `serializers.py`), which are now
merged into the umbrella, so this PR applies cleanly on top.

Adds a fourth tool to the chatbot's LangChain ReAct agent:

- `get_data_model(job_id)` — returns a job's aggregated data model (IntelOwl's normalized,
  analyzer-agnostic view of the observable: evaluation, reliability, tags, kill-chain phase,
  plus type-specific fields for domains/IPs/files).

The tool is built per-request and closes over the requesting `user`, and the lookup is
hard-scoped with `Job.objects.get(pk=job_id, user=user)` — the same owner-strict scope as the
existing job tools (`search_jobs`, `get_job_details`, `summarize_job`). It mirrors the public
`JobSerializer.get_data_model`: `data_model` is a nullable `GenericForeignKey`, so the tool
returns `job.data_model.serialize()` when present and an empty object otherwise.

The result rides the existing `ToolResultSerializer` envelope as `DataModelResultSerializer`,
where `data_model` is a `DictField`. This is not a hand-built dict: `BaseDataModel.serialize()`
is the model's own DRF serializer output (polymorphic across `DomainDataModel`/`IPDataModel`/
`FileDataModel`), so the envelope simply carries that already-serialized dict.

No new dependencies, no new env vars, no migrations.

This PR was developed with the assistance of an LLM; all generated code has been reviewed
and verified.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop` _(targets the `gsoc-2026/llm-chatbot` umbrella branch)_
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. _(no new libraries added)_
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
- [x] I have addressed raised Copilot issues. In case of FPs, I have commented the Copilot issue and proved that it is wrong before having the comment resolved.
- [x] I have reviewed and verified any LLM-generated code included in this PR. Also, I have explicitly stated that I have used LLMs in this PR.
