### PR TITLE
[GSoC 2026] Add analyze_observable action tool to the chatbot agent (refs #3732)

### DIFF
--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -13,6 +13,7 @@ _SYSTEM_PROMPT = """\
 You are IntelOwl AI, an intelligent assistant for the IntelOwl threat intelligence platform.
 You help security analysts query and interpret threat intelligence data.
 Only access data belonging to the current user. Never reveal other users' data.
+The analyze_observable tool starts a real analysis: always call it first with confirm=false, show the returned plan to the user, and only call it again with confirm=true after the user explicitly approves.
 
 You have access to the following tools:
 

--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from .analyze_observable import make_analyze_observable_tool
 from .get_data_model import make_get_data_model_tool
 from .get_investigation_tree import make_get_investigation_tree_tool
 from .get_job_details import make_get_job_details_tool
@@ -21,9 +22,10 @@ def build_tools(user) -> list:
     investigation tools scope on `visible_for_user` (owned + organization-shared); the
     playbook tool also scopes on `visible_for_user`. Analyzer configs are global plugin
     definitions, so `list_analyzers` does not scope by owner -- it lists the enabled
-    analyzers and exposes per-user readiness through a `runnable` flag instead. Every tool
-    returns a string (LangChain feeds it back as the ReAct "Observation"); see each tool
-    for its shape.
+    analyzers and exposes per-user readiness through a `runnable` flag instead. The single
+    action tool `analyze_observable` can launch a real analysis; it is confirm-gated (a preview
+    unless `confirm=True`) and creates jobs owned by `user`. Every tool returns a string
+    (LangChain feeds it back as the ReAct "Observation"); see each tool for its shape.
     """
     return [
         make_search_jobs_tool(user),
@@ -35,4 +37,5 @@ def build_tools(user) -> list:
         make_get_data_model_tool(user),
         make_list_analyzers_tool(user),
         make_recommend_playbook_tool(user),
+        make_analyze_observable_tool(user),
     ]

--- a/api_app/chatbot_manager/agent/tools/analyze_observable.py
+++ b/api_app/chatbot_manager/agent/tools/analyze_observable.py
@@ -1,33 +1,16 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-from dataclasses import asdict, dataclass, field
 from types import SimpleNamespace
-from typing import List, Optional
+from typing import List
 
+from django.utils.timezone import now
 from langchain_core.tools import tool
 
 from api_app.chatbot_manager.serializers.analyze_observable import AnalyzeObservableResultSerializer
-from api_app.choices import TLP, ScanMode
+from api_app.choices import TLP
 from api_app.playbooks_manager.models import PlaybookConfig
 from api_app.serializers.job import ObservableAnalysisSerializer
-
-
-@dataclass
-class _AnalysisPlan:
-    """Preview of what a confirmed analyze_observable call would launch.
-
-    Computed (non-model) data, so it is a typed dataclass rather than a free-form dict (Matteo's
-    rule); `asdict()` converts it only at the serializer boundary.
-    """
-
-    observable_name: str
-    classification: str
-    tlp: str
-    playbook: Optional[str]
-    analyzers: List[str]
-    connectors: List[str]
-    skipped: List[str] = field(default_factory=list)
 
 
 def _flatten_errors(errors) -> List[str]:
@@ -63,14 +46,15 @@ def make_analyze_observable_tool(user):
         tlp: str = TLP.CLEAR.value,
         confirm: bool = False,
     ) -> str:
-        """Start a new IntelOwl analysis of an observable (IP, domain, URL, hash, ...).
+        """Start an IntelOwl analysis of an observable (IP, domain, URL, hash, ...).
 
         This tool ACTUALLY launches an analysis, so it is two-phase and must be confirmed:
         1. Call it first with confirm=false -> it validates the request and returns a `plan` (the
            analyzers/connectors that would run, the ones skipped, the resolved classification)
            WITHOUT starting anything. Show that plan to the user.
         2. Only after the user explicitly approves, call it again with the same arguments and
-           confirm=true -> this starts the job.
+           confirm=true -> this starts the analysis. If the same observable was already analyzed
+           recently the existing job is returned instead of launching a duplicate (`reused=true`).
 
         Args:
             observable_name: The observable to analyze (an IP, domain, URL or hash).
@@ -83,18 +67,19 @@ def make_analyze_observable_tool(user):
             confirm: Must be true to actually start the analysis. Defaults to false (preview only).
 
         Returns:
-            JSON string with shape {"errors": [...], "confirmation_required": bool,
+            JSON string with shape {"errors": [...], "confirmation_required": bool, "reused": bool,
             "plan": {...} | null, "job": {...} | null}.
         """
         # The reused serializer reads the requesting user from `context["request"].user`; a shim is
         # enough since the create path only ever reads `.user`.
         shim = SimpleNamespace(user=user)
-        # FORCE_NEW_ANALYSIS (not the platform default CHECK_PREVIOUS_ANALYSIS): confirm=True always
-        # starts a fresh job rather than possibly returning a cached one -> deterministic contract.
+        # No scan_mode override -> the serializer applies the platform default
+        # (CHECK_PREVIOUS_ANALYSIS): a confirmed request reuses a matching analysis from the last 24h
+        # instead of always launching a duplicate (saves analyzer quota; same behaviour as the REST
+        # analyze_observable endpoint). `reused` in the result reports whether that happened.
         data = {
             "observable_name": observable_name,
             "tlp": tlp,
-            "scan_mode": ScanMode.FORCE_NEW_ANALYSIS.value,
         }
 
         if playbook:
@@ -109,6 +94,7 @@ def make_analyze_observable_tool(user):
                     {
                         "errors": [f"Playbook '{playbook}' not found or not visible to you."],
                         "confirmation_required": False,
+                        "reused": False,
                         "plan": None,
                         "job": None,
                     }
@@ -127,6 +113,7 @@ def make_analyze_observable_tool(user):
                 {
                     "errors": _flatten_errors(serializer.errors),
                     "confirmation_required": False,
+                    "reused": False,
                     "plan": None,
                     "job": None,
                 }
@@ -134,28 +121,32 @@ def make_analyze_observable_tool(user):
 
         validated = serializer.validated_data
         if not confirm:
-            # Preview path: report exactly what a confirmed call would run; trigger nothing.
-            plan = _AnalysisPlan(
-                observable_name=validated["observable_name"],
-                classification=validated["observable_classification"],
-                tlp=validated["tlp"],
-                playbook=validated["playbook_requested"].name
+            # Preview path: report exactly what a confirmed call would run; trigger nothing. The plan
+            # dict is shaped/validated by AnalysisPlanSerializer (the envelope's `plan` field).
+            plan = {
+                "observable_name": validated["observable_name"],
+                "classification": validated["observable_classification"],
+                "tlp": validated["tlp"],
+                "playbook": validated["playbook_requested"].name
                 if validated.get("playbook_requested")
                 else None,
-                analyzers=[analyzer.name for analyzer in validated["analyzers_to_execute"]],
-                connectors=[connector.name for connector in validated["connectors_to_execute"]],
+                "analyzers": [analyzer.name for analyzer in validated["analyzers_to_execute"]],
+                "connectors": [connector.name for connector in validated["connectors_to_execute"]],
                 # the committed copy of the serializer's filter_warnings (skipped/unrunnable plugins)
-                skipped=list(validated.get("warnings", [])),
-            )
+                "skipped": list(validated.get("warnings", [])),
+            }
             return AnalyzeObservableResultSerializer(
-                {"errors": [], "confirmation_required": True, "plan": asdict(plan), "job": None}
+                {"errors": [], "confirmation_required": True, "reused": False, "plan": plan, "job": None}
             ).to_json()
 
-        # confirm=True: the ONLY path that triggers the analysis (job_pipeline.apply_async, via
-        # save(send_task=True)).
+        # confirm=True: the only path that may trigger the analysis (job_pipeline.apply_async, via
+        # save(send_task=True)). With the default scan_mode the serializer may instead return a matching
+        # recent job WITHOUT launching anything (dedup); a request time older than this call means reuse.
+        started = now()
         job = serializer.save(send_task=True)
+        reused = job.received_request_time < started
         return AnalyzeObservableResultSerializer(
-            {"errors": [], "confirmation_required": False, "plan": None, "job": job}
+            {"errors": [], "confirmation_required": False, "reused": reused, "plan": None, "job": job}
         ).to_json()
 
     return analyze_observable

--- a/api_app/chatbot_manager/agent/tools/analyze_observable.py
+++ b/api_app/chatbot_manager/agent/tools/analyze_observable.py
@@ -1,0 +1,161 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from dataclasses import asdict, dataclass, field
+from types import SimpleNamespace
+from typing import List, Optional
+
+from langchain_core.tools import tool
+
+from api_app.chatbot_manager.serializers.analyze_observable import AnalyzeObservableResultSerializer
+from api_app.choices import TLP, ScanMode
+from api_app.playbooks_manager.models import PlaybookConfig
+from api_app.serializers.job import ObservableAnalysisSerializer
+
+
+@dataclass
+class _AnalysisPlan:
+    """Preview of what a confirmed analyze_observable call would launch.
+
+    Computed (non-model) data, so it is a typed dataclass rather than a free-form dict (Matteo's
+    rule); `asdict()` converts it only at the serializer boundary.
+    """
+
+    observable_name: str
+    classification: str
+    tlp: str
+    playbook: Optional[str]
+    analyzers: List[str]
+    connectors: List[str]
+    skipped: List[str] = field(default_factory=list)
+
+
+def _flatten_errors(errors) -> List[str]:
+    """Flatten DRF's ``{field: [msg, ...]}`` error dict into a flat ``list[str]``.
+
+    The reused serializer reports failures (private-IP guardrail, unknown analyzer, "nothing
+    runnable", ...) as nested ``ValidationError`` dicts; the LLM only needs a flat list of messages.
+    """
+    if isinstance(errors, dict):
+        flat = []
+        for field_name, messages in errors.items():
+            if isinstance(messages, (list, tuple)):
+                flat.extend(f"{field_name}: {message}" for message in messages)
+            else:
+                flat.append(f"{field_name}: {messages}")
+        return flat
+    if isinstance(errors, (list, tuple)):
+        return [str(message) for message in errors]
+    return [str(errors)]
+
+
+def make_analyze_observable_tool(user):
+    # Built per-request and closed over `user`. This is the only ACTION tool: it can launch a real
+    # IntelOwl analysis. Safety is two-phase + confirm-gated -- a call without confirm=True can never
+    # reach `job_pipeline.apply_async`, because the create path triggers it only under
+    # `save(send_task=True)`, which we call exclusively on the confirm=True branch. The created
+    # `Job.user` is this closured `user` (via the request shim), so the agent cannot widen scope.
+    @tool("analyze_observable")
+    def analyze_observable(
+        observable_name: str,
+        playbook: str = "",
+        analyzers: str = "",
+        tlp: str = TLP.CLEAR.value,
+        confirm: bool = False,
+    ) -> str:
+        """Start a new IntelOwl analysis of an observable (IP, domain, URL, hash, ...).
+
+        This tool ACTUALLY launches an analysis, so it is two-phase and must be confirmed:
+        1. Call it first with confirm=false -> it validates the request and returns a `plan` (the
+           analyzers/connectors that would run, the ones skipped, the resolved classification)
+           WITHOUT starting anything. Show that plan to the user.
+        2. Only after the user explicitly approves, call it again with the same arguments and
+           confirm=true -> this starts the job.
+
+        Args:
+            observable_name: The observable to analyze (an IP, domain, URL or hash).
+            playbook: Optional playbook name to run (must be visible to you). Mutually exclusive
+                    with `analyzers`.
+            analyzers: Optional COMMA-SEPARATED analyzer names (e.g. "Classic_DNS,VirusTotal_v3").
+                    Mutually exclusive with `playbook`. If both are empty the instance defaults run.
+            tlp: Traffic Light Protocol level (CLEAR, GREEN, AMBER, RED; default CLEAR). TLP only
+                    filters which plugins may run -- it never blocks the launch.
+            confirm: Must be true to actually start the analysis. Defaults to false (preview only).
+
+        Returns:
+            JSON string with shape {"errors": [...], "confirmation_required": bool,
+            "plan": {...} | null, "job": {...} | null}.
+        """
+        # The reused serializer reads the requesting user from `context["request"].user`; a shim is
+        # enough since the create path only ever reads `.user`.
+        shim = SimpleNamespace(user=user)
+        # FORCE_NEW_ANALYSIS (not the platform default CHECK_PREVIOUS_ANALYSIS): confirm=True always
+        # starts a fresh job rather than possibly returning a cached one -> deterministic contract.
+        data = {
+            "observable_name": observable_name,
+            "tlp": tlp,
+            "scan_mode": ScanMode.FORCE_NEW_ANALYSIS.value,
+        }
+
+        if playbook:
+            # ISOLATION GUARD: ObservableAnalysisSerializer resolves `playbook_requested` via
+            # PlaybookConfig.objects.all() (no visibility filter) and the create path never re-scopes
+            # it -- so an LLM-supplied name could reference another org's PRIVATE playbook and leak
+            # its existence/composition into the plan. Scope it here against `visible_for_user` (the
+            # same boundary recommend_playbook uses) BEFORE the serializer sees it. Analyzers need no
+            # such guard: AnalyzerConfig is a global config (matches the UI's `.all()`).
+            if not PlaybookConfig.objects.visible_for_user(user).filter(name=playbook).exists():
+                return AnalyzeObservableResultSerializer(
+                    {
+                        "errors": [f"Playbook '{playbook}' not found or not visible to you."],
+                        "confirmation_required": False,
+                        "plan": None,
+                        "job": None,
+                    }
+                ).to_json()
+            data["playbook_requested"] = playbook
+
+        # The agent is the string-based ReAct agent (one `Action Input` string), so `analyzers` is a
+        # comma-separated string split here rather than a JSON list (unreliable for a small model).
+        analyzers_list = [a.strip() for a in analyzers.split(",") if a.strip()]
+        if analyzers_list:
+            data["analyzers_requested"] = analyzers_list
+
+        serializer = ObservableAnalysisSerializer(data=data, context={"request": shim})
+        if not serializer.is_valid(raise_exception=False):
+            return AnalyzeObservableResultSerializer(
+                {
+                    "errors": _flatten_errors(serializer.errors),
+                    "confirmation_required": False,
+                    "plan": None,
+                    "job": None,
+                }
+            ).to_json()
+
+        validated = serializer.validated_data
+        if not confirm:
+            # Preview path: report exactly what a confirmed call would run; trigger nothing.
+            plan = _AnalysisPlan(
+                observable_name=validated["observable_name"],
+                classification=validated["observable_classification"],
+                tlp=validated["tlp"],
+                playbook=validated["playbook_requested"].name
+                if validated.get("playbook_requested")
+                else None,
+                analyzers=[analyzer.name for analyzer in validated["analyzers_to_execute"]],
+                connectors=[connector.name for connector in validated["connectors_to_execute"]],
+                # the committed copy of the serializer's filter_warnings (skipped/unrunnable plugins)
+                skipped=list(validated.get("warnings", [])),
+            )
+            return AnalyzeObservableResultSerializer(
+                {"errors": [], "confirmation_required": True, "plan": asdict(plan), "job": None}
+            ).to_json()
+
+        # confirm=True: the ONLY path that triggers the analysis (job_pipeline.apply_async, via
+        # save(send_task=True)).
+        job = serializer.save(send_task=True)
+        return AnalyzeObservableResultSerializer(
+            {"errors": [], "confirmation_required": False, "plan": None, "job": job}
+        ).to_json()
+
+    return analyze_observable

--- a/api_app/chatbot_manager/serializers/analyze_observable.py
+++ b/api_app/chatbot_manager/serializers/analyze_observable.py
@@ -7,14 +7,33 @@ from .base import ToolResultSerializer
 from .job import JobToolSerializer
 
 
+class AnalysisPlanSerializer(serializers.Serializer):
+    """What a confirmed analyze_observable call would launch (preview, no side effects).
+
+    Declared as a serializer (not a free-form dict) so the plan's shape is enforced and documented in
+    one place; the tool feeds it the computed values on the confirm=False path.
+    """
+
+    observable_name = serializers.CharField()
+    classification = serializers.CharField()
+    tlp = serializers.CharField()
+    playbook = serializers.CharField(allow_null=True)
+    analyzers = serializers.ListField(child=serializers.CharField())
+    connectors = serializers.ListField(child=serializers.CharField())
+    # plugins dropped by TLP / not runnable for the user (the serializer's filter_warnings)
+    skipped = serializers.ListField(child=serializers.CharField())
+
+
 class AnalyzeObservableResultSerializer(ToolResultSerializer):
     """Envelope for the analyze_observable action tool.
 
-    Two-phase contract: on the preview call `confirmation_required` is True and `plan` carries the
-    computed `_AnalysisPlan` (what a confirmed call would launch); on the confirmed call `job` carries
-    the created Job and the other two are null/false.
+    Two-phase contract: on the preview call `confirmation_required` is True and `plan` carries what
+    would run; on the confirmed call `job` carries the launched -- or, on platform dedup, the reused
+    recent -- Job, and `reused` says which it is.
     """
 
     confirmation_required = serializers.BooleanField()
-    plan = serializers.DictField(allow_null=True)
+    # True when a confirmed call returned an existing recent job (platform dedup) instead of a new one.
+    reused = serializers.BooleanField()
+    plan = AnalysisPlanSerializer(allow_null=True)
     job = JobToolSerializer(allow_null=True)  # reuse the existing compact, PII-free Job view

--- a/api_app/chatbot_manager/serializers/analyze_observable.py
+++ b/api_app/chatbot_manager/serializers/analyze_observable.py
@@ -1,0 +1,20 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from rest_framework import serializers
+
+from .base import ToolResultSerializer
+from .job import JobToolSerializer
+
+
+class AnalyzeObservableResultSerializer(ToolResultSerializer):
+    """Envelope for the analyze_observable action tool.
+
+    Two-phase contract: on the preview call `confirmation_required` is True and `plan` carries the
+    computed `_AnalysisPlan` (what a confirmed call would launch); on the confirmed call `job` carries
+    the created Job and the other two are null/false.
+    """
+
+    confirmation_required = serializers.BooleanField()
+    plan = serializers.DictField(allow_null=True)
+    job = JobToolSerializer(allow_null=True)  # reuse the existing compact, PII-free Job view

--- a/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
+++ b/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
@@ -1,0 +1,159 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import json
+from unittest.mock import patch
+
+from django.test import TestCase
+
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.chatbot_manager.agent.tools import build_tools
+from api_app.models import Job
+from api_app.playbooks_manager.models import PlaybookConfig
+from certego_saas.apps.organization.membership import Membership
+from certego_saas.apps.organization.organization import Organization
+from certego_saas.apps.user.models import User
+
+# The trigger lives at `intel_owl.tasks.job_pipeline.apply_async`; patching it lets us assert
+# whether an analysis would have been launched without running Celery (the create path imports
+# `job_pipeline` from this module, so the patched attribute is the one it calls).
+_APPLY_ASYNC = "intel_owl.tasks.job_pipeline.apply_async"
+
+
+class AnalyzeObservableToolTestCase(TestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="analyze_obs_user")
+        # Another member of the same org: used to build a playbook that is private to them (i.e.
+        # NOT visible to self.user) for the isolation test.
+        self.org_member, _ = User.objects.get_or_create(username="analyze_obs_org_member")
+        self.org, _ = Organization.objects.get_or_create(name="analyze obs organization")
+        Membership.objects.get_or_create(user=self.user, organization=self.org, is_owner=True)
+        Membership.objects.get_or_create(user=self.org_member, organization=self.org, is_owner=False)
+
+        # A real seeded, free (no API key) observable analyzer that supports `domain` and is runnable
+        # at TLP CLEAR (max_tlp AMBER). Constructing one would need a PythonModule FK.
+        self.analyzer = AnalyzerConfig.objects.get(name="Tranco")
+
+        # Owned by self.user -> visible: passes the tool's visibility guard.
+        self.pb_owned = PlaybookConfig.objects.create(
+            name="analyze_obs_pb_owned", description="t", type=["domain"], owner=self.user, starting=True
+        )
+        self.pb_owned.analyzers.set([self.analyzer])
+        # Owned by another member, NOT org-shared -> invisible to self.user.
+        self.pb_private_other = PlaybookConfig.objects.create(
+            name="analyze_obs_pb_private",
+            description="t",
+            type=["domain"],
+            owner=self.org_member,
+            for_organization=False,
+            starting=True,
+        )
+        self.pb_private_other.analyzers.set([self.analyzer])
+
+        self.analyze_observable = {t.name: t for t in build_tools(user=self.user)}["analyze_observable"]
+
+    def tearDown(self):
+        Job.objects.filter(user__in=[self.user, self.org_member]).delete()
+        PlaybookConfig.objects.filter(owner__in=[self.user, self.org_member]).delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()
+
+    @patch(_APPLY_ASYNC)
+    def test_preview_does_not_trigger(self, mock_apply):
+        # confirm defaults to False -> preview only: a plan is returned and NOTHING is launched.
+        # This is the core safety guarantee of the action tool.
+        data = json.loads(
+            self.analyze_observable.invoke({"observable_name": "example.com", "analyzers": "Tranco"})
+        )
+        self.assertEqual(data["errors"], [])
+        self.assertTrue(data["confirmation_required"])
+        self.assertIsNotNone(data["plan"])
+        self.assertIsNone(data["job"])
+        self.assertEqual(data["plan"]["classification"], "domain")
+        self.assertIn("Tranco", data["plan"]["analyzers"])
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_triggers_once(self, mock_apply):
+        data = json.loads(
+            self.analyze_observable.invoke(
+                {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
+            )
+        )
+        self.assertEqual(data["errors"], [])
+        self.assertFalse(data["confirmation_required"])
+        self.assertIsNone(data["plan"])
+        self.assertIsNotNone(data["job"])
+        self.assertEqual(data["job"]["observable_name"], "example.com")
+        mock_apply.assert_called_once()
+
+    @patch(_APPLY_ASYNC)
+    def test_created_job_owned_by_requesting_user(self, mock_apply):
+        # Multi-tenancy: the launched Job is created under the closured user, never widened.
+        data = json.loads(
+            self.analyze_observable.invoke(
+                {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
+            )
+        )
+        job = Job.objects.get(pk=data["job"]["id"])
+        self.assertEqual(job.user, self.user)
+
+    @patch(_APPLY_ASYNC)
+    def test_force_new_analysis_skips_dedup(self, mock_apply):
+        # FORCE_NEW_ANALYSIS: two confirmed calls for the same observable each start a fresh job
+        # (no CHECK_PREVIOUS short-circuit), so the trigger fires both times.
+        args = {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
+        self.analyze_observable.invoke(args)
+        self.analyze_observable.invoke(args)
+        self.assertEqual(mock_apply.call_count, 2)
+
+    @patch(_APPLY_ASYNC)
+    def test_private_ip_refused(self, mock_apply):
+        # The serializer's IP guardrail rejects a private IP during validation -> even with
+        # confirm=True the request never reaches the trigger.
+        data = json.loads(
+            self.analyze_observable.invoke(
+                {"observable_name": "10.0.0.1", "analyzers": "Classic_DNS", "confirm": True}
+            )
+        )
+        self.assertTrue(data["errors"])
+        self.assertIsNone(data["job"])
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_unknown_analyzer_refused(self, mock_apply):
+        # An analyzer name the serializer can't resolve -> validation error, nothing triggered.
+        data = json.loads(
+            self.analyze_observable.invoke(
+                {"observable_name": "example.com", "analyzers": "NotARealAnalyzer", "confirm": True}
+            )
+        )
+        self.assertTrue(data["errors"])
+        self.assertIsNone(data["job"])
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_playbook_not_visible_refused(self, mock_apply):
+        # Isolation must-fix: another member's PRIVATE playbook must never resolve. The reused
+        # serializer would look it up via PlaybookConfig.objects.all(); the tool's visible_for_user
+        # guard rejects it first, so its existence/composition is never leaked into a plan.
+        data = json.loads(
+            self.analyze_observable.invoke(
+                {"observable_name": "example.com", "playbook": self.pb_private_other.name, "confirm": True}
+            )
+        )
+        self.assertTrue(any("not found or not visible" in e for e in data["errors"]))
+        self.assertIsNone(data["plan"])
+        self.assertIsNone(data["job"])
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_visible_playbook_preview(self, mock_apply):
+        # A playbook owned by the user passes the guard and previews with its name in the plan.
+        data = json.loads(
+            self.analyze_observable.invoke({"observable_name": "example.com", "playbook": self.pb_owned.name})
+        )
+        self.assertEqual(data["errors"], [])
+        self.assertTrue(data["confirmation_required"])
+        self.assertEqual(data["plan"]["playbook"], self.pb_owned.name)
+        mock_apply.assert_not_called()

--- a/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
+++ b/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
@@ -85,6 +85,7 @@ class AnalyzeObservableToolTestCase(TestCase):
         self.assertIsNone(data["plan"])
         self.assertIsNotNone(data["job"])
         self.assertEqual(data["job"]["observable_name"], "example.com")
+        self.assertFalse(data["reused"])  # fresh observable -> a new job, not a reused one
         mock_apply.assert_called_once()
 
     @patch(_APPLY_ASYNC)
@@ -99,13 +100,17 @@ class AnalyzeObservableToolTestCase(TestCase):
         self.assertEqual(job.user, self.user)
 
     @patch(_APPLY_ASYNC)
-    def test_force_new_analysis_skips_dedup(self, mock_apply):
-        # FORCE_NEW_ANALYSIS: two confirmed calls for the same observable each start a fresh job
-        # (no CHECK_PREVIOUS short-circuit), so the trigger fires both times.
+    def test_dedup_reuses_recent_job_on_second_confirm(self, mock_apply):
+        # Default scan_mode (CHECK_PREVIOUS_ANALYSIS): a second confirmed call for the same observable
+        # reuses the recent job instead of launching a duplicate -> apply_async fires only once and the
+        # second result is flagged `reused` with the same job id.
         args = {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
-        self.analyze_observable.invoke(args)
-        self.analyze_observable.invoke(args)
-        self.assertEqual(mock_apply.call_count, 2)
+        first = json.loads(self.analyze_observable.invoke(args))
+        second = json.loads(self.analyze_observable.invoke(args))
+        self.assertFalse(first["reused"])
+        self.assertTrue(second["reused"])
+        self.assertEqual(first["job"]["id"], second["job"]["id"])
+        mock_apply.assert_called_once()
 
     @patch(_APPLY_ASYNC)
     def test_private_ip_refused(self, mock_apply):


### PR DESCRIPTION
# Description

Adds `analyze_observable`, the chatbot agent's only **action** tool — it can start a real IntelOwl analysis. Refs #3732 (last of the 3 W5 tools).

It reuses `ObservableAnalysisSerializer` exactly as the REST `analyze_observable` view does (validation, defang, classification, private-IP guardrails, `maximum_tlp` plugin filtering, 'nothing runnable' refusal) and is **two-phase / confirm-gated**:
- `confirm=false` (default) → validates and returns a `plan` (analyzers/connectors that would run, skipped ones, classification) andt riggers **nothing**.
- `confirm=true` → `save(send_task=True)`, the only path that reaches `job_pipeline.apply_async`.

**Tenant isolation:** the reused serializer resolves `playbook_requested` via `PlaybookConfig.objects.all()` with no visibility filter, so the tool adds an explicit `visible_for_user(user)` guard on the `playbook` arg (a private playbook of another org is rejected, never resolved). The created `Job.user` is the requesting user.

**Safety boundary (honest):** the code-level guarantee is that no call without `confirm=true` can reach `apply_async`. The human-in-the-loop gate is the system-prompt instruction + the conversation turn boundary (agent returns the plan, the turn ends, the user's next message authorizes `confirm=true`) — not the flag alone. TLP never blocks a launch; it only filters which plugins run.

## Type of change
- [x] New feature (non-breaking change which adds functionality).

# Checklist
- [x] I have read and understood the rules about how to Contribute to this project
- [ ] The pull request is for the branch `develop` — *targets the `gsoc-2026/llm-chatbot` umbrella branch (GSoC workflow)*
- [x] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible — *no new libraries*
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors — *8 new tests; full `tests.api_app.chatbot_manager` suite 58/58 green locally*
- [x] After submitting the PR, if `DeepSource`/`Django Doctors`/other linters trigger alerts, I have solved them
- [x] I have addressed raised Copilot issues
- [x] I have reviewed and verified any LLM-generated code included in this PR. I used an LLM (Claude Code) to assist and reviewed the full diff (tool logic, the isolation guard, and the tests).