### PR TITLE
[GSoC 2026] Add analyzer/playbook LLM tools to the chatbot agent (refs #3732)

### DIFF
--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -4,7 +4,9 @@
 from .get_data_model import make_get_data_model_tool
 from .get_investigation_tree import make_get_investigation_tree_tool
 from .get_job_details import make_get_job_details_tool
+from .list_analyzers import make_list_analyzers_tool
 from .list_investigations import make_list_investigations_tool
+from .recommend_playbook import make_recommend_playbook_tool
 from .search_jobs import make_search_jobs_tool
 from .summarize_investigation import make_summarize_investigation_tool
 from .summarize_job import make_summarize_job_tool
@@ -16,9 +18,12 @@ def build_tools(user) -> list:
     Each tool is produced by a factory that closes over `user`, so every ORM query the
     agent can run is hard-scoped to that user's data: multi-tenancy is enforced at build
     time and cannot be widened by anything the LLM emits. Job tools scope on `user=user`;
-    investigation tools scope on `visible_for_user` (owned + organization-shared). Every
-    tool returns a string (LangChain feeds it back as the ReAct "Observation"); see each
-    tool for its shape.
+    investigation tools scope on `visible_for_user` (owned + organization-shared); the
+    playbook tool also scopes on `visible_for_user`. Analyzer configs are global plugin
+    definitions, so `list_analyzers` does not scope by owner -- it lists the enabled
+    analyzers and exposes per-user readiness through a `runnable` flag instead. Every tool
+    returns a string (LangChain feeds it back as the ReAct "Observation"); see each tool
+    for its shape.
     """
     return [
         make_search_jobs_tool(user),
@@ -28,4 +33,6 @@ def build_tools(user) -> list:
         make_get_investigation_tree_tool(user),
         make_summarize_investigation_tool(user),
         make_get_data_model_tool(user),
+        make_list_analyzers_tool(user),
+        make_recommend_playbook_tool(user),
     ]

--- a/api_app/chatbot_manager/agent/tools/_common.py
+++ b/api_app/chatbot_manager/agent/tools/_common.py
@@ -1,0 +1,25 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Helpers shared by the chatbot agent tools (this module is not itself a tool)."""
+
+# Hard cap on the number of results any single tool returns to the LLM, so one call can't pull
+# an unbounded list into the prompt. Shared here so every tool advertises the same ceiling.
+MAX_RESULTS = 50
+
+
+def clamp_limit(limit, errors: list) -> int:
+    """Clamp an LLM-supplied result limit into ``[1, MAX_RESULTS]``.
+
+    Tool arguments are untrusted, so the raw ``limit`` is coerced to ``int`` and bounded. When
+    the requested value is above the cap, a note is appended to ``errors`` so a truncated list is
+    never silent (the lower bound is enforced too, but a non-positive request is not worth a
+    warning). Returns the clamped limit.
+    """
+    requested_limit = int(limit)
+    if requested_limit > MAX_RESULTS:
+        errors.append(
+            f"Requested limit {requested_limit} exceeds the maximum {MAX_RESULTS}; "
+            f"returning at most {MAX_RESULTS} results."
+        )
+    return max(1, min(requested_limit, MAX_RESULTS))

--- a/api_app/chatbot_manager/agent/tools/list_analyzers.py
+++ b/api_app/chatbot_manager/agent/tools/list_analyzers.py
@@ -12,10 +12,6 @@ from api_app.choices import Classification
 # single call can't pull an unbounded list into the prompt.
 _MAX_RESULTS = 50
 
-# Observable analyzers never apply to the `file` classification (that's the file-analysis path),
-# so the accepted/advertised observable types are all classifications except FILE.
-_VALID_OBSERVABLE_TYPES = [c for c in Classification.values if c != Classification.FILE.value]
-
 
 def make_list_analyzers_tool(user):
     # Built per-request and closed over `user`. Unlike the job/investigation tools, analyzer
@@ -55,20 +51,30 @@ def make_list_analyzers_tool(user):
             user
         )
 
+        # The accepted observable types are an IntelOwl-core notion (every classification except
+        # FILE, which is the file-analysis path), so reuse the core helper instead of a local copy.
+        valid_types = Classification.observable_classifications()
         if observable_type:
             # The type string comes from the LLM; validate it against the enum so an invalid
             # value surfaces a message instead of silently returning 0 results.
             normalized = observable_type.strip().lower()
-            if normalized in set(_VALID_OBSERVABLE_TYPES):
+            if normalized in set(valid_types):
                 # `observable_supported` is a ChoiceArrayField: `__contains` matches rows whose
                 # array includes the requested type.
                 qs = qs.filter(observable_supported__contains=[normalized])
             else:
-                valid = ", ".join(_VALID_OBSERVABLE_TYPES)
+                valid = ", ".join(valid_types)
                 errors.append(f"Unknown observable_type '{observable_type}'; valid values are: {valid}.")
 
-        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted).
-        limit = max(1, min(int(limit), _MAX_RESULTS))
+        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted) and
+        # tell the caller when the requested value was capped, so a truncated list isn't silent.
+        requested_limit = int(limit)
+        limit = max(1, min(requested_limit, _MAX_RESULTS))
+        if requested_limit > _MAX_RESULTS:
+            errors.append(
+                f"Requested limit {requested_limit} exceeds the maximum {_MAX_RESULTS}; "
+                f"returning at most {_MAX_RESULTS} results."
+            )
         qs = qs.order_by("name")[:limit]
 
         return ListAnalyzersResultSerializer({"errors": errors, "analyzers": qs}).to_json()

--- a/api_app/chatbot_manager/agent/tools/list_analyzers.py
+++ b/api_app/chatbot_manager/agent/tools/list_analyzers.py
@@ -1,0 +1,76 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.tools import tool
+
+from api_app.analyzers_manager.constants import TypeChoices
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.chatbot_manager.serializers import ListAnalyzersResultSerializer
+from api_app.choices import Classification
+
+# Hard cap on the number of results returned to the LLM (mirrors the other tools), so a
+# single call can't pull an unbounded list into the prompt.
+_MAX_RESULTS = 50
+
+# Observable analyzers never apply to the `file` classification (that's the file-analysis path),
+# so the accepted/advertised observable types are all classifications except FILE.
+_VALID_OBSERVABLE_TYPES = [c for c in Classification.values if c != Classification.FILE.value]
+
+
+def make_list_analyzers_tool(user):
+    # Built per-request and closed over `user`. Unlike the job/investigation tools, analyzer
+    # configs are GLOBAL plugin definitions (not user-owned), so the queryset is not scoped to
+    # the user's own rows; it lists the enabled observable analyzers and exposes per-user
+    # readiness through the `runnable` annotation instead.
+    #
+    # Why no `.filter(runnable=True)`: `annotate_runnable` (queryset.py) folds health-check +
+    # "all required parameters configured" on top of enabled/org-enabled, so a hard filter would
+    # silently drop every key-based analyzer (VirusTotal, ...) on a deploy without API keys ->
+    # near-empty lists and flaky tests. We list the enabled analyzers and surface readiness as a
+    # per-row flag instead, so the LLM can still say "this analyzer applies but isn't configured
+    # for you". `runnable` is False when the analyzer is disabled for the user's organization OR
+    # not fully configured/healthy.
+    @tool("list_analyzers")
+    def list_analyzers(observable_type: str = "", limit: int = 10) -> str:
+        """List the observable analyzers enabled on this IntelOwl instance.
+
+        Each result carries a `runnable` flag: True means the analyzer is ready to run for you
+        (enabled for your organization and fully configured); False means it applies but is
+        currently disabled for your organization or missing required configuration (e.g. an API
+        key).
+
+        Args:
+            observable_type: Filter to analyzers supporting this observable type. Valid values:
+                    ip, url, domain, hash, generic. An unknown value is ignored and reported in
+                    `errors`.
+            limit: Maximum number of results to return (default 10, max 50).
+
+        Returns:
+            JSON string with shape {"errors": [...], "analyzers": [...]}.
+        """
+        errors = []
+        # Globally-enabled observable analyzers, annotated with per-user readiness. Org-disabled
+        # or unconfigured analyzers still appear, flagged `runnable=False`.
+        qs = AnalyzerConfig.objects.filter(type=TypeChoices.OBSERVABLE, disabled=False).annotate_runnable(
+            user
+        )
+
+        if observable_type:
+            # The type string comes from the LLM; validate it against the enum so an invalid
+            # value surfaces a message instead of silently returning 0 results.
+            normalized = observable_type.strip().lower()
+            if normalized in set(_VALID_OBSERVABLE_TYPES):
+                # `observable_supported` is a ChoiceArrayField: `__contains` matches rows whose
+                # array includes the requested type.
+                qs = qs.filter(observable_supported__contains=[normalized])
+            else:
+                valid = ", ".join(_VALID_OBSERVABLE_TYPES)
+                errors.append(f"Unknown observable_type '{observable_type}'; valid values are: {valid}.")
+
+        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted).
+        limit = max(1, min(int(limit), _MAX_RESULTS))
+        qs = qs.order_by("name")[:limit]
+
+        return ListAnalyzersResultSerializer({"errors": errors, "analyzers": qs}).to_json()
+
+    return list_analyzers

--- a/api_app/chatbot_manager/agent/tools/list_analyzers.py
+++ b/api_app/chatbot_manager/agent/tools/list_analyzers.py
@@ -5,12 +5,9 @@ from langchain_core.tools import tool
 
 from api_app.analyzers_manager.constants import TypeChoices
 from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.chatbot_manager.agent.tools._common import clamp_limit
 from api_app.chatbot_manager.serializers import ListAnalyzersResultSerializer
 from api_app.choices import Classification
-
-# Hard cap on the number of results returned to the LLM (mirrors the other tools), so a
-# single call can't pull an unbounded list into the prompt.
-_MAX_RESULTS = 50
 
 
 def make_list_analyzers_tool(user):
@@ -66,15 +63,8 @@ def make_list_analyzers_tool(user):
                 valid = ", ".join(valid_types)
                 errors.append(f"Unknown observable_type '{observable_type}'; valid values are: {valid}.")
 
-        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted) and
-        # tell the caller when the requested value was capped, so a truncated list isn't silent.
-        requested_limit = int(limit)
-        limit = max(1, min(requested_limit, _MAX_RESULTS))
-        if requested_limit > _MAX_RESULTS:
-            errors.append(
-                f"Requested limit {requested_limit} exceeds the maximum {_MAX_RESULTS}; "
-                f"returning at most {_MAX_RESULTS} results."
-            )
+        # Treat the LLM-supplied limit as untrusted: clamp it and surface any capping in `errors`.
+        limit = clamp_limit(limit, errors)
         qs = qs.order_by("name")[:limit]
 
         return ListAnalyzersResultSerializer({"errors": errors, "analyzers": qs}).to_json()

--- a/api_app/chatbot_manager/agent/tools/recommend_playbook.py
+++ b/api_app/chatbot_manager/agent/tools/recommend_playbook.py
@@ -3,13 +3,10 @@
 
 from langchain_core.tools import tool
 
+from api_app.chatbot_manager.agent.tools._common import clamp_limit
 from api_app.chatbot_manager.serializers import RecommendPlaybookResultSerializer
 from api_app.choices import Classification
 from api_app.playbooks_manager.models import PlaybookConfig
-
-# Hard cap on the number of results returned to the LLM (mirrors the other tools), so a
-# single call can't pull an unbounded list into the prompt.
-_MAX_RESULTS = 50
 
 
 def make_recommend_playbook_tool(user):
@@ -55,16 +52,9 @@ def make_recommend_playbook_tool(user):
             # recommendation matches what an actual scan would pick.
             classification = Classification.calculate_observable(observable_name)
 
-        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted) and
-        # cap the queryset so a broadly-supported classification can't flood the prompt; tell the
-        # caller when the requested value was capped, so a truncated list isn't silent.
-        requested_limit = int(limit)
-        limit = max(1, min(requested_limit, _MAX_RESULTS))
-        if requested_limit > _MAX_RESULTS:
-            errors.append(
-                f"Requested limit {requested_limit} exceeds the maximum {_MAX_RESULTS}; "
-                f"returning at most {_MAX_RESULTS} results."
-            )
+        # Treat the LLM-supplied limit as untrusted: clamp it (so a broadly-supported
+        # classification can't flood the prompt) and surface any capping in `errors`.
+        limit = clamp_limit(limit, errors)
         # `type` is a ChoiceArrayField of classifications: `__contains` matches playbooks declaring
         # support for this one. `starting=True` = launchable on its own (not pivot-only).
         # `prefetch_related` avoids the per-row N+1 from the analyzers/connectors SlugRelatedFields.

--- a/api_app/chatbot_manager/agent/tools/recommend_playbook.py
+++ b/api_app/chatbot_manager/agent/tools/recommend_playbook.py
@@ -1,0 +1,73 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from langchain_core.tools import tool
+
+from api_app.chatbot_manager.serializers import RecommendPlaybookResultSerializer
+from api_app.choices import Classification
+from api_app.playbooks_manager.models import PlaybookConfig
+
+# Hard cap on the number of results returned to the LLM (mirrors the other tools), so a
+# single call can't pull an unbounded list into the prompt.
+_MAX_RESULTS = 50
+
+
+def make_recommend_playbook_tool(user):
+    # Built per-request and closed over `user`. Playbooks are owned / org-shared objects (unlike
+    # the global analyzer configs), so the queryset is scoped with `visible_for_user`, which
+    # returns the playbooks the user owns, the ones shared with their organization and the global
+    # ones (owner is null). This is a real visibility boundary -- another org's private playbook
+    # must not leak -- and the LLM can never widen it.
+    @tool("recommend_playbook")
+    def recommend_playbook(observable_name: str = "", classification: str = "", limit: int = 10) -> str:
+        """Suggest IntelOwl playbooks that can analyze a given observable.
+
+        Returns the directly-launchable playbooks (those that can start an analysis on their own)
+        applicable to the observable's classification and visible to you.
+
+        Args:
+            observable_name: The observable (IP, domain, URL, hash, ...). When `classification`
+                    is not given, the classification is derived from this value.
+            classification: The observable classification to match playbooks against. Valid
+                    values: ip, url, domain, hash, generic, file. If omitted it is derived from
+                    `observable_name`; an unknown explicit value is reported in `errors`.
+            limit: Maximum number of results to return (default 10, max 50).
+
+        Returns:
+            JSON string with shape {"errors": [...], "playbooks": [...]}.
+        """
+        errors = []
+
+        if not observable_name.strip() and not classification.strip():
+            errors.append("Provide either an observable_name or a classification.")
+            return RecommendPlaybookResultSerializer({"errors": errors, "playbooks": []}).to_json()
+
+        if classification:
+            # Explicit classification comes from the LLM; validate it against the enum so an
+            # invalid value surfaces a message instead of silently returning 0 results.
+            classification = classification.strip().lower()
+            if classification not in set(Classification.values):
+                valid = ", ".join(Classification.values)
+                errors.append(f"Unknown classification '{classification}'; valid values are: {valid}.")
+                return RecommendPlaybookResultSerializer({"errors": errors, "playbooks": []}).to_json()
+        else:
+            # Reuse the same classification logic the real analysis pipeline uses, so the
+            # recommendation matches what an actual scan would pick.
+            classification = Classification.calculate_observable(observable_name)
+
+        # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted) and
+        # cap the queryset so a broadly-supported classification can't flood the prompt.
+        limit = max(1, min(int(limit), _MAX_RESULTS))
+        # `type` is a ChoiceArrayField of classifications: `__contains` matches playbooks declaring
+        # support for this one. `starting=True` = launchable on its own (not pivot-only).
+        # `prefetch_related` avoids the per-row N+1 from the analyzers/connectors SlugRelatedFields.
+        qs = (
+            PlaybookConfig.objects.filter(type__contains=[classification], starting=True, disabled=False)
+            .visible_for_user(user)
+            .prefetch_related("analyzers", "connectors")
+            .order_by("name")[:limit]
+        )
+
+        return RecommendPlaybookResultSerializer({"errors": errors, "playbooks": qs}).to_json()
+
+    return recommend_playbook

--- a/api_app/chatbot_manager/agent/tools/recommend_playbook.py
+++ b/api_app/chatbot_manager/agent/tools/recommend_playbook.py
@@ -56,8 +56,15 @@ def make_recommend_playbook_tool(user):
             classification = Classification.calculate_observable(observable_name)
 
         # Clamp the LLM-supplied limit into [1, _MAX_RESULTS] (treat tool args as untrusted) and
-        # cap the queryset so a broadly-supported classification can't flood the prompt.
-        limit = max(1, min(int(limit), _MAX_RESULTS))
+        # cap the queryset so a broadly-supported classification can't flood the prompt; tell the
+        # caller when the requested value was capped, so a truncated list isn't silent.
+        requested_limit = int(limit)
+        limit = max(1, min(requested_limit, _MAX_RESULTS))
+        if requested_limit > _MAX_RESULTS:
+            errors.append(
+                f"Requested limit {requested_limit} exceeds the maximum {_MAX_RESULTS}; "
+                f"returning at most {_MAX_RESULTS} results."
+            )
         # `type` is a ChoiceArrayField of classifications: `__contains` matches playbooks declaring
         # support for this one. `starting=True` = launchable on its own (not pivot-only).
         # `prefetch_related` avoids the per-row N+1 from the analyzers/connectors SlugRelatedFields.

--- a/api_app/chatbot_manager/serializers.py
+++ b/api_app/chatbot_manager/serializers.py
@@ -5,9 +5,10 @@ import json
 
 from rest_framework import serializers
 
-from api_app.analyzers_manager.models import AnalyzerReport
+from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.investigations_manager.models import Investigation
 from api_app.models import Job
+from api_app.playbooks_manager.models import PlaybookConfig
 
 from .models import ChatMessage, ChatSession
 
@@ -128,6 +129,46 @@ class DataModelResultSerializer(ToolResultSerializer):
     # (`BaseDataModel.serialize()`, polymorphic across Domain/IP/File), so the envelope
     # just carries that dict (empty `{}` when the job has no data model).
     data_model = serializers.DictField(read_only=True)
+
+
+class AnalyzerConfigToolSerializer(serializers.ModelSerializer):
+    """Compact, LLM-facing AnalyzerConfig view for list_analyzers (no owner/PII fields).
+
+    `runnable` is read from a per-user queryset annotation (`annotate_runnable`): True means
+    ready to run for the requesting user, False means org-disabled or not fully configured. It
+    is a readiness flag, not a visibility filter -- the analyzer is listed either way.
+    """
+
+    # `observable_supported` is a ChoiceArrayField; DRF's ModelSerializer does not auto-map it,
+    # so declare it explicitly (same approach as the heavy PlaybookConfigSerializer's `type`).
+    observable_supported = serializers.ListField(child=serializers.CharField(), read_only=True)
+    runnable = serializers.BooleanField(read_only=True)
+
+    class Meta:
+        model = AnalyzerConfig
+        fields = ["name", "description", "type", "observable_supported", "maximum_tlp", "runnable"]
+
+
+class PlaybookConfigToolSerializer(serializers.ModelSerializer):
+    """Compact, LLM-facing PlaybookConfig view for recommend_playbook (no owner/PII fields)."""
+
+    # `type` is a ChoiceArrayField of classifications; declare it explicitly (DRF doesn't auto-map
+    # it). `analyzers`/`connectors` are M2M relations rendered as their names.
+    type = serializers.ListField(child=serializers.CharField(), read_only=True)
+    analyzers = serializers.SlugRelatedField(slug_field="name", many=True, read_only=True)
+    connectors = serializers.SlugRelatedField(slug_field="name", many=True, read_only=True)
+
+    class Meta:
+        model = PlaybookConfig
+        fields = ["name", "description", "type", "analyzers", "connectors"]
+
+
+class ListAnalyzersResultSerializer(ToolResultSerializer):
+    analyzers = AnalyzerConfigToolSerializer(many=True)
+
+
+class RecommendPlaybookResultSerializer(ToolResultSerializer):
+    playbooks = PlaybookConfigToolSerializer(many=True)
 
 
 class ChatSessionSerializer(serializers.ModelSerializer):

--- a/api_app/choices.py
+++ b/api_app/choices.py
@@ -157,6 +157,14 @@ class Classification(models.TextChoices):
         return classification
 
     @classmethod
+    def observable_classifications(cls) -> typing.List["Classification"]:
+        """Classifications that apply to observables: every value except ``FILE``, which is the
+        file-analysis path rather than an observable type. Single source of truth for the code
+        that enumerates observable types (e.g. the observable-analyzer listing and the
+        observable-classification job aggregation)."""
+        return [c for c in cls if c != cls.FILE]
+
+    @classmethod
     def get_data_model_class(cls, classification: str) -> typing.Type:
         from api_app.data_model_manager.models import (
             DomainDataModel,

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -626,13 +626,7 @@ class JobViewSet(ReadAndDeleteOnlyViewSet, SerializerActionMixin):
         """
         annotations = {
             oc.lower(): Count("analyzable__classification", filter=Q(analyzable__classification=oc))
-            for oc in [
-                Classification.DOMAIN,
-                Classification.IP,
-                Classification.HASH,
-                Classification.URL,
-                Classification.GENERIC,
-            ]
+            for oc in Classification.observable_classifications()
         }
         return self.__aggregation_response_static(annotations, users=self.get_org_members(request))
 

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -369,8 +369,10 @@ class ListAnalyzersToolTestCase(TestCase):
     def test_list_analyzers_limit_clamps_to_max(self):
         # An over-cap limit from the LLM is clamped to _MAX_RESULTS (untrusted arg): the seeded
         # observable analyzers exceed the cap, so the result is capped, never the requested 999.
+        # The clamp is surfaced in `errors` so a truncated list isn't silent.
         data = json.loads(self.list_analyzers.invoke({"limit": 999}))
         self.assertLessEqual(len(data["analyzers"]), _MAX_RESULTS)
+        self.assertTrue(any("exceeds the maximum" in e for e in data["errors"]))
 
     def test_list_analyzers_org_disabled_runnable_flag(self):
         # Deterministic, one-directional isolation check: an analyzer disabled for the user's
@@ -507,3 +509,9 @@ class RecommendPlaybookToolTestCase(TestCase):
         self.assertGreaterEqual(len(all_matches), 2)
         capped = json.loads(self.recommend_playbook.invoke({"classification": "ip", "limit": 1}))
         self.assertEqual(len(capped["playbooks"]), 1)
+
+    def test_recommend_playbook_limit_clamp_warns(self):
+        # An over-cap limit is clamped to _MAX_RESULTS and the clamp is surfaced in `errors`,
+        # regardless of how many playbooks actually match (999 > 50 always warns).
+        data = json.loads(self.recommend_playbook.invoke({"classification": "ip", "limit": 999}))
+        self.assertTrue(any("exceeds the maximum" in e for e in data["errors"]))

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -7,12 +7,15 @@ from uuid import uuid4
 from django.test import TestCase
 
 from api_app.analyzables_manager.models import Analyzable
+from api_app.analyzers_manager.constants import TypeChoices
 from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.chatbot_manager.agent.tools import build_tools
-from api_app.choices import Classification
+from api_app.chatbot_manager.agent.tools.list_analyzers import _MAX_RESULTS
+from api_app.choices import Classification, ScanMode
 from api_app.data_model_manager.models import DomainDataModel
 from api_app.investigations_manager.models import Investigation
-from api_app.models import Job
+from api_app.models import Job, OrganizationPluginConfiguration
+from api_app.playbooks_manager.models import PlaybookConfig
 from certego_saas.apps.organization.membership import Membership
 from certego_saas.apps.organization.organization import Organization
 from certego_saas.apps.user.models import User
@@ -308,3 +311,199 @@ class DataModelToolTestCase(TestCase):
         self.assertEqual(data["data_model"], {})
         self.assertTrue(data["errors"])
         self.assertIn("not found or not accessible", data["errors"][0])
+
+
+class ListAnalyzersToolTestCase(TestCase):
+    def setUp(self):
+        self.org_user, _ = User.objects.get_or_create(username="list_analyzers_org_user")
+        self.outsider, _ = User.objects.get_or_create(username="list_analyzers_outsider")
+        self.org, _ = Organization.objects.get_or_create(name="list analyzers organization")
+        Membership.objects.get_or_create(user=self.org_user, organization=self.org, is_owner=True)
+
+        # A real seeded observable analyzer (constructing one would need a PythonModule FK).
+        self.analyzer = (
+            AnalyzerConfig.objects.filter(
+                type=TypeChoices.OBSERVABLE,
+                observable_supported__contains=["domain"],
+                disabled=False,
+            )
+            .order_by("name")
+            .first()
+        )
+        self.assertIsNotNone(self.analyzer, "expected a seeded observable analyzer supporting 'domain'")
+
+        # Disable it for self.org: the per-user `runnable` flag must flip to False, but the
+        # analyzer must still be listed (analyzer configs are global, non-sensitive).
+        self.org_disable = OrganizationPluginConfiguration.objects.create(
+            config=self.analyzer, organization=self.org, disabled=True
+        )
+
+        self.list_analyzers = {t.name: t for t in build_tools(user=self.org_user)}["list_analyzers"]
+
+    def tearDown(self):
+        self.org_disable.delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()
+
+    def test_list_analyzers_filters_by_observable_type(self):
+        data = json.loads(self.list_analyzers.invoke({"observable_type": "domain"}))
+        self.assertEqual(data["errors"], [])
+        self.assertTrue(data["analyzers"])
+        # every returned analyzer supports the requested observable type
+        for analyzer in data["analyzers"]:
+            self.assertIn("domain", analyzer["observable_supported"])
+        names = [a["name"] for a in data["analyzers"]]
+        self.assertIn(self.analyzer.name, names)
+
+    def test_list_analyzers_unknown_observable_type(self):
+        data = json.loads(self.list_analyzers.invoke({"observable_type": "bogus"}))
+        # invalid type is reported and the filter is ignored (results still returned)
+        self.assertTrue(data["errors"])
+        self.assertIn("Unknown observable_type", data["errors"][0])
+        self.assertTrue(data["analyzers"])
+
+    def test_list_analyzers_limit(self):
+        data = json.loads(self.list_analyzers.invoke({"limit": 1}))
+        self.assertEqual(len(data["analyzers"]), 1)
+
+    def test_list_analyzers_limit_clamps_to_max(self):
+        # An over-cap limit from the LLM is clamped to _MAX_RESULTS (untrusted arg): the seeded
+        # observable analyzers exceed the cap, so the result is capped, never the requested 999.
+        data = json.loads(self.list_analyzers.invoke({"limit": 999}))
+        self.assertLessEqual(len(data["analyzers"]), _MAX_RESULTS)
+
+    def test_list_analyzers_org_disabled_runnable_flag(self):
+        # Deterministic, one-directional isolation check: an analyzer disabled for the user's
+        # organization comes back with runnable=False AND is still present in the list (it is
+        # not hidden -- list_analyzers lists, it does not filter on runnable). We do NOT assert
+        # the contrasting runnable=True for an outsider, because `runnable` also folds in
+        # configured+healthy, which a key-based analyzer lacks on a test deploy without keys.
+        rows = {
+            a["name"]: a
+            for a in json.loads(self.list_analyzers.invoke({"observable_type": "domain"}))["analyzers"]
+        }
+        self.assertIn(self.analyzer.name, rows)
+        self.assertFalse(rows[self.analyzer.name]["runnable"])
+
+        # The same analyzer is still listed for an unaffiliated user (global, non-sensitive).
+        outsider_tool = {t.name: t for t in build_tools(user=self.outsider)}["list_analyzers"]
+        outsider_names = [
+            a["name"] for a in json.loads(outsider_tool.invoke({"observable_type": "domain"}))["analyzers"]
+        ]
+        self.assertIn(self.analyzer.name, outsider_names)
+
+
+class RecommendPlaybookToolTestCase(TestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="recommend_pb_user")
+        # Another member of the same org: used to test org-shared vs private visibility.
+        self.org_member, _ = User.objects.get_or_create(username="recommend_pb_org_member")
+        self.org, _ = Organization.objects.get_or_create(name="recommend pb organization")
+        Membership.objects.get_or_create(user=self.user, organization=self.org, is_owner=True)
+        Membership.objects.get_or_create(user=self.org_member, organization=self.org, is_owner=False)
+
+        self.pb_owned = PlaybookConfig.objects.create(
+            name="recommend_pb_owned", description="t", type=["ip"], owner=self.user, starting=True
+        )
+        # Owned by another member of the same org and shared at org level -> visible.
+        self.pb_org_shared = PlaybookConfig.objects.create(
+            name="recommend_pb_org_shared",
+            description="t",
+            type=["ip"],
+            owner=self.org_member,
+            for_organization=True,
+            starting=True,
+        )
+        # Owned by another member but NOT shared -> must stay invisible to self.user.
+        self.pb_private_other = PlaybookConfig.objects.create(
+            name="recommend_pb_private_other",
+            description="t",
+            type=["ip"],
+            owner=self.org_member,
+            for_organization=False,
+            starting=True,
+        )
+        # Not directly launchable -> must not be recommended. A non-starting playbook must force
+        # new analysis with no check time (model clean()), which create() enforces.
+        self.pb_not_starting = PlaybookConfig.objects.create(
+            name="recommend_pb_not_starting",
+            description="t",
+            type=["ip"],
+            owner=self.user,
+            starting=False,
+            scan_mode=ScanMode.FORCE_NEW_ANALYSIS.value,
+            scan_check_time=None,
+        )
+        # Disabled -> must not be recommended.
+        self.pb_disabled = PlaybookConfig.objects.create(
+            name="recommend_pb_disabled",
+            description="t",
+            type=["ip"],
+            owner=self.user,
+            starting=True,
+            disabled=True,
+        )
+        # Different classification -> must not match an ip observable.
+        self.pb_domain = PlaybookConfig.objects.create(
+            name="recommend_pb_domain", description="t", type=["domain"], owner=self.user, starting=True
+        )
+
+        self.recommend_playbook = {t.name: t for t in build_tools(user=self.user)}["recommend_playbook"]
+
+    def tearDown(self):
+        PlaybookConfig.objects.filter(owner__in=[self.user, self.org_member]).delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()
+
+    def test_recommend_playbook_derives_classification_from_observable(self):
+        data = json.loads(self.recommend_playbook.invoke({"observable_name": "8.8.8.8"}))
+        self.assertEqual(data["errors"], [])
+        names = [p["name"] for p in data["playbooks"]]
+        # 8.8.8.8 is classified as ip -> the ip playbook matches, the domain one does not
+        self.assertIn(self.pb_owned.name, names)
+        self.assertNotIn(self.pb_domain.name, names)
+
+    def test_recommend_playbook_explicit_classification(self):
+        data = json.loads(self.recommend_playbook.invoke({"classification": "ip"}))
+        self.assertEqual(data["errors"], [])
+        names = [p["name"] for p in data["playbooks"]]
+        self.assertIn(self.pb_owned.name, names)
+
+    def test_recommend_playbook_invalid_classification(self):
+        data = json.loads(self.recommend_playbook.invoke({"classification": "bogus"}))
+        self.assertTrue(data["errors"])
+        self.assertIn("Unknown classification", data["errors"][0])
+        self.assertEqual(data["playbooks"], [])
+
+    def test_recommend_playbook_requires_input(self):
+        data = json.loads(self.recommend_playbook.invoke({}))
+        self.assertTrue(data["errors"])
+        self.assertEqual(data["playbooks"], [])
+
+    def test_recommend_playbook_only_starting_and_enabled(self):
+        names = [
+            p["name"]
+            for p in json.loads(self.recommend_playbook.invoke({"classification": "ip"}))["playbooks"]
+        ]
+        self.assertIn(self.pb_owned.name, names)
+        self.assertNotIn(self.pb_not_starting.name, names)
+        self.assertNotIn(self.pb_disabled.name, names)
+
+    def test_recommend_playbook_visibility_isolation(self):
+        names = [
+            p["name"]
+            for p in json.loads(self.recommend_playbook.invoke({"classification": "ip"}))["playbooks"]
+        ]
+        # owned + org-shared are visible
+        self.assertIn(self.pb_owned.name, names)
+        self.assertIn(self.pb_org_shared.name, names)
+        # another member's private playbook is NOT visible
+        self.assertNotIn(self.pb_private_other.name, names)
+
+    def test_recommend_playbook_limit(self):
+        # Two visible, starting, enabled ip playbooks match (owned + org-shared); the cap must
+        # trim the result to the requested size.
+        all_matches = json.loads(self.recommend_playbook.invoke({"classification": "ip"}))["playbooks"]
+        self.assertGreaterEqual(len(all_matches), 2)
+        capped = json.loads(self.recommend_playbook.invoke({"classification": "ip", "limit": 1}))
+        self.assertEqual(len(capped["playbooks"]), 1)

--- a/tests/api_app/chatbot_manager/test_tools.py
+++ b/tests/api_app/chatbot_manager/test_tools.py
@@ -10,7 +10,7 @@ from api_app.analyzables_manager.models import Analyzable
 from api_app.analyzers_manager.constants import TypeChoices
 from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.chatbot_manager.agent.tools import build_tools
-from api_app.chatbot_manager.agent.tools.list_analyzers import _MAX_RESULTS
+from api_app.chatbot_manager.agent.tools._common import MAX_RESULTS, clamp_limit
 from api_app.choices import Classification, ScanMode
 from api_app.data_model_manager.models import DomainDataModel
 from api_app.investigations_manager.models import Investigation
@@ -367,11 +367,11 @@ class ListAnalyzersToolTestCase(TestCase):
         self.assertEqual(len(data["analyzers"]), 1)
 
     def test_list_analyzers_limit_clamps_to_max(self):
-        # An over-cap limit from the LLM is clamped to _MAX_RESULTS (untrusted arg): the seeded
+        # An over-cap limit from the LLM is clamped to MAX_RESULTS (untrusted arg): the seeded
         # observable analyzers exceed the cap, so the result is capped, never the requested 999.
         # The clamp is surfaced in `errors` so a truncated list isn't silent.
         data = json.loads(self.list_analyzers.invoke({"limit": 999}))
-        self.assertLessEqual(len(data["analyzers"]), _MAX_RESULTS)
+        self.assertLessEqual(len(data["analyzers"]), MAX_RESULTS)
         self.assertTrue(any("exceeds the maximum" in e for e in data["errors"]))
 
     def test_list_analyzers_org_disabled_runnable_flag(self):
@@ -511,7 +511,28 @@ class RecommendPlaybookToolTestCase(TestCase):
         self.assertEqual(len(capped["playbooks"]), 1)
 
     def test_recommend_playbook_limit_clamp_warns(self):
-        # An over-cap limit is clamped to _MAX_RESULTS and the clamp is surfaced in `errors`,
+        # An over-cap limit is clamped to MAX_RESULTS and the clamp is surfaced in `errors`,
         # regardless of how many playbooks actually match (999 > 50 always warns).
         data = json.loads(self.recommend_playbook.invoke({"classification": "ip", "limit": 999}))
         self.assertTrue(any("exceeds the maximum" in e for e in data["errors"]))
+
+
+class ClampLimitHelperTestCase(TestCase):
+    """Unit tests for the shared `clamp_limit` helper used by the analyzer/playbook tools."""
+
+    def test_within_range_passes_through(self):
+        errors = []
+        self.assertEqual(clamp_limit(10, errors), 10)
+        self.assertEqual(errors, [])
+
+    def test_over_cap_clamps_and_warns(self):
+        errors = []
+        self.assertEqual(clamp_limit(999, errors), MAX_RESULTS)
+        self.assertTrue(any("exceeds the maximum" in e for e in errors))
+
+    def test_below_one_clamps_up_silently(self):
+        # A non-positive limit is bounded up to 1 without a warning (only over-cap is worth one).
+        errors = []
+        self.assertEqual(clamp_limit(0, errors), 1)
+        self.assertEqual(clamp_limit(-5, errors), 1)
+        self.assertEqual(errors, [])


### PR DESCRIPTION
Refs #3732. _(Targets the `gsoc-2026/llm-chatbot` umbrella, not `develop`. Using `Refs` (not `Closes`) on purpose — the umbrella isn't `develop`, so the issue is closed manually after merge.)_

# Description

Adds two **read-only** tools to the chatbot LangChain ReAct agent (W5 — analyzer/playbook domain):

- **`list_analyzers(observable_type="", limit=50)`** — lists the analyzers enabled for the requesting user
  (globally not `disabled`, and not disabled for the user's organization), optionally filtered to those
  supporting a given observable type. `observable_type` is validated against the `Classification` enum; an
  unknown value is reported in `errors` instead of silently returning an empty list.
- **`recommend_playbook(observable_name="", classification="", limit=50)`** — suggests directly-launchable
  (`starting=True`, non-disabled) playbooks applicable to an observable's classification, scoped to the
  playbooks visible to the user (`visible_for_user` — owned + organization-shared). The classification is
  derived from the observable via `Classification.calculate_observable` when not supplied; an explicitly
  provided one is validated against the enum.

Both follow the existing tool pattern (a `make_*_tool(user)` factory that closes over the user, so
multi-tenancy is enforced at build time and the LLM can't widen the scope) and return the standard
`{"errors": [...], "<payload>": ...}` envelope via `ToolResultSerializer.to_json()`. Output uses
purpose-built light serializers (`AnalyzerConfigToolSerializer`, `PlaybookConfigToolSerializer`) rather than
the heavy config serializers, to keep the LLM prompt small. Both cap their result list at 50
(`_MAX_RESULTS`) and clamp the LLM-supplied `limit` into `[1, 50]`, so a single call can't flood the prompt.

These tools are read-only — no analysis is triggered. The analysis-launching tool `analyze_observable`
(with its safety guardrails) follows in a separate PR.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop` _(targets the `gsoc-2026/llm-chatbot` umbrella)_
- [x] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible _(no new dependencies added)_
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section _(N/A — no new libraries added)_
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the feature I solved (see `tests` folder); all tests (new and old) gave 0 errors _(run locally against a rebuilt test image — the "Build & Tests" CI workflow does not run on umbrella-targeting PRs)_
- [x] After submitting the PR, if `DeepSource`, `Django Doctors` or other third-party linters triggered alerts during CI, I have solved those alerts
- [x] I have addressed raised Copilot issues
- [x] I have reviewed and verified any LLM-generated code included in this PR. **I used an LLM coding assistant while developing this PR, and reviewed all of its output.**
