### PR TITLE
[Connectors] Refactor YETI to API v2 payload and auth schemas

### DIFF
--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -48,7 +48,7 @@ class YETI(classes.Connector):
             "source": "IntelOwl",
             "report": f"{settings.WEB_CLIENT_URL}/jobs/{self.job_id}",
             "status": "analyzed",
-            "date": str(self._job.finished_analysis_time),
+            "date": str(self._job.received_request_time),
             "description": f"IntelOwl's analysis report for Job: {self.job_id} | {obs_value} | {obs_type}",
             "analyzers executed": ", ".join(
                 list(self._job.analyzers_to_execute.all().values_list("name", flat=True))

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -73,7 +73,7 @@ class YETI(classes.Connector):
 
         # auth
         auth_url = f"{self._url_key_name}/api/v2/auth/api-token"
-        auth_headers = {"x-yeti-apikey": self._api_key_name}
+        auth_headers = {"x-yeti-apikey": self._api_key_name, "User-Agent": "IntelOwl"}
 
         try:
             auth_resp = requests.post(
@@ -94,7 +94,11 @@ class YETI(classes.Connector):
         # new context, tags, source are appended with existing ones
 
         url = f"{self._url_key_name}/api/v2/observables/extended"
-        headers = {"Accept": "application/json", "Authorization": f"Bearer {access_token}"}
+        headers = {
+            "Accept": "application/json",
+            "User-Agent": "IntelOwl",
+            "Authorization": f"Bearer {access_token}",
+        }
 
         try:
             resp = requests.post(

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -40,18 +40,44 @@ class YETI(classes.Connector):
 
         # request payload
         payload = {
-            "value": obs_value,
-            "source": "IntelOwl",
             "tags": tags,
-            "context": context,
+            "observable": {
+                # there are type mismatches between YETI and IntelOwl
+                # so for now we are not senging the type to YETI
+                # "type": obs_type,
+                "value": obs_value,
+                "context": [context],
+            },
         }
-        headers = {"Accept": "application/json", "X-Api-Key": self._api_key_name}
+
         if self._url_key_name and self._url_key_name.endswith("/"):
             self._url_key_name = self._url_key_name[:-1]
-        url = f"{self._url_key_name}/api/v2/observables/"
+
+        # auth
+        auth_url = f"{self._url_key_name}/api/v2/auth/api-token"
+        auth_headers = {"x-yeti-apikey": self._api_key_name}
+
+        try:
+            auth_resp = requests.post(
+                url=auth_url,
+                headers=auth_headers,
+                verify=self.verify_ssl,
+                timeout=60,
+            )
+            auth_resp.raise_for_status()
+            access_token = auth_resp.json().get("access_token")
+
+            if not access_token:
+                raise ConnectorRunException("Failed to obtain access token from YETI.")
+        except requests.RequestException as e:
+            raise ConnectorRunException(f"YETI Auth Request failed: {e}")
 
         # create observable with `obs_value` if it doesn't exists
         # new context, tags, source are appended with existing ones
+
+        url = f"{self._url_key_name}/api/v2/observables/extended"
+        headers = {"Accept": "application/json", "Authorization": f"Bearer {access_token}"}
+
         try:
             resp = requests.post(
                 url=url,

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import ipaddress
+
 import requests
 from django.conf import settings
 
@@ -23,6 +25,24 @@ class YETI(classes.Connector):
             obs_value = self._job.analyzable.name
             obs_type = self._job.analyzable.classification
 
+        # convert obs_type to YETI's expected types if possible
+        if obs_type == "ip":
+            # mark whether the IP is ipv4 or ipv6, fallback to generic on error
+            try:
+                ip_obj = ipaddress.ip_address(obs_value)
+                if ip_obj.version == 4:
+                    obs_type = "ipv4"
+                elif ip_obj.version == 6:
+                    obs_type = "ipv6"
+                else:
+                    obs_type = "generic"
+            except Exception:
+                obs_type = "generic"
+        elif obs_type == "domain":
+            obs_type = "hostname"
+        elif obs_type == "hash":
+            obs_type = "generic"
+
         # create context
         context = {
             "source": "IntelOwl",
@@ -42,9 +62,7 @@ class YETI(classes.Connector):
         payload = {
             "tags": tags,
             "observable": {
-                # there are type mismatches between YETI and IntelOwl
-                # so for now we are not senging the type to YETI
-                # "type": obs_type,
+                "type": obs_type,
                 "value": obs_value,
                 "context": [context],
             },

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
@@ -1,0 +1,140 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from requests.exceptions import HTTPError
+
+from api_app.connectors_manager.connectors.yeti import YETI
+from api_app.connectors_manager.exceptions import ConnectorRunException
+from tests.api_app.connectors_manager.unit_tests.base_test_class import BaseConnectorTest
+
+
+class MockResponse:
+    # Mock replacement for requests.Response objects to support raise_for_status
+
+    def __init__(self, json_data, status_code):
+        self.json_data = json_data
+        self.status_code = status_code
+
+    def json(self):
+        return self.json_data
+
+    def raise_for_status(self):
+        if self.status_code >= 400:
+            raise HTTPError(f"HTTP Error: {self.status_code}")
+
+
+def mock_yeti_api_flow(url, *args, **kwargs):
+    # Dynamic mock router to handle different YETI API endpoints
+
+    if "api-token" in url:
+        return MockResponse({"access_token": "mocked_jwt_token_123", "token_type": "bearer"}, 200)
+
+    if "observables/extended" in url:
+        return MockResponse(
+            {
+                "context": [
+                    {
+                        "source": "IntelOwl",
+                        "report": "https://intelowl.example/jobs/51",
+                        "status": "analyzed",
+                        "date": "2026-06-02T12:34:56Z",
+                        "description": "IntelOwl analysis report for Job: 51 | 1.2.3.4 | ipv4",
+                        "analyzers executed": "IPApi",
+                    }
+                ],
+                "tags": [
+                    {
+                        "name": "intelowl",
+                        "last_seen": "2026-06-04T08:45:45.136845Z",
+                        "expires": "2026-09-02T08:45:45.136845Z",
+                        "fresh": True,
+                        "id": None,
+                    }
+                ],
+                "value": "1.2.3.4",
+                "last_analysis": {},
+                "created": "2026-06-04T08:45:45.086020Z",
+                "modified": "2026-06-04T08:45:45.186824Z",
+                "type": "ipv4",
+                "id": "12345",
+                "acls": {},
+                "root_type": "observable",
+                "is_valid": True,
+            },
+            200,
+        )
+
+    return MockResponse({"detail": "Not Found"}, 404)
+
+
+class YETITestCase(BaseConnectorTest):
+    connector_class = YETI
+
+    @classmethod
+    def get_extra_config(cls) -> dict:
+        return {
+            "_url_key_name": "http://yeti.local/",
+            "_api_key_name": "dummy_api_key",
+            "verify_ssl": False,
+            "job_id": 51,
+        }
+
+    @staticmethod
+    def get_mocked_response():
+        return [
+            patch("api_app.connectors_manager.connectors.yeti.requests.post", side_effect=mock_yeti_api_flow)
+        ]
+
+    def _create_mock_job(self, observable_name, observable_type):
+        mock_job = super()._create_mock_job(observable_name, observable_type)
+
+        mock_tags = MagicMock()
+        mock_tags.all().values_list.return_value = ["intelowl"]
+        mock_job.tags = mock_tags
+
+        mock_analyzers = MagicMock()
+        mock_analyzers.all().values_list.return_value = ["IPApi"]
+        mock_job.analyzers_to_execute = mock_analyzers
+
+        mock_job.received_request_time = "2026-06-04 08:36:35.035498+00:00"
+
+        return mock_job
+
+    def test_yeti_run_with_file_sample(self):
+        connector = self._setup_connector()
+
+        mock_job = self._create_mock_job("xyz_filename", "file")
+        mock_job.is_sample = True
+        mock_job.analyzable.md5 = "abcdef1234567890abcdef1234567890"
+        connector._job = mock_job
+
+        # enforce the mock during this specific execution
+        with patch(
+            "api_app.connectors_manager.connectors.yeti.requests.post", side_effect=mock_yeti_api_flow
+        ):
+            result = connector.run()
+
+        self.assertEqual(result.get("id"), "12345")
+        self.assertEqual(result.get("type"), "ipv4")
+        self.assertTrue(result.get("is_valid"))
+        self.assertEqual(len(result.get("context", [])), 1)
+
+    def test_yeti_auth_failure_raises_exception(self):
+        connector = self._setup_connector()
+
+        with patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post:
+            mock_post.return_value = MockResponse({"error": "Unauthorized"}, 401)
+
+            with self.assertRaisesRegex(ConnectorRunException, "YETI Auth Request failed"):
+                connector.run()
+
+    def test_yeti_missing_access_token_raises_exception(self):
+        connector = self._setup_connector()
+
+        with patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post:
+            mock_post.return_value = MockResponse({}, 200)
+
+            with self.assertRaisesRegex(ConnectorRunException, "Failed to obtain access token from YETI"):
+                connector.run()


### PR DESCRIPTION
Closes #3707 
# Description

- Implemented YETI JWT authentication and access token handling.
- Updated YETI API endpoints and request payload schemas to align with the current v2 API requirements.
- Added unit tests covering :
  - Authentication failure scenario.
  - Missing access token in authentication response.
  - Successful file-sample submission and processing flow.

## Type of change

Please delete options that are not relevant.

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
