### PR TITLE
[GSoC 2026] Switch the chatbot agent to native tool calling (refs #3761)

### DIFF
--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -2,9 +2,8 @@
 # See the file 'LICENSE' for copying permission.
 
 from django.conf import settings
-from langchain.agents import AgentExecutor, create_react_agent
-from langchain_core.messages import AIMessage, HumanMessage
-from langchain_core.prompts import PromptTemplate
+from langchain.agents import AgentExecutor, create_tool_calling_agent
+from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
 from langchain_ollama import ChatOllama
 
 from .tools import build_tools
@@ -13,43 +12,60 @@ _SYSTEM_PROMPT = """\
 You are IntelOwl AI, an intelligent assistant for the IntelOwl threat intelligence platform.
 You help security analysts query and interpret threat intelligence data.
 Only access data belonging to the current user. Never reveal other users' data.
-The analyze_observable tool starts a real analysis: always call it first with confirm=false, show the returned plan to the user, and only call it again with confirm=true after the user explicitly approves.
+Ground every answer in tool results: call the relevant tool instead of guessing, and say so \
+when a tool returns no data.
+The analyze_observable tool starts a real analysis: always call it first with confirm=false, \
+show the returned plan to the user, and only call it again with confirm=true after the user \
+explicitly approves."""
 
-You have access to the following tools:
+# The agent uses Ollama's native tool-calling API (`llm.bind_tools`, wired by
+# `create_tool_calling_agent`), so the prompt carries no rendered tool list and no ReAct
+# Thought/Action/Final Answer text scaffolding: the model emits structured tool calls and the
+# executor loops tool call -> observation under the hood. `chat_history` and `agent_scratchpad`
+# are message lists (MessagesPlaceholder), not pre-rendered text.
+PROMPT = ChatPromptTemplate.from_messages(
+    [
+        ("system", _SYSTEM_PROMPT),
+        MessagesPlaceholder("chat_history"),
+        ("human", "{input}"),
+        MessagesPlaceholder("agent_scratchpad"),
+    ]
+)
 
-{tools}
+# One iteration = one round of tool calls + observation. Real questions resolve in 1-3 rounds
+# (analyze_observable's confirm flow spans two turns, not two iterations), so 6 leaves room for
+# a retry after a failed call while force-stopping a looping model well before the Celery task's
+# 300s soft time limit would on CPU.
+_MAX_AGENT_ITERATIONS = 6
 
-Use the following format:
+# What AgentExecutor returns as "output" when max_iterations force-stops the run (the
+# multi-action agent's return_stopped_response, langchain 0.3.25). Callers compare against this
+# to turn a forced stop into a user-facing error instead of persisting the canned framework
+# string as an assistant message.
+AGENT_STOPPED_OUTPUT = "Agent stopped due to max iterations."
 
-Question: the input question you must answer
-Thought: you should always think about what to do
-Action: the action to take, should be one of [{tool_names}]
-Action Input: the input to the action
-Observation: the result of the action
-... (this Thought/Action/Action Input/Observation can repeat N times)
-Thought: I now know the final answer
-Final Answer: the final answer to the original input question
-
-Previous conversation:
-{chat_history}
-
-Question: {input}
-{agent_scratchpad}"""
-
-# The prompt drives the ReAct loop. `create_react_agent` fills in the placeholders:
-# `{tools}`/`{tool_names}` are rendered from the tool list, and `{agent_scratchpad}` is
-# where the model's own Thought/Action/Observation steps are accumulated across iterations.
-REACT_PROMPT = PromptTemplate.from_template(_SYSTEM_PROMPT)
+# The rendered prompt (system prompt + the 10 bound tool schemas) is already ~2.2k tokens
+# before any history: Ollama's default 2048-token context window silently truncates it from
+# the start (observed live: "truncating input prompt" limit=2048 prompt=2174), dropping the
+# system prompt and most tool schemas and wrecking tool selection. 8192 fits prompt + history
+# + tool observations comfortably and keeps the prompt prefix stable across iterations, so
+# follow-up rounds hit Ollama's KV prefix cache instead of re-evaluating everything.
+_NUM_CTX = 8192
 
 
 def build_agent_executor(user, streaming: bool = False) -> AgentExecutor:
-    """Build a ReAct agent executor scoped to `user`.
+    """Build a tool-calling agent executor scoped to `user`.
 
-    `ChatOllama` is the local LLM; `create_react_agent` wires the model + tools + prompt
-    into a reasoning loop (Thought → Action → Observation → ...); `AgentExecutor` runs
-    that loop until a Final Answer. `handle_parsing_errors=True` makes the executor feed
-    a malformed model output back as an Observation instead of raising, which keeps small
-    local models from crashing the turn on a formatting slip.
+    `ChatOllama` is the local LLM; `create_tool_calling_agent` binds the tools to the model
+    through the native tool-calling API — there is no text format to parse, which is what made
+    the previous string-ReAct loop unreliable on small local models (they rarely emit a
+    parseable `Final Answer:` line). `AgentExecutor` runs the tool-call -> observation loop
+    until the model replies with plain text. `handle_parsing_errors=True` feeds an unparseable
+    model output back as an observation instead of raising (it does NOT cover schema-invalid
+    tool *arguments*, which raise from the tool itself and surface through the caller's generic
+    error handling); `max_iterations` bounds a looping model (`early_stopping_method` stays at
+    its default "force" — runnable agents support no other value in langchain 0.3, "generate"
+    raises ValueError).
 
     `streaming=True` makes `ChatOllama` emit token-level callbacks so the WebSocket path can
     stream the answer live. No callbacks are bound to the model here: the caller attaches them
@@ -60,24 +76,15 @@ def build_agent_executor(user, streaming: bool = False) -> AgentExecutor:
         model=settings.OLLAMA_MODEL,
         base_url=settings.OLLAMA_BASE_URL,
         temperature=0,
+        num_ctx=_NUM_CTX,
         streaming=streaming,
     )
     tools = build_tools(user=user)
-    agent = create_react_agent(llm, tools, REACT_PROMPT)
+    agent = create_tool_calling_agent(llm, tools, PROMPT)
     return AgentExecutor(
         agent=agent,
         tools=tools,
         verbose=False,
         handle_parsing_errors=True,
+        max_iterations=_MAX_AGENT_ITERATIONS,
     )
-
-
-def format_history(messages: list) -> str:
-    """Serialize LangChain message list to plain text for prompt injection."""
-    lines = []
-    for msg in messages:
-        if isinstance(msg, HumanMessage):
-            lines.append(f"User: {msg.content}")
-        elif isinstance(msg, AIMessage):
-            lines.append(f"Assistant: {msg.content}")
-    return "\n".join(lines) if lines else ""

--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -10,36 +10,31 @@ no event loop, so ``async_to_sync`` is the right bridge to the async channel lay
 pattern ``JobConsumer.serialize_and_send_job`` already uses.
 """
 
-import logging
-
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from langchain_core.callbacks.base import BaseCallbackHandler
 
 from api_app.chatbot_manager.events import (
-    ANSWER_MARKER,
     ChatEvent,
     StatusEvent,
     TokenEvent,
     chat_group_for_user,
 )
 
-logger = logging.getLogger(__name__)
-
 
 class ChatStreamingCallbackHandler(BaseCallbackHandler):
-    """Streams the agent's *final answer* token-by-token, plus a status event per tool.
+    """Streams the answer text token-by-token, plus a status event per tool call.
 
-    A ReAct turn is several LLM calls (Thought/Action/Observation loops); only the last one
-    emits the ``Final Answer:`` line. Streaming every token would leak that scaffolding, so the
-    handler buffers tokens and starts forwarding only once ``ANSWER_MARKER`` appears in the
-    buffer. The marker is matched as a *substring* (not a fixed token tuple) because a local
-    model's tokenization of ``"Final Answer:"`` is not guaranteed. ``on_llm_start`` re-arms the
-    gate for each call so a non-final iteration never streams.
+    With a tool-calling agent there is no ``Final Answer:`` marker to gate on: when the model
+    decides to call a tool, the streamed chunks carry structured tool-call deltas whose *text*
+    is empty (the call itself rides ``tool_call_chunks``), and when it answers it streams plain
+    text. Forwarding only non-empty text therefore streams the answer while keeping tool-call
+    payloads off the wire.
 
-    This is a best-effort live view: the worker persists ``result["output"]`` and sends it in the
-    ``chat.end`` event, which the client treats as the source of truth, so a tokenization miss
-    can never corrupt the stored/displayed answer.
+    This is a best-effort live view: a model may emit a short text preamble before a tool call,
+    which streams and is then superseded by the actual answer. The worker persists
+    ``result["output"]`` and sends it in the ``chat.end`` event, which the client treats as the
+    source of truth, so the stored/displayed answer is always correct.
     """
 
     def __init__(self, user_id: int, session_id: int, tool_names: set[str] | None = None):
@@ -47,41 +42,22 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         self._session_id = session_id
         # Only these tool names produce a chat.status; None means "emit any" (unit tests).
         # Filtering by the real registry suppresses LangChain's internal "_Exception" pseudo-tool
-        # (and the raw parse-error text) that handle_parsing_errors surfaces as agent actions.
+        # (and the raw error text) that handle_parsing_errors surfaces as agent actions.
         self._tool_names = tool_names
         self._channel_layer = get_channel_layer()
-        self._buffer = ""
-        self._answer_reached = False
 
     def _emit(self, event: ChatEvent) -> None:
         async_to_sync(self._channel_layer.group_send)(self._group, event.as_channel_message())
 
-    def on_llm_start(self, *args, **kwargs) -> None:
-        # Each ReAct iteration is a fresh LLM call; re-arm so only the call that produces the
-        # Final Answer streams, and drop the previous iteration's buffered scaffolding.
-        self._buffer = ""
-        self._answer_reached = False
-
     def on_llm_new_token(self, token: str, **kwargs) -> None:
-        if self._answer_reached:
+        # Tool-call deltas surface here with empty text; only real answer text is forwarded.
+        if token:
             self._emit(TokenEvent(self._session_id, token))
-            return
-        self._buffer += token
-        marker_index = self._buffer.find(ANSWER_MARKER)
-        if marker_index == -1:
-            return
-        self._answer_reached = True
-        # Stream whatever already trails the marker in this same chunk; lstrip so the answer
-        # doesn't open with the space/newline that usually follows "Final Answer:".
-        tail = self._buffer[marker_index + len(ANSWER_MARKER) :].lstrip()
-        self._buffer = ""
-        if tail:
-            self._emit(TokenEvent(self._session_id, tail))
 
     def on_agent_action(self, action, **kwargs) -> None:
-        # Fired when the ReAct agent picks a tool; action.tool is the clean tool name. Skip
-        # anything that isn't a registered tool (e.g. the "_Exception" parse-error pseudo-tool,
-        # whose "tool" is the raw malformed model output) so internals don't leak as chat.status.
+        # Fired when the agent picks a tool; action.tool is the clean tool name. Skip anything
+        # that isn't a registered tool (e.g. the "_Exception" parse-error pseudo-tool, whose
+        # "tool" is the raw malformed model output) so internals don't leak as chat.status.
         tool_name = getattr(action, "tool", "") or ""
         if not tool_name or (self._tool_names is not None and tool_name not in self._tool_names):
             return

--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -25,7 +25,8 @@ def build_tools(user) -> list:
     analyzers and exposes per-user readiness through a `runnable` flag instead. The single
     action tool `analyze_observable` can launch a real analysis; it is confirm-gated (a preview
     unless `confirm=True`) and creates jobs owned by `user`. Every tool returns a string
-    (LangChain feeds it back as the ReAct "Observation"); see each tool for its shape.
+    (LangChain feeds it back to the model as the tool-call observation); see each tool
+    for its shape.
     """
     return [
         make_search_jobs_tool(user),

--- a/api_app/chatbot_manager/agent/tools/analyze_observable.py
+++ b/api_app/chatbot_manager/agent/tools/analyze_observable.py
@@ -101,8 +101,9 @@ def make_analyze_observable_tool(user):
                 ).to_json()
             data["playbook_requested"] = playbook
 
-        # The agent is the string-based ReAct agent (one `Action Input` string), so `analyzers` is a
-        # comma-separated string split here rather than a JSON list (unreliable for a small model).
+        # `analyzers` stays a comma-separated string rather than a list[str]: a flat string is
+        # the simplest schema for a small local model to emit reliably, and splitting here keeps
+        # the tool signature stable regardless of how the agent encodes its arguments.
         analyzers_list = [a.strip() for a in analyzers.split(",") if a.strip()]
         if analyzers_list:
             data["analyzers_requested"] = analyzers_list

--- a/api_app/chatbot_manager/agent/tools/get_data_model.py
+++ b/api_app/chatbot_manager/agent/tools/get_data_model.py
@@ -10,8 +10,8 @@ from api_app.models import Job
 def make_get_data_model_tool(user):
     # Built per-request and closed over `user`, so the lookup is hard-scoped to that user's
     # jobs (multi-tenancy enforced here), matching the other job tools' `user=user` scope.
-    # LangChain feeds a tool's return value back as the ReAct "Observation", so it must be a
-    # string: we return a JSON-serialized envelope.
+    # LangChain feeds a tool's return value back as the tool-call observation, so it must be
+    # a string: we return a JSON-serialized envelope.
     @tool("get_data_model")
     def get_data_model(job_id: int) -> str:
         """Get the aggregated data model of an IntelOwl job by its numeric ID.

--- a/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
+++ b/api_app/chatbot_manager/agent/tools/get_investigation_tree.py
@@ -90,8 +90,8 @@ def _build_tree(investigation) -> _InvestigationTree:
 def make_get_investigation_tree_tool(user):
     # Built per-request and closed over `user`. The lookup is scoped with
     # `visible_for_user` (owned + organization-shared investigations), so the LLM cannot
-    # reach an investigation the user can't see. Returns a string for the ReAct
-    # "Observation": a JSON-serialized envelope.
+    # reach an investigation the user can't see. Returns a string (the tool-call
+    # observation): a JSON-serialized envelope.
     @tool("get_investigation_tree")
     def get_investigation_tree(investigation_id: int) -> str:
         """Get the job tree of an IntelOwl investigation by its numeric ID.

--- a/api_app/chatbot_manager/agent/tools/get_job_details.py
+++ b/api_app/chatbot_manager/agent/tools/get_job_details.py
@@ -7,7 +7,7 @@ from langchain_core.tools import tool
 def make_get_job_details_tool(user):
     # Built per-request and closed over `user`, so the lookup is hard-scoped to that
     # user's jobs (multi-tenancy enforced here). LangChain requires a tool to return a
-    # string for the ReAct "Observation" step, so we return a JSON-serialized envelope.
+    # string (the tool-call observation), so we return a JSON-serialized envelope.
     @tool("get_job_details")
     def get_job_details(job_id: int) -> str:
         """Get full details of an IntelOwl job by its numeric ID.

--- a/api_app/chatbot_manager/agent/tools/list_investigations.py
+++ b/api_app/chatbot_manager/agent/tools/list_investigations.py
@@ -18,7 +18,7 @@ def make_list_investigations_tool(user):
     # with their organization (`for_organization=True`). This is wider than the job tools'
     # `user=user` scope on purpose -- investigations have an explicit org-sharing flag --
     # and the LLM can never widen it. LangChain feeds a tool's return value back as the
-    # ReAct "Observation", so it must be a string: we return a JSON-serialized envelope.
+    # tool-call observation, so it must be a string: we return a JSON-serialized envelope.
     @tool("list_investigations")
     def list_investigations(query: str = "", status: str = "", limit: int = 10) -> str:
         """List IntelOwl investigations visible to you (owned or shared with your org).

--- a/api_app/chatbot_manager/agent/tools/search_jobs.py
+++ b/api_app/chatbot_manager/agent/tools/search_jobs.py
@@ -8,8 +8,8 @@ from langchain_core.tools import tool
 def make_search_jobs_tool(user):
     # The tool is built per-request and closes over `user`: every query is hard-scoped
     # to that user's jobs, so multi-tenancy is enforced here and the LLM can never widen
-    # it. LangChain feeds a tool's return value back to the model as the ReAct
-    # "Observation" step, so it must be a string; we return a JSON-serialized envelope.
+    # it. LangChain feeds a tool's return value back to the model as the tool-call
+    # observation, so it must be a string; we return a JSON-serialized envelope.
     @tool("search_jobs")
     def search_jobs(query: str = "", status: str = "", limit: int = 10) -> str:
         """Search IntelOwl jobs by observable name, MD5, or status.

--- a/api_app/chatbot_manager/events.py
+++ b/api_app/chatbot_manager/events.py
@@ -23,10 +23,6 @@ from typing import ClassVar, Optional
 
 CHAT_GROUP_PREFIX = "chat-"
 
-# The ReAct prompt ends every turn with a "Final Answer:" line (see REACT_PROMPT). The streaming
-# callback streams only what follows this marker, hiding the Thought/Action scaffolding.
-ANSWER_MARKER = "Final Answer:"
-
 # Inbound guardrail: mirrors MessageRequestSerializer(message=CharField(max_length=4096)).
 MAX_INBOUND_MESSAGE_LEN = 4096
 
@@ -49,6 +45,7 @@ class ChatErrorDetail(StrEnum):
     INVALID_MESSAGE = "Invalid message payload."
     TIMEOUT = "The assistant took too long to respond. Please try again."
     UNAVAILABLE = "The assistant is currently unavailable. Please try again."
+    ITERATION_LIMIT = "The assistant could not complete this request. Please try rephrasing."
 
 
 def chat_group_for_user(user_id: int) -> str:

--- a/api_app/chatbot_manager/serializers/base.py
+++ b/api_app/chatbot_manager/serializers/base.py
@@ -9,8 +9,8 @@ from rest_framework import serializers
 class ToolResultSerializer(serializers.Serializer):
     """Base envelope for agent-tool output: an always-present `errors` list plus a payload.
 
-    A LangChain tool must return a string (it is fed back to the model as the ReAct
-    Observation), so `to_json()` renders the serialized envelope to a JSON string.
+    A LangChain tool must return a string (it is fed back to the model as the tool-call
+    observation), so `to_json()` renders the serialized envelope to a JSON string.
     """
 
     errors = serializers.ListField(child=serializers.CharField(), default=list)

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -26,8 +26,8 @@ from intel_owl.tasks import FailureLoggedTask
 logger = logging.getLogger(__name__)
 
 
-# soft_time_limit is 300s on purpose: a single chat turn can chain several ReAct
-# iterations, each one an Ollama inference on a local model, so it can legitimately take
+# soft_time_limit is 300s on purpose: a single chat turn can chain several tool-calling
+# rounds, each one an Ollama inference on a local model, so it can legitimately take
 # tens of seconds to a couple of minutes. A *soft* limit raises SoftTimeLimitExceeded
 # (catchable, lets us clean up) rather than a hard time_limit that SIGKILLs the worker,
 # and it bounds a hung Ollama call so it can't occupy a worker indefinitely.
@@ -48,7 +48,7 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
     # The agent/LLM stack (langchain + ChatOllama) is imported lazily so the other Celery
     # workers that load this module never pay for that heavy import — only the chatbot worker,
     # which actually runs this task, does.
-    from api_app.chatbot_manager.agent.agent import build_agent_executor, format_history
+    from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
     from api_app.chatbot_manager.agent.memory import DjangoChatMessageHistory
     from api_app.chatbot_manager.agent.streaming import ChatStreamingCallbackHandler
     from api_app.chatbot_manager.models import ChatMessage, ChatSession
@@ -70,7 +70,10 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
 
     user = get_user_model().objects.get(pk=user_id)
     history = DjangoChatMessageHistory(session=session)
-    chat_history_text = format_history(history.messages)
+    # LangChain message objects, fed straight into the prompt's chat_history
+    # MessagesPlaceholder (no text pre-rendering). Evaluated here, before this turn is
+    # written, so the current message is not double-counted.
+    chat_history = history.messages
 
     emit(StartEvent(session_id))
     try:
@@ -83,7 +86,7 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
             tool_names={tool.name for tool in executor.tools},
         )
         result = executor.invoke(
-            {"input": user_message, "chat_history": chat_history_text},
+            {"input": user_message, "chat_history": chat_history},
             config={"callbacks": [handler]},
         )
     except SoftTimeLimitExceeded:
@@ -96,6 +99,13 @@ def process_chat_message(session_id: int, user_message: str, user_id: int) -> No
         return
 
     response_text = result.get("output", "")
+    if response_text == AGENT_STOPPED_OUTPUT:
+        # max_iterations force-stopped a looping model: surface a real error and drop the
+        # turn rather than persisting LangChain's canned string as the assistant's answer.
+        logger.warning(f"process_chat_message: iteration cap hit for session {session_id}")
+        emit(ErrorEvent(session_id, ChatErrorDetail.ITERATION_LIMIT.value))
+        return
+
     history.add_user_message(user_message)
     # Create the assistant row directly (rather than add_ai_message + a latest("timestamp")
     # re-query) so chat.end carries its exact id, without a lookup two overlapping turns of the

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import logging
+
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -8,8 +10,9 @@ from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
 from rest_framework.viewsets import ModelViewSet
 
-from .agent.agent import build_agent_executor, format_history
+from .agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
 from .agent.memory import DjangoChatMessageHistory
+from .events import ChatErrorDetail
 from .models import ChatMessage, ChatSession
 from .serializers.chat import (
     ChatMessageSerializer,
@@ -17,6 +20,8 @@ from .serializers.chat import (
     MessageRequestSerializer,
     MessageResponseSerializer,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ChatSessionViewSet(ModelViewSet):
@@ -36,8 +41,8 @@ class ChatSessionViewSet(ModelViewSet):
 
         Flow: validate the request, resolve the target session (or create a new one),
         load the prior turns from the DB as the agent's conversation history, invoke the
-        ReAct agent with the user's message, then persist both the user message and the
-        assistant reply and return the reply. Persistence goes through
+        tool-calling agent with the user's message, then persist both the user message and
+        the assistant reply and return the reply. Persistence goes through
         DjangoChatMessageHistory so the ORM stays the single source of truth for history.
         """
         req = MessageRequestSerializer(data=request.data)
@@ -52,11 +57,22 @@ class ChatSessionViewSet(ModelViewSet):
             session = ChatSession.objects.create(user=request.user)
 
         history = DjangoChatMessageHistory(session=session)
-        chat_history_text = format_history(history.messages)
 
         executor = build_agent_executor(user=request.user)
-        result = executor.invoke({"input": user_message, "chat_history": chat_history_text})
+        # history.messages are LangChain message objects, fed straight into the prompt's
+        # chat_history MessagesPlaceholder; read before this turn is persisted below.
+        result = executor.invoke({"input": user_message, "chat_history": history.messages})
         response_text = result.get("output", "")
+        if response_text == AGENT_STOPPED_OUTPUT:
+            # max_iterations force-stopped a looping model: return an error and drop the turn
+            # rather than persisting LangChain's canned string as the assistant's answer
+            # (mirrors the WebSocket path's chat.error semantics, session_id included so the
+            # client can keep using a session created by this very request).
+            logger.warning(f"chatbot message: iteration cap hit for session {session.pk}")
+            return Response(
+                {"detail": ChatErrorDetail.ITERATION_LIMIT.value, "session_id": session.pk},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
 
         history.add_user_message(user_message)
         history.add_ai_message(response_text)

--- a/docker/entrypoints/ollama.sh
+++ b/docker/entrypoints/ollama.sh
@@ -4,7 +4,9 @@
 
 set -e
 
-DEFAULT_MODEL="mistral:7b-instruct-v0.3-q4_K_M"
+# Must stay in sync with the OLLAMA_MODEL defaults in intel_owl/settings/chatbot.py and
+# docker/env_file_app_template; must be a model that supports Ollama tool calling.
+DEFAULT_MODEL="qwen2.5:3b"
 MODEL="${OLLAMA_MODEL:-$DEFAULT_MODEL}"
 
 echo "[ollama] Starting server..."

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -87,6 +87,7 @@ FLOWER_PWD=flower
 
 # LLM Chatbot
 OLLAMA_BASE_URL=http://ollama:11434
-OLLAMA_MODEL=mistral
+# must be a model that supports Ollama tool calling
+OLLAMA_MODEL=qwen2.5:3b
 # chat sessions whose last activity is older than this are flushed periodically. Default: 90 days
 CHATBOT_MESSAGE_RETENTION_DAYS=90

--- a/docker/ollama.override.yml
+++ b/docker/ollama.override.yml
@@ -1,6 +1,9 @@
 services:
   ollama:
-    image: ollama/ollama:0.5.0
+    # 0.8.0+ is required to stream responses while tools are bound (older servers return the
+    # whole message in one chunk, breaking token-by-token chat streaming); 0.30.7 is the
+    # latest stable at the time of writing.
+    image: ollama/ollama:0.30.7
     container_name: intelowl_ollama
     hostname: ollama
     restart: unless-stopped

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -4,6 +4,10 @@
 from intel_owl import secrets
 
 OLLAMA_BASE_URL = secrets.get_secret("OLLAMA_BASE_URL", "http://ollama:11434")
-OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "mistral")
+# qwen2.5:3b is the default on purpose: the agent relies on native tool calling, and this is
+# the smallest model that proved able to pick the right tool and answer from its output with
+# usable latency on a CPU-only deploy (mistral 7B took ~2.5 minutes per agent round). Stronger
+# hardware can override it with any tool-capable Ollama model via the OLLAMA_MODEL secret.
+OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "qwen2.5:3b")
 CHATBOT_QUEUE = secrets.get_secret("CHATBOT_QUEUE", "chatbot")
 CHATBOT_MESSAGE_RETENTION_DAYS = int(secrets.get_secret("CHATBOT_MESSAGE_RETENTION_DAYS", 90))

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -1,0 +1,82 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from django.conf import settings
+from django.test import TestCase
+from langchain_core.messages import AIMessage
+from langchain_core.runnables import RunnableLambda
+
+from api_app.chatbot_manager.agent.agent import (
+    _MAX_AGENT_ITERATIONS,
+    _NUM_CTX,
+    AGENT_STOPPED_OUTPUT,
+    build_agent_executor,
+)
+from certego_saas.apps.user.models import User
+
+# The full tool registry the agent must expose (one factory per module in agent/tools/).
+EXPECTED_TOOL_NAMES = {
+    "search_jobs",
+    "get_job_details",
+    "summarize_job",
+    "list_investigations",
+    "get_investigation_tree",
+    "summarize_investigation",
+    "get_data_model",
+    "list_analyzers",
+    "recommend_playbook",
+    "analyze_observable",
+}
+
+
+class BuildAgentExecutorTestCase(TestCase):
+    """The executor wires the full user-scoped tool registry and bounds the agent loop."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_agent_user")
+
+    def _build(self, **kwargs):
+        # ChatOllama is mocked so no Ollama/network is ever touched; create_tool_calling_agent
+        # only needs the mock's bind_tools() result to be composable into its runnable chain.
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama") as mock_llm_cls:
+            executor = build_agent_executor(user=self.user, **kwargs)
+        return executor, mock_llm_cls
+
+    def test_executor_has_all_tools_and_a_bounded_loop(self):
+        executor, _ = self._build()
+
+        self.assertEqual({tool.name for tool in executor.tools}, EXPECTED_TOOL_NAMES)
+        # max_iterations is the only bound that force-stops a looping model
+        self.assertEqual(executor.max_iterations, _MAX_AGENT_ITERATIONS)
+        self.assertTrue(executor.handle_parsing_errors)
+
+    def test_streaming_flag_reaches_the_llm(self):
+        for streaming in (False, True):
+            with self.subTest(streaming=streaming):
+                _, mock_llm_cls = self._build(streaming=streaming)
+                llm_kwargs = mock_llm_cls.call_args.kwargs
+                self.assertEqual(llm_kwargs["streaming"], streaming)
+                self.assertEqual(llm_kwargs["model"], settings.OLLAMA_MODEL)
+                self.assertEqual(llm_kwargs["base_url"], settings.OLLAMA_BASE_URL)
+                # without an explicit context window Ollama truncates the multi-tool prompt
+                self.assertEqual(llm_kwargs["num_ctx"], _NUM_CTX)
+
+    def test_forced_stop_output_matches_the_sentinel(self):
+        # Ties AGENT_STOPPED_OUTPUT to the real framework behavior: the executor is the real
+        # tool-calling pipeline, only the LLM is faked to request a tool on every round, so
+        # max_iterations force-stops it. A langchain bump that changes the canned stop message
+        # must fail here rather than silently persist it as an assistant answer.
+        tool_call_forever = AIMessage(
+            content="",
+            tool_calls=[{"name": "search_jobs", "args": {"query": ""}, "id": "call_1"}],
+        )
+        llm = MagicMock()
+        llm.bind_tools.return_value = RunnableLambda(lambda _: tool_call_forever)
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
+            executor = build_agent_executor(user=self.user)
+
+        result = executor.invoke({"input": "loop forever", "chat_history": []})
+
+        self.assertEqual(result["output"], AGENT_STOPPED_OUTPUT)

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -13,10 +13,10 @@ SESSION_ID = 3
 
 
 class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
-    """The callback streams only the final answer and a status per tool action."""
+    """The callback streams answer text and a status per tool action."""
 
-    def _make_handler(self):
-        handler = ChatStreamingCallbackHandler(user_id=USER_ID, session_id=SESSION_ID)
+    def _make_handler(self, tool_names=None):
+        handler = ChatStreamingCallbackHandler(user_id=USER_ID, session_id=SESSION_ID, tool_names=tool_names)
         layer = MagicMock()
         layer.group_send = AsyncMock()
         handler._channel_layer = layer
@@ -27,65 +27,37 @@ class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
         # each group_send call is (group, channel_message)
         return [call.args for call in layer.group_send.call_args_list]
 
-    def test_streams_only_after_final_answer_marker(self):
+    def test_text_tokens_stream_in_order(self):
         handler, layer = self._make_handler()
-        handler.on_llm_start()
-        for token in [
-            "Thought",
-            ":",
-            " I",
-            " now",
-            " know",
-            "\n",
-            "Final",
-            " Answer",
-            ":",
-            " Hello",
-            " world",
-        ]:
+        for token in ["Hello", " world"]:
             handler.on_llm_new_token(token)
 
         group = events.chat_group_for_user(USER_ID)
         self.assertEqual(
             self._messages(layer),
             [
-                (group, events.TokenEvent(SESSION_ID, " Hello").as_channel_message()),
+                (group, events.TokenEvent(SESSION_ID, "Hello").as_channel_message()),
                 (group, events.TokenEvent(SESSION_ID, " world").as_channel_message()),
             ],
         )
 
-    def test_marker_split_across_tokens_is_still_detected(self):
-        # Ollama/Mistral may tokenize "Final Answer:" arbitrarily; the buffer substring match
-        # must not depend on a particular token boundary.
+    def test_empty_tokens_are_not_streamed(self):
+        # A tool-call delta reaches on_llm_new_token with empty text (the call itself rides
+        # tool_call_chunks); nothing may hit the wire for it.
         handler, layer = self._make_handler()
-        handler.on_llm_start()
-        for token in ["Fin", "al Ans", "wer:", "Hi"]:
+        for token in ["", "", ""]:
+            handler.on_llm_new_token(token)
+
+        layer.group_send.assert_not_called()
+
+    def test_mixed_stream_forwards_only_text(self):
+        # A turn that starts with tool-call deltas and ends with the streamed answer.
+        handler, layer = self._make_handler()
+        for token in ["", "", "The", " answer"]:
             handler.on_llm_new_token(token)
 
         contents = [m[1]["payload"]["content"] for m in self._messages(layer)]
-        self.assertEqual(contents, ["Hi"])
-
-    def test_tokens_before_marker_are_never_streamed(self):
-        handler, layer = self._make_handler()
-        handler.on_llm_start()
-        for token in ["Thought", ":", " just", " reasoning"]:
-            handler.on_llm_new_token(token)
-
-        layer.group_send.assert_not_called()
-
-    def test_on_llm_start_rearms_gate_between_iterations(self):
-        handler, layer = self._make_handler()
-        handler.on_llm_start()
-        for token in ["Final", " Answer", ":", " done"]:
-            handler.on_llm_new_token(token)
-        layer.group_send.reset_mock()
-
-        # A fresh LLM call (next ReAct iteration) must not stream until its own marker.
-        handler.on_llm_start()
-        for token in ["Thought", ":", " hmm"]:
-            handler.on_llm_new_token(token)
-
-        layer.group_send.assert_not_called()
+        self.assertEqual(contents, ["The", " answer"])
 
     def test_agent_action_emits_status_event_with_tool_name(self):
         handler, layer = self._make_handler()
@@ -105,12 +77,7 @@ class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
     def test_agent_action_for_unregistered_tool_is_suppressed(self):
         # With a real tool registry, LangChain's "_Exception" parse-error pseudo-tool (and any
         # raw malformed model output as a "tool") must not leak to the client as chat.status.
-        handler = ChatStreamingCallbackHandler(
-            user_id=USER_ID, session_id=SESSION_ID, tool_names={"search_jobs"}
-        )
-        layer = MagicMock()
-        layer.group_send = AsyncMock()
-        handler._channel_layer = layer
+        handler, layer = self._make_handler(tool_names={"search_jobs"})
 
         exception_action = MagicMock()
         exception_action.tool = "_Exception"

--- a/tests/api_app/chatbot_manager/test_tasks.py
+++ b/tests/api_app/chatbot_manager/test_tasks.py
@@ -6,8 +6,10 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import TestCase, override_settings
 from django.utils.timezone import now
+from langchain_core.messages import AIMessage, HumanMessage
 
 from api_app.chatbot_manager import events
+from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
 from api_app.chatbot_manager.tasks import delete_old_chat_sessions, process_chat_message
 from certego_saas.apps.user.models import User
@@ -139,6 +141,28 @@ class ProcessChatMessageTestCase(TestCase):
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
     @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    def test_prior_turns_reach_the_agent_as_messages(self, mock_build, mock_get_layer):
+        self._patched_layer(mock_get_layer)
+        ChatMessage.objects.create(session=self.session, role=ChatMessage.Role.USER, content="prev q")
+        ChatMessage.objects.create(session=self.session, role=ChatMessage.Role.ASSISTANT, content="prev a")
+        executor = MagicMock()
+        executor.invoke.return_value = {"output": "ok"}
+        mock_build.return_value = executor
+
+        process_chat_message(self.session.id, "hello", self.user.id)
+
+        # history feeds the prompt's chat_history MessagesPlaceholder directly: LangChain
+        # message objects (not pre-rendered text), snapshotted before this turn is persisted
+        # so the current message is not part of it.
+        invoke_input = executor.invoke.call_args.args[0]
+        self.assertEqual(invoke_input["input"], "hello")
+        self.assertEqual(
+            [(type(m), m.content) for m in invoke_input["chat_history"]],
+            [(HumanMessage, "prev q"), (AIMessage, "prev a")],
+        )
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
     def test_agent_failure_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
         layer = self._patched_layer(mock_get_layer)
         executor = MagicMock()
@@ -155,6 +179,26 @@ class ProcessChatMessageTestCase(TestCase):
         )
         error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
         self.assertEqual(error_payload["detail"], events.ChatErrorDetail.UNAVAILABLE.value)
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    def test_iteration_cap_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
+        layer = self._patched_layer(mock_get_layer)
+        executor = MagicMock()
+        # what AgentExecutor returns when max_iterations force-stops the run
+        executor.invoke.return_value = {"output": AGENT_STOPPED_OUTPUT}
+        mock_build.return_value = executor
+
+        process_chat_message(self.session.id, "hello", self.user.id)
+
+        # the canned framework string must never be persisted as an assistant message
+        self.assertFalse(ChatMessage.objects.filter(session=self.session).exists())
+        self.assertEqual(
+            self._event_types(layer),
+            [events.ChatEventType.START.value, events.ChatEventType.ERROR.value],
+        )
+        error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
+        self.assertEqual(error_payload["detail"], events.ChatErrorDetail.ITERATION_LIMIT.value)
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
     @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -5,9 +5,12 @@ from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
 from django.utils.timezone import now
+from langchain_core.messages import AIMessage, HumanMessage
 from rest_framework import status
 from rest_framework.test import APITestCase
 
+from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT
+from api_app.chatbot_manager.events import ChatErrorDetail
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
 from certego_saas.apps.user.models import User
 
@@ -72,6 +75,53 @@ class ChatSessionViewSetTestCase(APITestCase):
         self.assertEqual(msgs[0].content, "Hello")
         self.assertEqual(msgs[1].role, ChatMessage.Role.ASSISTANT)
         self.assertEqual(msgs[1].content, MOCK_AGENT_OUTPUT["output"])
+
+    @patch("api_app.chatbot_manager.views.build_agent_executor")
+    def test_message_passes_prior_turns_as_messages(self, mock_build):
+        executor = MagicMock()
+        executor.invoke.return_value = MOCK_AGENT_OUTPUT
+        mock_build.return_value = executor
+        session = ChatSession.objects.create(user=self.user)
+        ChatMessage.objects.create(session=session, role=ChatMessage.Role.USER, content="prev q")
+        ChatMessage.objects.create(session=session, role=ChatMessage.Role.ASSISTANT, content="prev a")
+
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello", "session_id": session.pk},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        # history reaches the agent as LangChain message objects (the prompt's chat_history
+        # MessagesPlaceholder), read before this turn is persisted.
+        invoke_input = executor.invoke.call_args.args[0]
+        self.assertEqual(invoke_input["input"], "Hello")
+        self.assertEqual(
+            [(type(m), m.content) for m in invoke_input["chat_history"]],
+            [(HumanMessage, "prev q"), (AIMessage, "prev a")],
+        )
+
+    @patch("api_app.chatbot_manager.views.build_agent_executor")
+    def test_message_iteration_cap_returns_error_and_drops_the_turn(self, mock_build):
+        executor = MagicMock()
+        # what AgentExecutor returns when max_iterations force-stops the run
+        executor.invoke.return_value = {"output": AGENT_STOPPED_OUTPUT}
+        mock_build.return_value = executor
+        session = ChatSession.objects.create(user=self.user)
+
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello", "session_id": session.pk},
+            format="json",
+        )
+
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        content = response.json()
+        self.assertEqual(content["detail"], ChatErrorDetail.ITERATION_LIMIT.value)
+        # the session id rides the error so a session created by this request stays usable
+        self.assertEqual(content["session_id"], session.pk)
+        # the canned framework string must never be persisted as an assistant message
+        self.assertFalse(ChatMessage.objects.filter(session=session).exists())
 
     def test_message_returns_404_for_other_users_session(self):
         other_user, _ = User.objects.get_or_create(username="chatbot_other_view_user")


### PR DESCRIPTION
# (Part of #3761) Switch the chatbot agent to native tool calling

## Description

Refs #3761 

Replaces the chatbot's string-based ReAct agent with a native **tool-calling agent**, fixing the
blocker found while live-testing the W6 WebSocket pipeline: small local models never produced a
parseable `Final Answer:` line, so every turn looped until the Celery 300s soft time limit and
the user got a timeout instead of an answer (the synchronous REST endpoint was affected too).

### Agent (`agent/agent.py`)

- `create_react_agent` → `create_tool_calling_agent` (still wrapped in `AgentExecutor`): tool
  schemas ride Ollama's native tool-calling API via `bind_tools`, so there is **no text format
  to parse at all** — the model emits structured tool calls and the executor loops
  tool call → observation natively.
- String `PromptTemplate` → `ChatPromptTemplate` with `MessagesPlaceholder` for `chat_history`
  and `agent_scratchpad`. History reaches the model as LangChain message objects
  (`DjangoChatMessageHistory.messages` is passed straight through; the `format_history`
  text pre-rendering is removed from both the task and the REST view).
- The loop is bounded by `_MAX_AGENT_ITERATIONS` (6, rationale in-code).
  `early_stopping_method` stays at its default `"force"`: runnable agents support no other
  value in langchain 0.3 (`"generate"` raises `ValueError`).
- A forced stop is detected via the named `AGENT_STOPPED_OUTPUT` sentinel and surfaced as a
  proper user-facing error (`ChatErrorDetail.ITERATION_LIMIT`) on both paths — WS `chat.error`
  + dropped turn, REST 503 — instead of persisting LangChain's canned stop string as an
  assistant message.

### Streaming (`agent/streaming.py`)

- With tool calling there is no `Final Answer:` marker, so the buffer/gate logic is gone
  (`ANSWER_MARKER` removed from `events.py`): tool-call deltas reach `on_llm_new_token` with
  empty text, so the handler simply forwards **non-empty** text tokens.
- Per-tool `chat.status` events and the registered-tool filter (suppressing the `_Exception`
  pseudo-tool) are unchanged.
- **The WebSocket wire protocol is unchanged** — same event types and payload shapes — so this
  has zero impact on the upcoming frontend work.

### Default model & Ollama runtime

- **`num_ctx=8192`** on `ChatOllama` (named constant, rationale in-code): the rendered prompt
  (system + 10 tool schemas) is already ~2.2k tokens, and Ollama's default 2048 context
  **silently truncated it from the start** — observed live as `truncating input prompt
  limit=2048 prompt=2174` — dropping the system prompt and most tool schemas (wrong tool
  selection) and busting the KV prefix cache (every round re-evaluated the whole prompt). With
  an explicit window, follow-up rounds hit the prefix cache (measured: 2m46s cold → 14–41s for
  the next rounds on CPU).
- **Default model `mistral` → `qwen2.5:3b`** (changed consistently in `settings/chatbot.py`,
  `docker/env_file_app_template`, `docker/entrypoints/ollama.sh`): the agent now relies on
  native tool calling, and qwen2.5:3b is the smallest model that reliably picked the right tool
  and answered from its output with usable CPU latency (mistral 7B took ~2.5 min per agent
  round on a CPU-only deploy and chose the wrong tool under truncation). 1.9 GB pull vs 4.4 GB.
  Any tool-capable Ollama model can still be set via the `OLLAMA_MODEL` secret.
- **Ollama image `0.5.0` → `0.30.7`**: servers older than 0.8.0 do not stream responses while
  tools are bound (the whole answer arrives as a single chunk), which would defeat
  token-by-token chat streaming.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case its documentation was added or updated...
- [x] I have inspected and verified that the API schema is working (N/A: no REST schema change; the message endpoint only gains an error status)
- [x] If external libraries/packages with restrictive licenses were used, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section (N/A: no new dependency)
- [x] Linters (`Black`, `Flake8`, `Isort`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf (ruff check + format clean)
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated (N/A: no model change)
- [x] If the GUI has been modified: (N/A: backend only)
  - [ ] I have a provided a screenshot of the result in the PR.
  - [ ] I have created new frontend tests for the new component or updated existing ones.

### Important rules

- [x] I have read and understood the rules

## Real world example

Live end-to-end smoke on the full `--ollama` stack (CPU-only machine, `qwen2.5:3b`,
Ollama 0.30.7), raw WebSocket client → daphne → Celery chatbot worker → Ollama:

```
SENT {"message": "Which analysis jobs do I have? List them."}
EVENT ack    {"type": "ack", "session_id": 8}
EVENT start  {"type": "start", "session_id": 8}
EVENT status {"type": "status", "session_id": 8, "tool": "search_jobs"}
token: 'You'  token: ' currently'  token: ' have'  ... (token-by-token stream)
EVENT end    {"type": "end", "session_id": 8, "message_id": 6, "content": "You currently have
the following analysis jobs:\n\n1. Job ID: 2\n - Observable Name: 8.8.8.8 ..."}
```

The agent picked the right tool from a natural-language question, the answer is grounded in the
user's real jobs, the full content streamed token-by-token, and `chat.end.content` matches the
assembled tokens. Turn timing on CPU: ~1m14s for the tool-call round (cold model load) +
~27s for the streamed answer round (KV prefix cache hit) — well within the task's 300s soft
time limit. With the previous string-ReAct agent the same stack produced no parseable answer
and every turn timed out at 300s.

Backend validation: **81/81 chatbot tests green** against a rebuilt test image, ruff
check/format + ShellCheck clean.
