### PR TITLE
fix(analyzers): handle empty ASN history in BGPRanking

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/bgp_ranking.py
+++ b/api_app/analyzers_manager/observable_analyzers/bgp_ranking.py
@@ -33,7 +33,11 @@ class BGPRanking(classes.ObservableAnalyzer):
         )
         response.raise_for_status()
         response = response.json()
-        asn = response.get("response", {}).popitem()[1].get("asn", None)
+        asn_history = response.get("response", {})
+        # an IP with no ASN history returns an empty "response"; peek the latest
+        # entry without mutating it (popitem() would crash on the empty dict and,
+        # when populated, drop the entry from the error message below)
+        asn = list(asn_history.values())[-1].get("asn", None) if asn_history else None
         if not asn:
             raise AnalyzerRunException(f"ASN not found in {response}")
         logger.info(f"ASN {asn} extracted from {self.observable_name}")

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_bgp_ranking.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_bgp_ranking.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from api_app.analyzers_manager.exceptions import AnalyzerRunException
+from api_app.analyzers_manager.observable_analyzers import bgp_ranking as bgp_ranking_module
 from api_app.analyzers_manager.observable_analyzers.bgp_ranking import BGPRanking
 from tests.api_app.analyzers_manager.unit_tests.observable_analyzers.base_test_class import (
     BaseAnalyzerTest,
@@ -9,6 +12,26 @@ from tests.mock_utils import MockUpResponse
 
 class BGPRankingTestCase(BaseAnalyzerTest):
     analyzer_class = BGPRanking
+
+    def test_run_raises_clean_exception_on_empty_asn_history(self):
+        # An IP with no ASN history returns an empty "response" object. The
+        # analyzer must raise a clean AnalyzerRunException instead of crashing
+        # with "KeyError: 'popitem(): dictionary is empty'". The analyzer is
+        # built with a stand-in config so the test runs deterministically and is
+        # not skipped when no AnalyzerConfig is loaded in the DB.
+        analyzer = BGPRanking(SimpleNamespace(name="BGPRanking"))
+        analyzer.observable_name = "8.8.8.8"
+        analyzer.url = "https://bgp-ranking.circl.lu"
+        analyzer.timeout = 30
+        with (
+            patch.object(
+                bgp_ranking_module.requests,
+                "get",
+                return_value=MockUpResponse({"meta": {"ip": "8.8.8.8"}, "response": {}}, 200),
+            ),
+            self.assertRaises(AnalyzerRunException),
+        ):
+            analyzer.run()
 
     @staticmethod
     def get_mocked_response():


### PR DESCRIPTION
## Description

When BGP Ranking has no ASN history for an IP, the API returns an empty `response` object. The current implementation calls `.popitem()` on that empty dictionary, resulting in an uncaught:

```text
KeyError: 'popitem(): dictionary is empty'
```

This occurs before the intended `AnalyzerRunException("ASN not found ...")` can be raised.

This change handles the empty-response case explicitly, allowing the analyzer to raise a clean `AnalyzerRunException` instead of terminating with a traceback. Behavior remains unchanged when ASN history is available.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added a regression test, `test_run_raises_clean_exception_on_empty_asn_history`, which mocks an empty API response:

```python
{"response": {}}
```

The test verifies that `AnalyzerRunException` is raised.

* Fails on the current code with:

  ```text
  KeyError: 'popitem(): dictionary is empty'
  ```
* Passes with this fix applied.

All existing tests continue to pass. `ruff check` and `ruff format --check` are also clean.
