### PR TITLE
fix(analyzers): handle empty results in Netlas

### DIFF
--- a/api_app/analyzers_manager/observable_analyzers/netlas.py
+++ b/api_app/analyzers_manager/observable_analyzers/netlas.py
@@ -32,5 +32,9 @@ class Netlas(classes.ObservableAnalyzer):
         except requests.RequestException as e:
             raise AnalyzerRunException(e)
 
-        result = response.json()["items"][0]["data"]
-        return result
+        # an IP with no whois record returns an empty "items" list, which must
+        # not crash with an IndexError when accessing the first element
+        items = response.json().get("items")
+        if not items:
+            raise AnalyzerRunException(f"No Netlas whois data found for {self.observable_name}")
+        return items[0]["data"]

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_netlas.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_netlas.py
@@ -1,5 +1,8 @@
+from types import SimpleNamespace
 from unittest.mock import patch
 
+from api_app.analyzers_manager.exceptions import AnalyzerRunException
+from api_app.analyzers_manager.observable_analyzers import netlas as netlas_module
 from api_app.analyzers_manager.observable_analyzers.netlas import Netlas
 from tests.api_app.analyzers_manager.unit_tests.observable_analyzers.base_test_class import (
     BaseAnalyzerTest,
@@ -9,6 +12,26 @@ from tests.mock_utils import MockUpResponse
 
 class NetlasTestCase(BaseAnalyzerTest):
     analyzer_class = Netlas
+
+    def test_run_raises_clean_exception_on_empty_items(self):
+        # An IP with no whois record returns an empty "items" list. The analyzer
+        # must raise a clean AnalyzerRunException instead of crashing with
+        # "IndexError: list index out of range". The analyzer is built with a
+        # stand-in config so the test runs deterministically and is not skipped
+        # when no AnalyzerConfig is loaded in the DB.
+        analyzer = Netlas(SimpleNamespace(name="Netlas"))
+        analyzer.observable_name = "8.8.8.8"
+        analyzer.parameters = {"q": "ip:8.8.8.8"}
+        analyzer.headers = {"X-API-Key": "mock-api-key"}
+        with (
+            patch.object(
+                netlas_module.requests,
+                "get",
+                return_value=MockUpResponse({"items": [], "took": 1}, 200),
+            ),
+            self.assertRaises(AnalyzerRunException),
+        ):
+            analyzer.run()
 
     @staticmethod
     def get_mocked_response():


### PR DESCRIPTION
## Description

When Netlas has no WHOIS record for an IP, the API returns an empty `items` list. The current implementation accesses:

```python
response.json()["items"][0]["data"]
```

which results in an uncaught:

```text
IndexError: list index out of range
```

when no results are returned.

This change handles empty or missing `items` responses explicitly, allowing the analyzer to raise a clean `AnalyzerRunException` instead of failing with a traceback. Behavior remains unchanged when WHOIS data is available.

## Type of Change

* [x] Bug fix (non-breaking change that fixes an issue)

## Tests

Added a regression test, `test_run_raises_clean_exception_on_empty_items`, which mocks the API response:

```python
{"items": []}
```

The test verifies that `AnalyzerRunException` is raised.

* Fails on the current code with:

  ```text
  IndexError: list index out of range
  ```
* Passes with this fix applied.

All existing tests continue to pass. `ruff check` and `ruff format --check` are also clean.
