### PR TITLE
[GSoC 2026] Add chatbot WebSocket consumer with token streaming (refs #3756)

### DIFF
--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -42,7 +42,7 @@ Question: {input}
 REACT_PROMPT = PromptTemplate.from_template(_SYSTEM_PROMPT)
 
 
-def build_agent_executor(user) -> AgentExecutor:
+def build_agent_executor(user, streaming: bool = False) -> AgentExecutor:
     """Build a ReAct agent executor scoped to `user`.
 
     `ChatOllama` is the local LLM; `create_react_agent` wires the model + tools + prompt
@@ -50,11 +50,17 @@ def build_agent_executor(user) -> AgentExecutor:
     that loop until a Final Answer. `handle_parsing_errors=True` makes the executor feed
     a malformed model output back as an Observation instead of raising, which keeps small
     local models from crashing the turn on a formatting slip.
+
+    `streaming=True` makes `ChatOllama` emit token-level callbacks so the WebSocket path can
+    stream the answer live. No callbacks are bound to the model here: the caller attaches them
+    per run (`executor.invoke(..., config={"callbacks": [...]})`) so they also receive the
+    agent's tool actions, which originate from the executor and not from the LLM.
     """
     llm = ChatOllama(
         model=settings.OLLAMA_MODEL,
         base_url=settings.OLLAMA_BASE_URL,
         temperature=0,
+        streaming=streaming,
     )
     tools = build_tools(user=user)
     agent = create_react_agent(llm, tools, REACT_PROMPT)

--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -18,10 +18,10 @@ from langchain_core.callbacks.base import BaseCallbackHandler
 
 from api_app.chatbot_manager.events import (
     ANSWER_MARKER,
-    OutboundEvent,
+    ChatEvent,
+    StatusEvent,
+    TokenEvent,
     chat_group_for_user,
-    status_event,
-    token_event,
 )
 
 logger = logging.getLogger(__name__)
@@ -53,7 +53,7 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         self._buffer = ""
         self._answer_reached = False
 
-    def _emit(self, event: OutboundEvent) -> None:
+    def _emit(self, event: ChatEvent) -> None:
         async_to_sync(self._channel_layer.group_send)(self._group, event.as_channel_message())
 
     def on_llm_start(self, *args, **kwargs) -> None:
@@ -64,7 +64,7 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
 
     def on_llm_new_token(self, token: str, **kwargs) -> None:
         if self._answer_reached:
-            self._emit(token_event(self._session_id, token))
+            self._emit(TokenEvent(self._session_id, token))
             return
         self._buffer += token
         marker_index = self._buffer.find(ANSWER_MARKER)
@@ -76,7 +76,7 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         tail = self._buffer[marker_index + len(ANSWER_MARKER) :].lstrip()
         self._buffer = ""
         if tail:
-            self._emit(token_event(self._session_id, tail))
+            self._emit(TokenEvent(self._session_id, tail))
 
     def on_agent_action(self, action, **kwargs) -> None:
         # Fired when the ReAct agent picks a tool; action.tool is the clean tool name. Skip
@@ -85,4 +85,4 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         tool_name = getattr(action, "tool", "") or ""
         if not tool_name or (self._tool_names is not None and tool_name not in self._tool_names):
             return
-        self._emit(status_event(self._session_id, tool_name))
+        self._emit(StatusEvent(self._session_id, tool_name))

--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -1,0 +1,88 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""LangChain callback that streams a chat turn to the WebSocket as it runs.
+
+Attached at run level (``executor.invoke(..., config={"callbacks": [handler]})``) so it sees
+both the LLM token stream and the agent's tool actions, then pushes them onto the per-user
+channel group via ``group_send``. Running inside the (synchronous) Celery worker means there is
+no event loop, so ``async_to_sync`` is the right bridge to the async channel layer — the same
+pattern ``JobConsumer.serialize_and_send_job`` already uses.
+"""
+
+import logging
+
+from asgiref.sync import async_to_sync
+from channels.layers import get_channel_layer
+from langchain_core.callbacks.base import BaseCallbackHandler
+
+from api_app.chatbot_manager.events import (
+    ANSWER_MARKER,
+    OutboundEvent,
+    chat_group_for_user,
+    status_event,
+    token_event,
+)
+
+logger = logging.getLogger(__name__)
+
+
+class ChatStreamingCallbackHandler(BaseCallbackHandler):
+    """Streams the agent's *final answer* token-by-token, plus a status event per tool.
+
+    A ReAct turn is several LLM calls (Thought/Action/Observation loops); only the last one
+    emits the ``Final Answer:`` line. Streaming every token would leak that scaffolding, so the
+    handler buffers tokens and starts forwarding only once ``ANSWER_MARKER`` appears in the
+    buffer. The marker is matched as a *substring* (not a fixed token tuple) because a local
+    model's tokenization of ``"Final Answer:"`` is not guaranteed. ``on_llm_start`` re-arms the
+    gate for each call so a non-final iteration never streams.
+
+    This is a best-effort live view: the worker persists ``result["output"]`` and sends it in the
+    ``chat.end`` event, which the client treats as the source of truth, so a tokenization miss
+    can never corrupt the stored/displayed answer.
+    """
+
+    def __init__(self, user_id: int, session_id: int, tool_names: set[str] | None = None):
+        self._group = chat_group_for_user(user_id)
+        self._session_id = session_id
+        # Only these tool names produce a chat.status; None means "emit any" (unit tests).
+        # Filtering by the real registry suppresses LangChain's internal "_Exception" pseudo-tool
+        # (and the raw parse-error text) that handle_parsing_errors surfaces as agent actions.
+        self._tool_names = tool_names
+        self._channel_layer = get_channel_layer()
+        self._buffer = ""
+        self._answer_reached = False
+
+    def _emit(self, event: OutboundEvent) -> None:
+        async_to_sync(self._channel_layer.group_send)(self._group, event.as_channel_message())
+
+    def on_llm_start(self, *args, **kwargs) -> None:
+        # Each ReAct iteration is a fresh LLM call; re-arm so only the call that produces the
+        # Final Answer streams, and drop the previous iteration's buffered scaffolding.
+        self._buffer = ""
+        self._answer_reached = False
+
+    def on_llm_new_token(self, token: str, **kwargs) -> None:
+        if self._answer_reached:
+            self._emit(token_event(self._session_id, token))
+            return
+        self._buffer += token
+        marker_index = self._buffer.find(ANSWER_MARKER)
+        if marker_index == -1:
+            return
+        self._answer_reached = True
+        # Stream whatever already trails the marker in this same chunk; lstrip so the answer
+        # doesn't open with the space/newline that usually follows "Final Answer:".
+        tail = self._buffer[marker_index + len(ANSWER_MARKER) :].lstrip()
+        self._buffer = ""
+        if tail:
+            self._emit(token_event(self._session_id, tail))
+
+    def on_agent_action(self, action, **kwargs) -> None:
+        # Fired when the ReAct agent picks a tool; action.tool is the clean tool name. Skip
+        # anything that isn't a registered tool (e.g. the "_Exception" parse-error pseudo-tool,
+        # whose "tool" is the raw malformed model output) so internals don't leak as chat.status.
+        tool_name = getattr(action, "tool", "") or ""
+        if not tool_name or (self._tool_names is not None and tool_name not in self._tool_names):
+            return
+        self._emit(status_event(self._session_id, tool_name))

--- a/api_app/chatbot_manager/consumers.py
+++ b/api_app/chatbot_manager/consumers.py
@@ -17,11 +17,10 @@ from asgiref.sync import async_to_sync
 from channels.generic.websocket import JsonWebsocketConsumer
 
 from api_app.chatbot_manager.events import (
-    DETAIL_INVALID_MESSAGE,
-    DETAIL_SESSION_NOT_FOUND,
-    ack_payload,
+    AckEvent,
+    ChatErrorDetail,
+    ErrorEvent,
     chat_group_for_user,
-    error_payload,
 )
 from api_app.chatbot_manager.models import ChatSession
 from api_app.chatbot_manager.serializers.chat import MessageRequestSerializer
@@ -46,13 +45,13 @@ class ChatConsumer(JsonWebsocketConsumer):
         self.group_name = chat_group_for_user(user.id)
         self.accept()
         async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
-        logger.debug("user %s connected to chat group %s", user, self.group_name)
+        logger.debug(f"user {user} connected to chat group {self.group_name}")
 
     def disconnect(self, close_code) -> None:
         group_name = getattr(self, "group_name", None)
         if group_name:
             async_to_sync(self.channel_layer.group_discard)(group_name, self.channel_name)
-        logger.debug("chat ws disconnected (group=%s, code=%s)", group_name, close_code)
+        logger.debug(f"chat ws disconnected (group={group_name}, code={close_code})")
 
     def receive_json(self, content, **kwargs) -> None:
         """Validate one inbound message, resolve its session, and enqueue the agent turn.
@@ -64,7 +63,7 @@ class ChatConsumer(JsonWebsocketConsumer):
         user = self.scope["user"]
         serializer = MessageRequestSerializer(data=content)
         if not serializer.is_valid():
-            self.send_json(error_payload(None, DETAIL_INVALID_MESSAGE))
+            self.send_json(ErrorEvent(None, ChatErrorDetail.INVALID_MESSAGE.value).to_client())
             return
 
         session_id = serializer.validated_data.get("session_id")
@@ -72,11 +71,11 @@ class ChatConsumer(JsonWebsocketConsumer):
         try:
             session = self._resolve_session(user, session_id)
         except ChatSession.DoesNotExist:
-            self.send_json(error_payload(session_id, DETAIL_SESSION_NOT_FOUND))
+            self.send_json(ErrorEvent(session_id, ChatErrorDetail.SESSION_NOT_FOUND.value).to_client())
             return
 
         # Ack the (possibly newly created) session id before the asynchronous stream begins.
-        self.send_json(ack_payload(session.id))
+        self.send_json(AckEvent(session.id).to_client())
         process_chat_message.delay(session.id, message, user.id)
 
     @staticmethod

--- a/api_app/chatbot_manager/consumers.py
+++ b/api_app/chatbot_manager/consumers.py
@@ -1,0 +1,108 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""WebSocket consumer for the chatbot.
+
+Mirrors JobConsumer (api_app/websocket.py): a synchronous JsonWebsocketConsumer that joins a
+channel group on connect and relays group messages to the browser. Unlike JobConsumer it is
+bidirectional — the client sends a chat message over the socket and the consumer enqueues the
+Celery turn — and it groups by user (chat-<user_id>) rather than by resource, because the fixed
+URL ws/chat/?context_url=... carries no session id and a session belongs to exactly one user.
+"""
+
+import logging
+from urllib.parse import parse_qs
+
+from asgiref.sync import async_to_sync
+from channels.generic.websocket import JsonWebsocketConsumer
+
+from api_app.chatbot_manager.events import (
+    DETAIL_INVALID_MESSAGE,
+    DETAIL_SESSION_NOT_FOUND,
+    ack_payload,
+    chat_group_for_user,
+    error_payload,
+)
+from api_app.chatbot_manager.models import ChatSession
+from api_app.chatbot_manager.serializers.chat import MessageRequestSerializer
+from api_app.chatbot_manager.tasks import process_chat_message
+
+logger = logging.getLogger(__name__)
+
+
+class ChatConsumer(JsonWebsocketConsumer):
+    """Streams chat turns to the user and accepts inbound messages to start them.
+
+    Auth is handled upstream by WSAuthMiddleware (anonymous users are rejected before reaching
+    here). The group key is the server-authenticated scope["user"].id, so a client can only ever
+    receive its own stream.
+    """
+
+    def connect(self) -> None:
+        user = self.scope["user"]
+        # context_url (the page the user is on) is captured for later context injection (W9);
+        # it is intentionally unused for now.
+        self.context_url = self._parse_context_url()
+        self.group_name = chat_group_for_user(user.id)
+        self.accept()
+        async_to_sync(self.channel_layer.group_add)(self.group_name, self.channel_name)
+        logger.debug("user %s connected to chat group %s", user, self.group_name)
+
+    def disconnect(self, close_code) -> None:
+        group_name = getattr(self, "group_name", None)
+        if group_name:
+            async_to_sync(self.channel_layer.group_discard)(group_name, self.channel_name)
+        logger.debug("chat ws disconnected (group=%s, code=%s)", group_name, close_code)
+
+    def receive_json(self, content, **kwargs) -> None:
+        """Validate one inbound message, resolve its session, and enqueue the agent turn.
+
+        The frame is untrusted: it is validated/length-capped by MessageRequestSerializer, and
+        any supplied session_id is resolved scoped to the connected user, so a client cannot
+        drive another user's session.
+        """
+        user = self.scope["user"]
+        serializer = MessageRequestSerializer(data=content)
+        if not serializer.is_valid():
+            self.send_json(error_payload(None, DETAIL_INVALID_MESSAGE))
+            return
+
+        session_id = serializer.validated_data.get("session_id")
+        message = serializer.validated_data["message"]
+        try:
+            session = self._resolve_session(user, session_id)
+        except ChatSession.DoesNotExist:
+            self.send_json(error_payload(session_id, DETAIL_SESSION_NOT_FOUND))
+            return
+
+        # Ack the (possibly newly created) session id before the asynchronous stream begins.
+        self.send_json(ack_payload(session.id))
+        process_chat_message.delay(session.id, message, user.id)
+
+    @staticmethod
+    def _resolve_session(user, session_id) -> ChatSession:
+        """Return the user's existing session, or create a fresh one when none is given."""
+        if session_id is None:
+            return ChatSession.objects.create(user=user)
+        return ChatSession.objects.get(pk=session_id, user=user)
+
+    def _parse_context_url(self) -> str:
+        query_string = self.scope.get("query_string", b"").decode()
+        return parse_qs(query_string).get("context_url", [""])[0]
+
+    # Group handlers: Channels maps an event "type" (e.g. "chat.token") to the same-named method
+    # with dots turned into underscores. Each one relays the payload the producer already built.
+    def chat_start(self, event) -> None:
+        self.send_json(event["payload"])
+
+    def chat_status(self, event) -> None:
+        self.send_json(event["payload"])
+
+    def chat_token(self, event) -> None:
+        self.send_json(event["payload"])
+
+    def chat_end(self, event) -> None:
+        self.send_json(event["payload"])
+
+    def chat_error(self, event) -> None:
+        self.send_json(event["payload"])

--- a/api_app/chatbot_manager/events.py
+++ b/api_app/chatbot_manager/events.py
@@ -1,0 +1,122 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Wire protocol for the chat WebSocket.
+
+Single source of truth for everything that crosses the chat WebSocket so the producer
+(Celery worker / streaming callback) and the consumer never hand-build event dicts:
+
+- the Channels ``group_send`` routing types (``chat.token`` -> ``ChatConsumer.chat_token``);
+- the client-facing payload built by the typed ``*_payload`` helpers;
+- the ``OutboundEvent`` dataclass that pairs a routing type with its payload;
+- the per-user group name and the inbound limits.
+
+A chat turn streams to a per-user group (``chat-<user_id>``) rather than a per-session group:
+the fixed URL ``ws/chat/?context_url=...`` carries no session id, the group key is the
+server-authenticated user id (so no cross-tenant subscription is possible), and every payload
+carries ``session_id`` so a client with several open sessions/tabs can demultiplex.
+"""
+
+from dataclasses import dataclass
+from typing import Optional
+
+# --- Channels group_send "type" -> ChatConsumer handler (dots become underscores) ---
+EVENT_START = "chat.start"
+EVENT_STATUS = "chat.status"
+EVENT_TOKEN = "chat.token"
+EVENT_END = "chat.end"
+EVENT_ERROR = "chat.error"
+
+# --- client-facing payload "type" labels (what the browser switches on) ---
+CLIENT_ACK = "ack"
+CLIENT_START = "start"
+CLIENT_STATUS = "status"
+CLIENT_TOKEN = "token"
+CLIENT_END = "end"
+CLIENT_ERROR = "error"
+
+CHAT_GROUP_PREFIX = "chat-"
+
+# The ReAct prompt ends every turn with a "Final Answer:" line (see REACT_PROMPT). The
+# streaming callback streams only what follows this marker, hiding the Thought/Action scaffolding.
+ANSWER_MARKER = "Final Answer:"
+
+# Inbound guardrail: mirrors MessageRequestSerializer(message=CharField(max_length=4096)).
+MAX_INBOUND_MESSAGE_LEN = 4096
+
+# User-facing error details (kept generic on purpose: never leak internals to the client).
+DETAIL_SESSION_NOT_FOUND = "Chat session not found."
+DETAIL_INVALID_MESSAGE = "Invalid message payload."
+DETAIL_TIMEOUT = "The assistant took too long to respond. Please try again."
+DETAIL_UNAVAILABLE = "The assistant is currently unavailable. Please try again."
+
+
+def chat_group_for_user(user_id: int) -> str:
+    """Return the per-user channel group that carries this user's chat stream."""
+    return f"{CHAT_GROUP_PREFIX}{user_id}"
+
+
+def _payload(client_type: str, **fields) -> dict:
+    return {"type": client_type, **fields}
+
+
+# --- client-facing payload builders (also used for messages the consumer sends directly) ---
+def ack_payload(session_id: int) -> dict:
+    """Synchronous reply to an inbound frame, telling the client which session it landed on."""
+    return _payload(CLIENT_ACK, session_id=session_id)
+
+
+def start_payload(session_id: int) -> dict:
+    return _payload(CLIENT_START, session_id=session_id)
+
+
+def status_payload(session_id: int, tool: str) -> dict:
+    return _payload(CLIENT_STATUS, session_id=session_id, tool=tool)
+
+
+def token_payload(session_id: int, content: str) -> dict:
+    return _payload(CLIENT_TOKEN, session_id=session_id, content=content)
+
+
+def end_payload(session_id: int, message_id: int, content: str) -> dict:
+    return _payload(CLIENT_END, session_id=session_id, message_id=message_id, content=content)
+
+
+def error_payload(session_id: Optional[int], detail: str) -> dict:
+    return _payload(CLIENT_ERROR, session_id=session_id, detail=detail)
+
+
+@dataclass(frozen=True)
+class OutboundEvent:
+    """A chat event pushed worker -> channel layer -> consumer -> client.
+
+    ``channel_type`` routes the ``group_send`` to the matching ``ChatConsumer`` handler;
+    ``payload`` is what that handler forwards verbatim to the browser via ``send_json``.
+    """
+
+    channel_type: str
+    payload: dict
+
+    def as_channel_message(self) -> dict:
+        return {"type": self.channel_type, "payload": self.payload}
+
+
+# --- OutboundEvent builders (group-routed events emitted by the worker / callback) ---
+def start_event(session_id: int) -> OutboundEvent:
+    return OutboundEvent(EVENT_START, start_payload(session_id))
+
+
+def status_event(session_id: int, tool: str) -> OutboundEvent:
+    return OutboundEvent(EVENT_STATUS, status_payload(session_id, tool))
+
+
+def token_event(session_id: int, content: str) -> OutboundEvent:
+    return OutboundEvent(EVENT_TOKEN, token_payload(session_id, content))
+
+
+def end_event(session_id: int, message_id: int, content: str) -> OutboundEvent:
+    return OutboundEvent(EVENT_END, end_payload(session_id, message_id, content))
+
+
+def error_event(session_id: Optional[int], detail: str) -> OutboundEvent:
+    return OutboundEvent(EVENT_ERROR, error_payload(session_id, detail))

--- a/api_app/chatbot_manager/events.py
+++ b/api_app/chatbot_manager/events.py
@@ -3,52 +3,52 @@
 
 """Wire protocol for the chat WebSocket.
 
-Single source of truth for everything that crosses the chat WebSocket so the producer
-(Celery worker / streaming callback) and the consumer never hand-build event dicts:
+Single source of truth for everything that crosses the chat WebSocket, so the producer (Celery
+worker / streaming callback) and the consumer never hand-build event dicts. One style throughout:
+a ``ChatEvent`` dataclass per event kind, each able to render
 
-- the Channels ``group_send`` routing types (``chat.token`` -> ``ChatConsumer.chat_token``);
-- the client-facing payload built by the typed ``*_payload`` helpers;
-- the ``OutboundEvent`` dataclass that pairs a routing type with its payload;
-- the per-user group name and the inbound limits.
+- ``to_client()`` — the JSON the browser receives (its ``type`` is a ``ChatEventType``), and
+- ``as_channel_message()`` — that payload wrapped for a Channels ``group_send``, whose ``type``
+  (``chat.token`` -> ``ChatConsumer.chat_token``) routes it to the matching consumer handler.
 
-A chat turn streams to a per-user group (``chat-<user_id>``) rather than a per-session group:
-the fixed URL ``ws/chat/?context_url=...`` carries no session id, the group key is the
-server-authenticated user id (so no cross-tenant subscription is possible), and every payload
-carries ``session_id`` so a client with several open sessions/tabs can demultiplex.
+A chat turn streams to a per-user group (``chat-<user_id>``) rather than a per-session group: the
+fixed URL ``ws/chat/?context_url=...`` carries no session id, the group key is the server-
+authenticated user id (so no cross-tenant subscription is possible), and every payload carries
+``session_id`` so a client with several open sessions/tabs can demultiplex.
 """
 
-from dataclasses import dataclass
-from typing import Optional
-
-# --- Channels group_send "type" -> ChatConsumer handler (dots become underscores) ---
-EVENT_START = "chat.start"
-EVENT_STATUS = "chat.status"
-EVENT_TOKEN = "chat.token"
-EVENT_END = "chat.end"
-EVENT_ERROR = "chat.error"
-
-# --- client-facing payload "type" labels (what the browser switches on) ---
-CLIENT_ACK = "ack"
-CLIENT_START = "start"
-CLIENT_STATUS = "status"
-CLIENT_TOKEN = "token"
-CLIENT_END = "end"
-CLIENT_ERROR = "error"
+from dataclasses import asdict, dataclass
+from enum import StrEnum
+from typing import ClassVar, Optional
 
 CHAT_GROUP_PREFIX = "chat-"
 
-# The ReAct prompt ends every turn with a "Final Answer:" line (see REACT_PROMPT). The
-# streaming callback streams only what follows this marker, hiding the Thought/Action scaffolding.
+# The ReAct prompt ends every turn with a "Final Answer:" line (see REACT_PROMPT). The streaming
+# callback streams only what follows this marker, hiding the Thought/Action scaffolding.
 ANSWER_MARKER = "Final Answer:"
 
 # Inbound guardrail: mirrors MessageRequestSerializer(message=CharField(max_length=4096)).
 MAX_INBOUND_MESSAGE_LEN = 4096
 
-# User-facing error details (kept generic on purpose: never leak internals to the client).
-DETAIL_SESSION_NOT_FOUND = "Chat session not found."
-DETAIL_INVALID_MESSAGE = "Invalid message payload."
-DETAIL_TIMEOUT = "The assistant took too long to respond. Please try again."
-DETAIL_UNAVAILABLE = "The assistant is currently unavailable. Please try again."
+
+class ChatEventType(StrEnum):
+    """The ``type`` discriminator of an outbound frame (what the browser switches on)."""
+
+    ACK = "ack"
+    START = "start"
+    STATUS = "status"
+    TOKEN = "token"
+    END = "end"
+    ERROR = "error"
+
+
+class ChatErrorDetail(StrEnum):
+    """User-facing error texts (kept generic on purpose: never leak internals to the client)."""
+
+    SESSION_NOT_FOUND = "Chat session not found."
+    INVALID_MESSAGE = "Invalid message payload."
+    TIMEOUT = "The assistant took too long to respond. Please try again."
+    UNAVAILABLE = "The assistant is currently unavailable. Please try again."
 
 
 def chat_group_for_user(user_id: int) -> str:
@@ -56,67 +56,64 @@ def chat_group_for_user(user_id: int) -> str:
     return f"{CHAT_GROUP_PREFIX}{user_id}"
 
 
-def _payload(client_type: str, **fields) -> dict:
-    return {"type": client_type, **fields}
+@dataclass(frozen=True)
+class ChatEvent:
+    """Base outbound chat event.
 
+    Subclasses only declare their extra fields and set ``type``. ``to_client()`` is the frame the
+    browser receives; ``as_channel_message()`` wraps it for a Channels ``group_send`` and is
+    relayed verbatim by ``ChatConsumer`` (``chat.<type>`` -> the same-named handler).
+    """
 
-# --- client-facing payload builders (also used for messages the consumer sends directly) ---
-def ack_payload(session_id: int) -> dict:
-    """Synchronous reply to an inbound frame, telling the client which session it landed on."""
-    return _payload(CLIENT_ACK, session_id=session_id)
+    # Channels routing prefix; "chat." + type -> "chat.token" -> ChatConsumer.chat_token.
+    _CHANNEL_TYPE_PREFIX: ClassVar[str] = "chat."
+    type: ClassVar[ChatEventType]
 
+    session_id: Optional[int]
 
-def start_payload(session_id: int) -> dict:
-    return _payload(CLIENT_START, session_id=session_id)
+    def to_client(self) -> dict:
+        return {"type": self.type.value, **asdict(self)}
 
+    @property
+    def channel_type(self) -> str:
+        return f"{self._CHANNEL_TYPE_PREFIX}{self.type.value}"
 
-def status_payload(session_id: int, tool: str) -> dict:
-    return _payload(CLIENT_STATUS, session_id=session_id, tool=tool)
-
-
-def token_payload(session_id: int, content: str) -> dict:
-    return _payload(CLIENT_TOKEN, session_id=session_id, content=content)
-
-
-def end_payload(session_id: int, message_id: int, content: str) -> dict:
-    return _payload(CLIENT_END, session_id=session_id, message_id=message_id, content=content)
-
-
-def error_payload(session_id: Optional[int], detail: str) -> dict:
-    return _payload(CLIENT_ERROR, session_id=session_id, detail=detail)
+    def as_channel_message(self) -> dict:
+        return {"type": self.channel_type, "payload": self.to_client()}
 
 
 @dataclass(frozen=True)
-class OutboundEvent:
-    """A chat event pushed worker -> channel layer -> consumer -> client.
+class AckEvent(ChatEvent):
+    """Synchronous reply to an inbound frame, telling the client which session it landed on."""
 
-    ``channel_type`` routes the ``group_send`` to the matching ``ChatConsumer`` handler;
-    ``payload`` is what that handler forwards verbatim to the browser via ``send_json``.
-    """
-
-    channel_type: str
-    payload: dict
-
-    def as_channel_message(self) -> dict:
-        return {"type": self.channel_type, "payload": self.payload}
+    type: ClassVar[ChatEventType] = ChatEventType.ACK
 
 
-# --- OutboundEvent builders (group-routed events emitted by the worker / callback) ---
-def start_event(session_id: int) -> OutboundEvent:
-    return OutboundEvent(EVENT_START, start_payload(session_id))
+@dataclass(frozen=True)
+class StartEvent(ChatEvent):
+    type: ClassVar[ChatEventType] = ChatEventType.START
 
 
-def status_event(session_id: int, tool: str) -> OutboundEvent:
-    return OutboundEvent(EVENT_STATUS, status_payload(session_id, tool))
+@dataclass(frozen=True)
+class StatusEvent(ChatEvent):
+    tool: str
+    type: ClassVar[ChatEventType] = ChatEventType.STATUS
 
 
-def token_event(session_id: int, content: str) -> OutboundEvent:
-    return OutboundEvent(EVENT_TOKEN, token_payload(session_id, content))
+@dataclass(frozen=True)
+class TokenEvent(ChatEvent):
+    content: str
+    type: ClassVar[ChatEventType] = ChatEventType.TOKEN
 
 
-def end_event(session_id: int, message_id: int, content: str) -> OutboundEvent:
-    return OutboundEvent(EVENT_END, end_payload(session_id, message_id, content))
+@dataclass(frozen=True)
+class EndEvent(ChatEvent):
+    message_id: int
+    content: str
+    type: ClassVar[ChatEventType] = ChatEventType.END
 
 
-def error_event(session_id: Optional[int], detail: str) -> OutboundEvent:
-    return OutboundEvent(EVENT_ERROR, error_payload(session_id, detail))
+@dataclass(frozen=True)
+class ErrorEvent(ChatEvent):
+    detail: str
+    type: ClassVar[ChatEventType] = ChatEventType.ERROR

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -15,13 +15,11 @@ from django.db.models.functions import Coalesce
 from django.utils.timezone import now
 
 from api_app.chatbot_manager.events import (
-    DETAIL_SESSION_NOT_FOUND,
-    DETAIL_TIMEOUT,
-    DETAIL_UNAVAILABLE,
+    ChatErrorDetail,
+    EndEvent,
+    ErrorEvent,
+    StartEvent,
     chat_group_for_user,
-    end_event,
-    error_event,
-    start_event,
 )
 from intel_owl.tasks import FailureLoggedTask
 
@@ -66,15 +64,15 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
     try:
         session = ChatSession.objects.get(pk=session_id, user_id=user_id)
     except ChatSession.DoesNotExist:
-        logger.warning("process_chat_message: session %s not found for user %s", session_id, user_id)
-        emit(error_event(session_id, DETAIL_SESSION_NOT_FOUND))
+        logger.warning(f"process_chat_message: session {session_id} not found for user {user_id}")
+        emit(ErrorEvent(session_id, ChatErrorDetail.SESSION_NOT_FOUND.value))
         return
 
     user = get_user_model().objects.get(pk=user_id)
     history = DjangoChatMessageHistory(session=session)
     chat_history_text = format_history(history.messages)
 
-    emit(start_event(session_id))
+    emit(StartEvent(session_id))
     try:
         executor = build_agent_executor(user=user, streaming=True)
         # Scope streamed tool-status events to the agent's real tools (drops the internal
@@ -89,12 +87,12 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
             config={"callbacks": [handler]},
         )
     except SoftTimeLimitExceeded:
-        logger.warning("process_chat_message: timed out for session %s", session_id)
-        emit(error_event(session_id, DETAIL_TIMEOUT))
+        logger.warning(f"process_chat_message: timed out for session {session_id}")
+        emit(ErrorEvent(session_id, ChatErrorDetail.TIMEOUT.value))
         return
     except Exception as exc:  # noqa: BLE001 - any agent/Ollama failure must still reach the client
-        logger.exception("process_chat_message: agent run failed for session %s: %s", session_id, exc)
-        emit(error_event(session_id, DETAIL_UNAVAILABLE))
+        logger.exception(f"process_chat_message: agent run failed for session {session_id}: {exc}")
+        emit(ErrorEvent(session_id, ChatErrorDetail.UNAVAILABLE.value))
         return
 
     response_text = result.get("output", "")
@@ -105,7 +103,7 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
     ai_message = ChatMessage.objects.create(
         session=session, role=ChatMessage.Role.ASSISTANT, content=response_text
     )
-    emit(end_event(session_id, ai_message.id, response_text))
+    emit(EndEvent(session_id, ai_message.id, response_text))
 
 
 # soft_time_limit=1800: daily maintenance task whose work is a single bulk DELETE that

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -4,12 +4,25 @@
 import datetime
 import logging
 
+from asgiref.sync import async_to_sync
 from celery import shared_task
+from celery.exceptions import SoftTimeLimitExceeded
+from channels.layers import get_channel_layer
 from django.conf import settings
+from django.contrib.auth import get_user_model
 from django.db.models import Max
 from django.db.models.functions import Coalesce
 from django.utils.timezone import now
 
+from api_app.chatbot_manager.events import (
+    DETAIL_SESSION_NOT_FOUND,
+    DETAIL_TIMEOUT,
+    DETAIL_UNAVAILABLE,
+    chat_group_for_user,
+    end_event,
+    error_event,
+    start_event,
+)
 from intel_owl.tasks import FailureLoggedTask
 
 logger = logging.getLogger(__name__)
@@ -21,9 +34,78 @@ logger = logging.getLogger(__name__)
 # (catchable, lets us clean up) rather than a hard time_limit that SIGKILLs the worker,
 # and it bounds a hung Ollama call so it can't occupy a worker indefinitely.
 @shared_task(base=FailureLoggedTask, soft_time_limit=300)
-def process_chat_message(session_id: int, user_message: str, user_id: int) -> str:
-    # TODO: full async implementation via the WebSocket consumer + Celery task.
-    raise NotImplementedError
+def process_chat_message(session_id: int, user_message: str, user_id: int) -> None:
+    """Run one chat turn off-request and stream it to the user's WebSocket group.
+
+    Enqueued by ChatConsumer.receive_json. The agent runs synchronously here (so token and
+    tool callbacks can bridge to the async channel layer via async_to_sync) and pushes
+    chat.start -> chat.status/chat.token* -> chat.end onto the per-user group, which the
+    consumer relays to the browser. On any failure a single chat.error is emitted instead and
+    the turn is dropped (no assistant message persisted), mirroring the sync REST path.
+
+    Persistence is the source of truth: the streamed tokens are a live preview, while
+    result["output"] is what gets stored and sent in chat.end. History is snapshotted before
+    this turn is written so the current message is not double-counted.
+    """
+    # The agent/LLM stack (langchain + ChatOllama) is imported lazily so the other Celery
+    # workers that load this module never pay for that heavy import — only the chatbot worker,
+    # which actually runs this task, does.
+    from api_app.chatbot_manager.agent.agent import build_agent_executor, format_history
+    from api_app.chatbot_manager.agent.memory import DjangoChatMessageHistory
+    from api_app.chatbot_manager.agent.streaming import ChatStreamingCallbackHandler
+    from api_app.chatbot_manager.models import ChatMessage, ChatSession
+
+    channel_layer = get_channel_layer()
+    group = chat_group_for_user(user_id)
+
+    def emit(event) -> None:
+        async_to_sync(channel_layer.group_send)(group, event.as_channel_message())
+
+    # Defense in depth: never trust the task args. The session must exist AND belong to the
+    # user (the consumer already enforces this, but the task must not assume that).
+    try:
+        session = ChatSession.objects.get(pk=session_id, user_id=user_id)
+    except ChatSession.DoesNotExist:
+        logger.warning("process_chat_message: session %s not found for user %s", session_id, user_id)
+        emit(error_event(session_id, DETAIL_SESSION_NOT_FOUND))
+        return
+
+    user = get_user_model().objects.get(pk=user_id)
+    history = DjangoChatMessageHistory(session=session)
+    chat_history_text = format_history(history.messages)
+
+    emit(start_event(session_id))
+    try:
+        executor = build_agent_executor(user=user, streaming=True)
+        # Scope streamed tool-status events to the agent's real tools (drops the internal
+        # "_Exception" pseudo-tool that handle_parsing_errors raises on malformed model output).
+        handler = ChatStreamingCallbackHandler(
+            user_id=user_id,
+            session_id=session_id,
+            tool_names={tool.name for tool in executor.tools},
+        )
+        result = executor.invoke(
+            {"input": user_message, "chat_history": chat_history_text},
+            config={"callbacks": [handler]},
+        )
+    except SoftTimeLimitExceeded:
+        logger.warning("process_chat_message: timed out for session %s", session_id)
+        emit(error_event(session_id, DETAIL_TIMEOUT))
+        return
+    except Exception as exc:  # noqa: BLE001 - any agent/Ollama failure must still reach the client
+        logger.exception("process_chat_message: agent run failed for session %s: %s", session_id, exc)
+        emit(error_event(session_id, DETAIL_UNAVAILABLE))
+        return
+
+    response_text = result.get("output", "")
+    history.add_user_message(user_message)
+    # Create the assistant row directly (rather than add_ai_message + a latest("timestamp")
+    # re-query) so chat.end carries its exact id, without a lookup two overlapping turns of the
+    # same session could race on.
+    ai_message = ChatMessage.objects.create(
+        session=session, role=ChatMessage.Role.ASSISTANT, content=response_text
+    )
+    emit(end_event(session_id, ai_message.id, response_text))
 
 
 # soft_time_limit=1800: daily maintenance task whose work is a single bulk DELETE that

--- a/docker/entrypoints/celery_chatbot.sh
+++ b/docker/entrypoints/celery_chatbot.sh
@@ -1,0 +1,29 @@
+#!/bin/bash
+
+until cd /opt/deploy/intel_owl
+do
+    echo "Waiting for server volume..."
+done
+
+if [ "$AWS_SQS" = "True" ]
+then
+  queues="chatbot.fifo,config.fifo"
+else
+  queues="chatbot,broadcast,config"
+fi
+
+# Concurrency is intentionally low (-c 2): a chat turn is a long, LLM-bound ReAct run
+# (soft_time_limit=300) that ends up serialized on the single Ollama backend, so a large pool
+# would only spawn idle workers all blocked on the model. --time-limit=600 is a hard backstop
+# comfortably above the task's 300s soft limit; it deliberately overrides the global
+# task_time_limit=1800 (intel_owl/celery.py) for this LLM worker so a hung turn is reclaimed
+# sooner.
+ARGUMENTS="-A intel_owl.celery worker -n worker_chatbot --uid www-data --gid www-data --time-limit=600 --pidfile= -c 2 -Ofair -Q ${queues} -E --without-gossip"
+if [[ $DEBUG == "True" ]] && [[ $DJANGO_TEST_SERVER == "True" ]];
+then
+    echo "Running celery with autoreload"
+    python3 manage.py celery_reload -c "$ARGUMENTS"
+else
+  # shellcheck disable=SC2086
+  /usr/local/bin/celery $ARGUMENTS
+fi

--- a/docker/ollama.override.yml
+++ b/docker/ollama.override.yml
@@ -21,5 +21,30 @@ services:
       retries: 5
       start_period: 180s
 
+  # Dedicated worker that drains the chatbot queue (process_chat_message). It lives with the
+  # ollama stack so the same --ollama flag that starts the LLM also starts the worker that uses
+  # it; without this service the chatbot queue would have no consumer and chat turns would hang.
+  celery_worker_chatbot:
+    image: intelowlproject/intelowl:${REACT_APP_INTELOWL_VERSION}
+    container_name: intelowl_celery_worker_chatbot
+    hostname: celery_worker_chatbot
+    restart: unless-stopped
+    stop_grace_period: 3m
+    volumes:
+      - ../configuration:/opt/deploy/intel_owl/configuration
+      - generic_logs:/var/log/intel_owl
+      - shared_files:/opt/deploy/files_required
+    entrypoint:
+      - ./docker/entrypoints/celery_chatbot.sh
+    env_file:
+      - env_file_app
+    depends_on:
+      uwsgi:
+        condition: service_healthy
+      ollama:
+        condition: service_healthy
+    healthcheck:
+      disable: true
+
 volumes:
   ollama_data:

--- a/intel_owl/asgi.py
+++ b/intel_owl/asgi.py
@@ -13,6 +13,7 @@ os.environ.setdefault("DJANGO_SETTINGS_MODULE", "intel_owl.settings")
 get_asgi_application()
 
 # pylint: disable=wrong-import-position
+from api_app.chatbot_manager.consumers import ChatConsumer  # noqa: E402
 from api_app.websocket import JobConsumer  # noqa: E402
 from intel_owl.middleware import WSAuthMiddleware  # noqa: E402
 
@@ -25,6 +26,7 @@ application = ProtocolTypeRouter(
                     URLRouter(
                         [
                             path("ws/jobs/<int:job_id>", JobConsumer.as_asgi()),
+                            path("ws/chat/", ChatConsumer.as_asgi()),
                         ]
                     )
                 )

--- a/intel_owl/celery.py
+++ b/intel_owl/celery.py
@@ -89,6 +89,13 @@ if not settings.AWS_SQS:
 app.conf.update(
     task_default_queue=get_queue_name(settings.DEFAULT_QUEUE),
     task_queues=task_queues,
+    # Pin the chat turn to the dedicated chatbot queue (drained by celery_worker_chatbot) so
+    # its long, LLM-bound runs never tie up the default workers, regardless of the call site.
+    task_routes={
+        "api_app.chatbot_manager.tasks.process_chat_message": {
+            "queue": get_queue_name(settings.CHATBOT_QUEUE),
+        },
+    },
     task_time_limit=1800,
     broker_url=settings.BROKER_URL,
     result_backend=settings.RESULT_BACKEND,

--- a/tests/api_app/chatbot_manager/test_consumers.py
+++ b/tests/api_app/chatbot_manager/test_consumers.py
@@ -1,0 +1,136 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import AsyncMock, MagicMock, patch
+
+from asgiref.sync import async_to_sync
+from django.contrib.auth.models import AnonymousUser
+from django.test import SimpleTestCase, TestCase
+
+from api_app.chatbot_manager import events
+from api_app.chatbot_manager.consumers import ChatConsumer
+from api_app.chatbot_manager.models import ChatSession
+from certego_saas.apps.user.models import User
+from intel_owl.middleware import WSAuthMiddleware
+
+CHANNEL_NAME = "test.channel"
+
+
+def _make_consumer(user):
+    """A ChatConsumer wired for direct (synchronous) method calls.
+
+    The consumer's sync methods (connect/receive_json/disconnect) are exercised directly with an
+    injected scope and a mocked channel layer. This deliberately avoids WebsocketCommunicator: a
+    sync consumer keeps a channel-layer receive listener bound to its event loop, and tearing
+    that down across the fresh per-test loops that async_to_sync creates hangs. The group_add /
+    group_discard / accept / send_json side effects are mocked, so each behaviour is asserted
+    deterministically.
+    """
+    consumer = ChatConsumer()
+    consumer.scope = {"user": user, "query_string": b"", "url_route": {"kwargs": {}}}
+    consumer.channel_name = CHANNEL_NAME
+    consumer.channel_layer = MagicMock()
+    consumer.channel_layer.group_add = AsyncMock()
+    consumer.channel_layer.group_discard = AsyncMock()
+    consumer.accept = MagicMock()
+    consumer.send_json = MagicMock()
+    return consumer
+
+
+class ChatConsumerTestCase(TestCase):
+    """ChatConsumer auth-scoped group join, session resolution, and task enqueue."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chat_ws_user")
+
+    def test_connect_joins_only_its_per_user_group(self):
+        consumer = _make_consumer(self.user)
+        consumer.connect()
+
+        consumer.accept.assert_called_once()
+        expected_group = events.chat_group_for_user(self.user.id)
+        # the group is keyed on the authenticated user id, so a client only gets its own stream
+        self.assertEqual(consumer.group_name, expected_group)
+        consumer.channel_layer.group_add.assert_called_once_with(expected_group, CHANNEL_NAME)
+
+    def test_disconnect_leaves_the_group(self):
+        consumer = _make_consumer(self.user)
+        consumer.connect()
+        consumer.disconnect(1000)
+
+        consumer.channel_layer.group_discard.assert_called_once_with(
+            events.chat_group_for_user(self.user.id), CHANNEL_NAME
+        )
+
+    @patch("api_app.chatbot_manager.consumers.process_chat_message")
+    def test_message_creates_session_acks_and_enqueues(self, mock_task):
+        consumer = _make_consumer(self.user)
+        consumer.receive_json({"message": "hello"})
+
+        session = ChatSession.objects.get(user=self.user)
+        consumer.send_json.assert_called_once_with(events.ack_payload(session.id))
+        mock_task.delay.assert_called_once_with(session.id, "hello", self.user.id)
+
+    @patch("api_app.chatbot_manager.consumers.process_chat_message")
+    def test_existing_owned_session_is_reused(self, mock_task):
+        session = ChatSession.objects.create(user=self.user)
+        consumer = _make_consumer(self.user)
+        consumer.receive_json({"message": "again", "session_id": session.id})
+
+        # no new session is created when a valid owned id is supplied
+        self.assertEqual(ChatSession.objects.filter(user=self.user).count(), 1)
+        consumer.send_json.assert_called_once_with(events.ack_payload(session.id))
+        mock_task.delay.assert_called_once_with(session.id, "again", self.user.id)
+
+    @patch("api_app.chatbot_manager.consumers.process_chat_message")
+    def test_oversized_message_is_rejected(self, mock_task):
+        consumer = _make_consumer(self.user)
+        consumer.receive_json({"message": "x" * (events.MAX_INBOUND_MESSAGE_LEN + 1)})
+
+        consumer.send_json.assert_called_once_with(events.error_payload(None, events.DETAIL_INVALID_MESSAGE))
+        mock_task.delay.assert_not_called()
+        # an invalid frame must not create a session
+        self.assertFalse(ChatSession.objects.filter(user=self.user).exists())
+
+    @patch("api_app.chatbot_manager.consumers.process_chat_message")
+    def test_message_for_another_users_session_is_rejected(self, mock_task):
+        other, _ = User.objects.get_or_create(username="other_ws_user")
+        foreign_session = ChatSession.objects.create(user=other)
+
+        consumer = _make_consumer(self.user)
+        consumer.receive_json({"message": "hi", "session_id": foreign_session.id})
+
+        consumer.send_json.assert_called_once_with(
+            events.error_payload(foreign_session.id, events.DETAIL_SESSION_NOT_FOUND)
+        )
+        mock_task.delay.assert_not_called()
+
+
+class ChatConsumerRelayTestCase(SimpleTestCase):
+    """Each group handler relays the producer's prebuilt payload verbatim to the client."""
+
+    def test_handlers_forward_event_payload(self):
+        payload = events.token_payload(3, "hi")
+        for handler_name in ("chat_start", "chat_status", "chat_token", "chat_end", "chat_error"):
+            consumer = ChatConsumer()
+            consumer.send_json = MagicMock()
+            getattr(consumer, handler_name)({"payload": payload})
+            consumer.send_json.assert_called_once_with(payload)
+
+
+class WSAuthMiddlewareTestCase(SimpleTestCase):
+    """Anonymous users are closed out before the consumer is ever reached."""
+
+    def test_anonymous_connection_is_closed_and_app_not_called(self):
+        inner_app = AsyncMock()
+        middleware = WSAuthMiddleware(inner_app)
+        sent = []
+
+        async def send(message):
+            sent.append(message)
+
+        scope = {"type": "websocket", "user": AnonymousUser()}
+        async_to_sync(middleware)(scope, AsyncMock(), send)
+
+        inner_app.assert_not_called()
+        self.assertEqual(sent, [{"type": "websocket.close", "code": 1008}])

--- a/tests/api_app/chatbot_manager/test_consumers.py
+++ b/tests/api_app/chatbot_manager/test_consumers.py
@@ -68,7 +68,7 @@ class ChatConsumerTestCase(TestCase):
         consumer.receive_json({"message": "hello"})
 
         session = ChatSession.objects.get(user=self.user)
-        consumer.send_json.assert_called_once_with(events.ack_payload(session.id))
+        consumer.send_json.assert_called_once_with(events.AckEvent(session.id).to_client())
         mock_task.delay.assert_called_once_with(session.id, "hello", self.user.id)
 
     @patch("api_app.chatbot_manager.consumers.process_chat_message")
@@ -79,7 +79,7 @@ class ChatConsumerTestCase(TestCase):
 
         # no new session is created when a valid owned id is supplied
         self.assertEqual(ChatSession.objects.filter(user=self.user).count(), 1)
-        consumer.send_json.assert_called_once_with(events.ack_payload(session.id))
+        consumer.send_json.assert_called_once_with(events.AckEvent(session.id).to_client())
         mock_task.delay.assert_called_once_with(session.id, "again", self.user.id)
 
     @patch("api_app.chatbot_manager.consumers.process_chat_message")
@@ -87,7 +87,9 @@ class ChatConsumerTestCase(TestCase):
         consumer = _make_consumer(self.user)
         consumer.receive_json({"message": "x" * (events.MAX_INBOUND_MESSAGE_LEN + 1)})
 
-        consumer.send_json.assert_called_once_with(events.error_payload(None, events.DETAIL_INVALID_MESSAGE))
+        consumer.send_json.assert_called_once_with(
+            events.ErrorEvent(None, events.ChatErrorDetail.INVALID_MESSAGE.value).to_client()
+        )
         mock_task.delay.assert_not_called()
         # an invalid frame must not create a session
         self.assertFalse(ChatSession.objects.filter(user=self.user).exists())
@@ -101,7 +103,7 @@ class ChatConsumerTestCase(TestCase):
         consumer.receive_json({"message": "hi", "session_id": foreign_session.id})
 
         consumer.send_json.assert_called_once_with(
-            events.error_payload(foreign_session.id, events.DETAIL_SESSION_NOT_FOUND)
+            events.ErrorEvent(foreign_session.id, events.ChatErrorDetail.SESSION_NOT_FOUND.value).to_client()
         )
         mock_task.delay.assert_not_called()
 
@@ -110,7 +112,7 @@ class ChatConsumerRelayTestCase(SimpleTestCase):
     """Each group handler relays the producer's prebuilt payload verbatim to the client."""
 
     def test_handlers_forward_event_payload(self):
-        payload = events.token_payload(3, "hi")
+        payload = events.TokenEvent(3, "hi").to_client()
         for handler_name in ("chat_start", "chat_status", "chat_token", "chat_end", "chat_error"):
             consumer = ChatConsumer()
             consumer.send_json = MagicMock()

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -1,0 +1,118 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import AsyncMock, MagicMock
+
+from django.test import SimpleTestCase
+
+from api_app.chatbot_manager import events
+from api_app.chatbot_manager.agent.streaming import ChatStreamingCallbackHandler
+
+USER_ID = 7
+SESSION_ID = 3
+
+
+class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
+    """The callback streams only the final answer and a status per tool action."""
+
+    def _make_handler(self):
+        handler = ChatStreamingCallbackHandler(user_id=USER_ID, session_id=SESSION_ID)
+        layer = MagicMock()
+        layer.group_send = AsyncMock()
+        handler._channel_layer = layer
+        return handler, layer
+
+    @staticmethod
+    def _messages(layer):
+        # each group_send call is (group, channel_message)
+        return [call.args for call in layer.group_send.call_args_list]
+
+    def test_streams_only_after_final_answer_marker(self):
+        handler, layer = self._make_handler()
+        handler.on_llm_start()
+        for token in [
+            "Thought",
+            ":",
+            " I",
+            " now",
+            " know",
+            "\n",
+            "Final",
+            " Answer",
+            ":",
+            " Hello",
+            " world",
+        ]:
+            handler.on_llm_new_token(token)
+
+        messages = self._messages(layer)
+        self.assertEqual([m[0] for m in messages], [events.chat_group_for_user(USER_ID)] * 2)
+        self.assertEqual([m[1]["type"] for m in messages], [events.EVENT_TOKEN, events.EVENT_TOKEN])
+        self.assertEqual([m[1]["payload"]["content"] for m in messages], [" Hello", " world"])
+        self.assertEqual(messages[0][1]["payload"]["session_id"], SESSION_ID)
+
+    def test_marker_split_across_tokens_is_still_detected(self):
+        # Ollama/Mistral may tokenize "Final Answer:" arbitrarily; the buffer substring match
+        # must not depend on a particular token boundary.
+        handler, layer = self._make_handler()
+        handler.on_llm_start()
+        for token in ["Fin", "al Ans", "wer:", "Hi"]:
+            handler.on_llm_new_token(token)
+
+        contents = [m[1]["payload"]["content"] for m in self._messages(layer)]
+        self.assertEqual(contents, ["Hi"])
+
+    def test_tokens_before_marker_are_never_streamed(self):
+        handler, layer = self._make_handler()
+        handler.on_llm_start()
+        for token in ["Thought", ":", " just", " reasoning"]:
+            handler.on_llm_new_token(token)
+
+        layer.group_send.assert_not_called()
+
+    def test_on_llm_start_rearms_gate_between_iterations(self):
+        handler, layer = self._make_handler()
+        handler.on_llm_start()
+        for token in ["Final", " Answer", ":", " done"]:
+            handler.on_llm_new_token(token)
+        layer.group_send.reset_mock()
+
+        # A fresh LLM call (next ReAct iteration) must not stream until its own marker.
+        handler.on_llm_start()
+        for token in ["Thought", ":", " hmm"]:
+            handler.on_llm_new_token(token)
+
+        layer.group_send.assert_not_called()
+
+    def test_agent_action_emits_status_event_with_tool_name(self):
+        handler, layer = self._make_handler()
+        action = MagicMock()
+        action.tool = "search_jobs"
+
+        handler.on_agent_action(action)
+
+        (group, message) = self._messages(layer)[0]
+        self.assertEqual(group, events.chat_group_for_user(USER_ID))
+        self.assertEqual(message["type"], events.EVENT_STATUS)
+        self.assertEqual(message["payload"]["tool"], "search_jobs")
+        self.assertEqual(message["payload"]["session_id"], SESSION_ID)
+
+    def test_agent_action_for_unregistered_tool_is_suppressed(self):
+        # With a real tool registry, LangChain's "_Exception" parse-error pseudo-tool (and any
+        # raw malformed model output as a "tool") must not leak to the client as chat.status.
+        handler = ChatStreamingCallbackHandler(
+            user_id=USER_ID, session_id=SESSION_ID, tool_names={"search_jobs"}
+        )
+        layer = MagicMock()
+        layer.group_send = AsyncMock()
+        handler._channel_layer = layer
+
+        exception_action = MagicMock()
+        exception_action.tool = "_Exception"
+        handler.on_agent_action(exception_action)
+        layer.group_send.assert_not_called()
+
+        real_action = MagicMock()
+        real_action.tool = "search_jobs"
+        handler.on_agent_action(real_action)
+        layer.group_send.assert_called_once()

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -45,11 +45,14 @@ class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
         ]:
             handler.on_llm_new_token(token)
 
-        messages = self._messages(layer)
-        self.assertEqual([m[0] for m in messages], [events.chat_group_for_user(USER_ID)] * 2)
-        self.assertEqual([m[1]["type"] for m in messages], [events.EVENT_TOKEN, events.EVENT_TOKEN])
-        self.assertEqual([m[1]["payload"]["content"] for m in messages], [" Hello", " world"])
-        self.assertEqual(messages[0][1]["payload"]["session_id"], SESSION_ID)
+        group = events.chat_group_for_user(USER_ID)
+        self.assertEqual(
+            self._messages(layer),
+            [
+                (group, events.TokenEvent(SESSION_ID, " Hello").as_channel_message()),
+                (group, events.TokenEvent(SESSION_ID, " world").as_channel_message()),
+            ],
+        )
 
     def test_marker_split_across_tokens_is_still_detected(self):
         # Ollama/Mistral may tokenize "Final Answer:" arbitrarily; the buffer substring match
@@ -91,11 +94,13 @@ class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
 
         handler.on_agent_action(action)
 
-        (group, message) = self._messages(layer)[0]
-        self.assertEqual(group, events.chat_group_for_user(USER_ID))
-        self.assertEqual(message["type"], events.EVENT_STATUS)
-        self.assertEqual(message["payload"]["tool"], "search_jobs")
-        self.assertEqual(message["payload"]["session_id"], SESSION_ID)
+        self.assertEqual(
+            self._messages(layer)[0],
+            (
+                events.chat_group_for_user(USER_ID),
+                events.StatusEvent(SESSION_ID, "search_jobs").as_channel_message(),
+            ),
+        )
 
     def test_agent_action_for_unregistered_tool_is_suppressed(self):
         # With a real tool registry, LangChain's "_Exception" parse-error pseudo-tool (and any

--- a/tests/api_app/chatbot_manager/test_tasks.py
+++ b/tests/api_app/chatbot_manager/test_tasks.py
@@ -2,13 +2,17 @@
 # See the file 'LICENSE' for copying permission.
 
 import datetime
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import TestCase, override_settings
 from django.utils.timezone import now
 
+from api_app.chatbot_manager import events
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
-from api_app.chatbot_manager.tasks import delete_old_chat_sessions
+from api_app.chatbot_manager.tasks import delete_old_chat_sessions, process_chat_message
 from certego_saas.apps.user.models import User
+
+INMEMORY_CHANNEL_LAYER = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
 
 
 @override_settings(CHATBOT_MESSAGE_RETENTION_DAYS=30)
@@ -74,3 +78,88 @@ class DeleteOldChatSessionsTestCase(TestCase):
 
         self.assertEqual(delete_old_chat_sessions(), 0)
         self.assertTrue(ChatSession.objects.filter(pk=session.pk).exists())
+
+
+@override_settings(CHANNEL_LAYERS=INMEMORY_CHANNEL_LAYER)
+class ProcessChatMessageTestCase(TestCase):
+    """The Celery turn persists the exchange, streams start/end, and fails closed.
+
+    The agent executor is mocked, so the LLM/Ollama is never touched; the token/status events
+    come from the agent's own callbacks (covered in test_streaming) and are not exercised here.
+    """
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_task_user")
+        self.session = ChatSession.objects.create(user=self.user)
+
+    @staticmethod
+    def _patched_layer(mock_get_layer):
+        layer = MagicMock()
+        layer.group_send = AsyncMock()
+        mock_get_layer.return_value = layer
+        return layer
+
+    @staticmethod
+    def _event_types(layer):
+        return [call.args[1]["type"] for call in layer.group_send.call_args_list]
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    def test_persists_turn_and_streams_start_end(self, mock_build, mock_get_layer):
+        layer = self._patched_layer(mock_get_layer)
+        executor = MagicMock()
+        executor.invoke.return_value = {"output": "Hi there"}
+        mock_build.return_value = executor
+
+        process_chat_message(self.session.id, "hello", self.user.id)
+
+        messages = list(
+            ChatMessage.objects.filter(session=self.session)
+            .order_by("timestamp")
+            .values_list("role", "content")
+        )
+        self.assertEqual(
+            messages,
+            [(ChatMessage.Role.USER, "hello"), (ChatMessage.Role.ASSISTANT, "Hi there")],
+        )
+        self.assertEqual(self._event_types(layer), [events.EVENT_START, events.EVENT_END])
+
+        end_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
+        assistant = ChatMessage.objects.get(session=self.session, role=ChatMessage.Role.ASSISTANT)
+        self.assertEqual(end_payload["message_id"], assistant.id)
+        self.assertEqual(end_payload["content"], "Hi there")
+
+        # streaming requested on the model + callbacks attached at run level (not on the LLM)
+        self.assertTrue(mock_build.call_args.kwargs["streaming"])
+        self.assertIn("callbacks", executor.invoke.call_args.kwargs["config"])
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    def test_agent_failure_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
+        layer = self._patched_layer(mock_get_layer)
+        executor = MagicMock()
+        executor.invoke.side_effect = ConnectionError("ollama down")
+        mock_build.return_value = executor
+
+        process_chat_message(self.session.id, "hello", self.user.id)
+
+        # failed turn is dropped: neither the user nor the assistant message is stored
+        self.assertFalse(ChatMessage.objects.filter(session=self.session).exists())
+        self.assertEqual(self._event_types(layer), [events.EVENT_START, events.EVENT_ERROR])
+        error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
+        self.assertEqual(error_payload["detail"], events.DETAIL_UNAVAILABLE)
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    def test_session_not_owned_by_user_is_rejected(self, mock_build, mock_get_layer):
+        layer = self._patched_layer(mock_get_layer)
+        other = User.objects.create(username="chatbot_task_other")
+        foreign_session = ChatSession.objects.create(user=other)
+
+        process_chat_message(foreign_session.id, "hello", self.user.id)
+
+        mock_build.assert_not_called()
+        self.assertFalse(ChatMessage.objects.filter(session=foreign_session).exists())
+        self.assertEqual(self._event_types(layer), [events.EVENT_ERROR])
+        error_payload = layer.group_send.call_args_list[0].args[1]["payload"]
+        self.assertEqual(error_payload["detail"], events.DETAIL_SESSION_NOT_FOUND)

--- a/tests/api_app/chatbot_manager/test_tasks.py
+++ b/tests/api_app/chatbot_manager/test_tasks.py
@@ -101,7 +101,8 @@ class ProcessChatMessageTestCase(TestCase):
 
     @staticmethod
     def _event_types(layer):
-        return [call.args[1]["type"] for call in layer.group_send.call_args_list]
+        # client-facing payload type of each group_send (start/status/token/end/error)
+        return [call.args[1]["payload"]["type"] for call in layer.group_send.call_args_list]
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
     @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
@@ -122,7 +123,10 @@ class ProcessChatMessageTestCase(TestCase):
             messages,
             [(ChatMessage.Role.USER, "hello"), (ChatMessage.Role.ASSISTANT, "Hi there")],
         )
-        self.assertEqual(self._event_types(layer), [events.EVENT_START, events.EVENT_END])
+        self.assertEqual(
+            self._event_types(layer),
+            [events.ChatEventType.START.value, events.ChatEventType.END.value],
+        )
 
         end_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
         assistant = ChatMessage.objects.get(session=self.session, role=ChatMessage.Role.ASSISTANT)
@@ -145,9 +149,12 @@ class ProcessChatMessageTestCase(TestCase):
 
         # failed turn is dropped: neither the user nor the assistant message is stored
         self.assertFalse(ChatMessage.objects.filter(session=self.session).exists())
-        self.assertEqual(self._event_types(layer), [events.EVENT_START, events.EVENT_ERROR])
+        self.assertEqual(
+            self._event_types(layer),
+            [events.ChatEventType.START.value, events.ChatEventType.ERROR.value],
+        )
         error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
-        self.assertEqual(error_payload["detail"], events.DETAIL_UNAVAILABLE)
+        self.assertEqual(error_payload["detail"], events.ChatErrorDetail.UNAVAILABLE.value)
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
     @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
@@ -160,6 +167,6 @@ class ProcessChatMessageTestCase(TestCase):
 
         mock_build.assert_not_called()
         self.assertFalse(ChatMessage.objects.filter(session=foreign_session).exists())
-        self.assertEqual(self._event_types(layer), [events.EVENT_ERROR])
+        self.assertEqual(self._event_types(layer), [events.ChatEventType.ERROR.value])
         error_payload = layer.group_send.call_args_list[0].args[1]["payload"]
-        self.assertEqual(error_payload["detail"], events.DETAIL_SESSION_NOT_FOUND)
+        self.assertEqual(error_payload["detail"], events.ChatErrorDetail.SESSION_NOT_FOUND.value)


### PR DESCRIPTION
Refs #3756. _(Targets the `gsoc-2026/llm-chatbot` umbrella, not `develop`. Using `Refs` (not `Closes`) on purpose — the umbrella isn't `develop`, so the issue is closed manually after merge. Branches off the refreshed umbrella.)_

# Description

Adds the **real-time path** of the chatbot (W6): a Django Channels `ChatConsumer` and an implementation of
the `process_chat_message` Celery task (previously a `NotImplementedError` stub) so a chat turn runs
off-request on a dedicated queue and **streams the answer token-by-token** to the browser over a WebSocket.
The synchronous REST turn (`POST /api/chatbot/sessions/message`, W2) stays as the non-streaming fallback,
unchanged.

```
Browser ──ws/chat/?context_url=…──▶ ChatConsumer.connect()  (joins group chat-<user_id>)
Browser ──{message, session_id?}──▶ ChatConsumer.receive_json()  → ack + process_chat_message.delay(...)
[chatbot worker] agent run  → chat.start → chat.status* / chat.token* → chat.end   (group_send)
                            → chat.error on failure (turn dropped, nothing persisted)
chat.*  ──▶ ChatConsumer.chat_*()  ──▶ send_json  ──▶ Browser
```

- **`ChatConsumer(JsonWebsocketConsumer)`** mirrors `JobConsumer` (sync consumer, `async_to_sync` group
  add/discard, handler methods named from the event `type`). It is **bidirectional** — the inbound frame,
  treated as untrusted, is validated by the existing `MessageRequestSerializer`, the supplied `session_id`
  is resolved scoped to the authenticated user (or a new session is created), the client is acked, and the
  Celery turn is enqueued. The group is **per-user** (`chat-<user_id>`) keyed on `scope["user"].id`: the
  fixed URL `ws/chat/?context_url=…` carries no session id, every event carries `session_id` so a client
  with several sessions/tabs demultiplexes, and a client can only ever receive its own stream. Auth is
  enforced upstream by `WSAuthMiddleware` (anonymous rejected with 1008).

- **Token streaming.** `process_chat_message` runs the ReAct `AgentExecutor` synchronously in the worker
  and attaches a callback **at run level** (`invoke(config={"callbacks": [handler]})`) — not on the LLM —
  so it sees both the LLM token stream and the agent's tool actions. `ChatStreamingCallbackHandler` streams
  only what follows the `Final Answer:` marker (the ReAct Thought/Action scaffolding is hidden) plus a
  lightweight `chat.status` per tool, pushing each via `group_send`. The worker is sync (no running loop),
  so `async_to_sync(channel_layer.group_send)` is the correct bridge — the same precedent as
  `JobConsumer.serialize_and_send_job`.

- **Persistence is the source of truth.** The streamed tokens are a live preview; the worker persists
  `result["output"]` and sends it in `chat.end` (with the assistant `message_id`), which the client treats
  as authoritative — so a tokenization miss can never corrupt the stored/displayed answer. History is
  snapshotted before the turn is written, mirroring the REST ordering. On any failure (Ollama unreachable,
  `SoftTimeLimitExceeded`, etc.) a single generic `chat.error` is emitted and the turn is dropped (nothing
  persisted), matching the sync path.

- **Dedicated chatbot worker (required, not optional).** The `chatbot` queue was declared but **no worker
  consumed it** (the four `celery_*.sh` entrypoints run `-Q …,broadcast,config`, never `chatbot`), so the
  enqueued task would hang silently. This PR adds a `celery_worker_chatbot` service + `celery_chatbot.sh`
  entrypoint (`-Q chatbot,broadcast,config`, `-c 2`, `--time-limit=600`) living in `ollama.override.yml`,
  so the same `--ollama` flag that starts the LLM also starts the worker that uses it; no chatbot worker is
  forced on deployments that don't use the LLM. A `task_routes` entry pins `process_chat_message` to the
  queue regardless of call site. _(Open to folding `chatbot` into the default worker's `-Q` instead if you
  prefer not to add a container — flagging the deployment choice.)_

## Framework-specific notes

- **Run-level callbacks, not on the model.** `on_agent_action` (the tool-status events) fires from the
  executor, not the LLM; binding the handler only to `ChatOllama` would stream tokens but lose the status
  events. `ChatOllama(streaming=True)` is set; callbacks are passed per run.
- **`Final Answer:` is matched as a substring** in an accumulating buffer (re-armed per LLM call), not a
  fixed token tuple — a local model's tokenization of `"Final Answer:"` is not guaranteed.

## Tests

- `test_streaming.py` — the marker heuristic: streams only after `Final Answer:`, marker split across tokens
  still detected, pre-marker tokens never streamed, gate re-arms per iteration, tool-status event.
- `test_consumers.py` — group join keyed on the authenticated user, group leave on disconnect, message
  creates/acks/enqueues, owned session reused, oversized frame rejected, **another user's session rejected**,
  handlers relay the payload, anonymous closed by `WSAuthMiddleware`. Driven by direct calls to the
  consumer's sync methods with a mocked channel layer — `WebsocketCommunicator` hangs here because a sync
  consumer's channel-receive listener is bound to the event loop and the per-test `async_to_sync` loops tear
  it down across loops.
- `test_tasks.py` — persists the exchange and emits `chat.start`/`chat.end` with the assistant id; an agent
  failure emits `chat.error` and drops the turn; a session not owned by the user is rejected before the agent
  is built. Ollama/channel layer fully mocked.

No new dependencies, no model/migration changes.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [ ] The pull request is for the branch `develop` _(targets the `gsoc-2026/llm-chatbot` umbrella)_
- [x] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible _(no new dependencies added)_
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section _(N/A — no new libraries added)_
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the feature I solved (see `tests` folder); all tests (new and old) gave 0 errors _(74 chatbot tests run locally against a rebuilt test image — the "Build & Tests" CI workflow does not run on umbrella-targeting PRs)_
- [x] After submitting the PR, if `DeepSource`, `Django Doctors` or other third-party linters triggered alerts during CI, I have solved those alerts
- [x] I have addressed raised Copilot issues
- [x] I have reviewed and verified any LLM-generated code included in this PR. **I used an LLM coding assistant while developing this PR, and reviewed all of its output.**
