### PR TITLE
[GSoC 2026] Add React chat panel with WebSocket streaming (refs #3763)

### DIFF
--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intelowl",
-  "version": "6.4.0",
+  "version": "6.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "intelowl",
-      "version": "6.4.0",
+      "version": "6.6.1",
       "dependencies": {
         "@certego/certego-ui": "^0.1.19",
         "@dagrejs/dagre": "^1.1.4",
@@ -19,6 +19,7 @@
         "date-fns-tz": "^3.2.0",
         "flag-icons": "^7.2.3",
         "formik": "^2.4.6",
+        "http-proxy-middleware": "^2.0.6",
         "js-cookie": "^3.0.5",
         "md5": "^2.3.0",
         "prop-types": "^15.8.1",
@@ -37,11 +38,13 @@
         "reactflow": "^11.11.4",
         "reactstrap": "^9.2.3",
         "recharts": "^2.13.0",
+        "remark-gfm": "^3.0.1",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.8",
         "@babel/preset-react": "^7.25.7",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.5.2",
@@ -55,7 +58,6 @@
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-react-hooks": "^4.6.2",
-        "http-proxy-middleware": "^2.0.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.3.3",
@@ -126,7 +128,6 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -715,7 +716,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -1511,7 +1511,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -3831,7 +3830,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4295,92 +4293,31 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -5172,7 +5109,6 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5393,7 +5329,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5805,7 +5740,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5883,7 +5817,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6299,7 +6232,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6310,7 +6242,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -6830,7 +6761,6 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -6878,7 +6808,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -7028,6 +6957,15 @@
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chalk": {
@@ -7723,7 +7661,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8094,7 +8031,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8245,7 +8181,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9035,7 +8970,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9228,7 +9162,6 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -9303,7 +9236,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
-      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -9333,7 +9265,6 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9365,7 +9296,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9466,7 +9396,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10483,7 +10412,6 @@
           "url": "https://opencollective.com/formik"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -14938,6 +14866,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -15046,6 +14983,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/match-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
@@ -15089,6 +15035,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
@@ -15112,6 +15084,107 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
@@ -15125,6 +15198,25 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15301,6 +15393,120 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "dependencies": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -15738,7 +15944,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16498,9 +16703,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -16643,7 +16848,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -17790,7 +17994,6 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18153,7 +18356,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18390,7 +18592,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18629,7 +18830,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18652,7 +18852,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -19296,7 +19495,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -20377,7 +20575,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -20496,7 +20693,6 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -20788,6 +20984,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
@@ -20987,7 +21198,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -21162,7 +21372,6 @@
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -22104,7 +22313,6 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -22920,8 +23128,7 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "peer": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -22965,7 +23172,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23659,7 +23865,6 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -23728,7 +23933,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -23778,7 +23982,6 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -23837,7 +24040,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24168,7 +24370,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24563,6 +24764,15 @@
           "optional": true
         }
       }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   },
   "dependencies": {
@@ -24609,7 +24819,6 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -25007,7 +25216,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
-      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
       }
@@ -25491,7 +25699,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -27028,8 +27235,7 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@reactflow/background": {
       "version": "11.3.14",
@@ -27332,68 +27538,28 @@
       }
     },
     "@testing-library/dom": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
           "dev": true,
           "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
+            "dequal": "^2.0.3"
           }
         }
       }
@@ -28117,7 +28283,6 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28307,7 +28472,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -28618,8 +28782,7 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "peer": true
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -28675,7 +28838,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -28962,7 +29124,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
-      "peer": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -28973,7 +29134,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -29370,7 +29530,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
       "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
-      "peer": true,
       "requires": {}
     },
     "brace-expansion": {
@@ -29399,7 +29558,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -29497,6 +29655,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw=="
+    },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -29991,7 +30154,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -30252,8 +30414,7 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -30357,8 +30518,7 @@
     "date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "peer": true
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "date-fns-tz": {
       "version": "3.2.0",
@@ -30955,7 +31115,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31205,7 +31364,6 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31258,7 +31416,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
-      "peer": true,
       "requires": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -31282,7 +31439,6 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -31328,7 +31484,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-      "peer": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {
@@ -31370,7 +31525,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -32004,7 +32158,6 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
       "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
-      "peer": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -35287,6 +35440,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -35370,6 +35528,11 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
     "match-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
@@ -35405,6 +35568,24 @@
         "unist-util-visit": "^4.0.0"
       }
     },
+    "mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
+    },
     "mdast-util-from-markdown": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
@@ -35424,6 +35605,79 @@
         "uvu": "^0.5.0"
       }
     },
+    "mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "requires": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      }
+    },
     "mdast-util-to-hast": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
@@ -35437,6 +35691,21 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
       }
     },
     "mdast-util-to-string": {
@@ -35562,6 +35831,92 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "requires": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "requires": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0"
       }
     },
@@ -35779,7 +36134,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -36337,9 +36691,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -36426,7 +36780,6 @@
       "version": "8.4.27",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
       "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -37066,7 +37419,6 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -37321,7 +37673,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37498,7 +37849,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -37688,8 +38038,7 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
       "version": "6.27.0",
@@ -37703,7 +38052,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
-      "peer": true,
       "requires": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -38188,7 +38536,6 @@
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
           "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-          "peer": true,
           "requires": {
             "@jest/core": "^27.5.1",
             "import-local": "^3.0.2",
@@ -39011,7 +39358,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "peer": true,
       "requires": {}
     },
     "react-textarea-autosize": {
@@ -39097,7 +39443,6 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -39330,6 +39675,17 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
+    "remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      }
+    },
     "remark-parse": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
@@ -39467,7 +39823,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -39581,7 +39936,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -40299,7 +40653,6 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -40930,8 +41283,7 @@
     "tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "peer": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -40964,8 +41316,7 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -41439,7 +41790,6 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -41499,7 +41849,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41537,7 +41886,6 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
-      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -41575,7 +41923,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41816,7 +42163,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -42127,6 +42473,11 @@
       "requires": {
         "use-sync-external-store": "1.2.2"
       }
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intelowl",
-  "version": "6.6.1",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "intelowl",
-      "version": "6.6.1",
+      "version": "6.4.0",
       "dependencies": {
         "@certego/certego-ui": "^0.1.19",
         "@dagrejs/dagre": "^1.1.4",
@@ -19,7 +19,6 @@
         "date-fns-tz": "^3.2.0",
         "flag-icons": "^7.2.3",
         "formik": "^2.4.6",
-        "http-proxy-middleware": "^2.0.6",
         "js-cookie": "^3.0.5",
         "md5": "^2.3.0",
         "prop-types": "^15.8.1",
@@ -44,7 +43,6 @@
       "devDependencies": {
         "@babel/preset-env": "^7.25.8",
         "@babel/preset-react": "^7.25.7",
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.5.2",
@@ -58,6 +56,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "http-proxy-middleware": "^2.0.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.3.3",
@@ -128,6 +127,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -716,6 +716,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -1511,6 +1512,7 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -3830,6 +3832,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4293,31 +4296,92 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "dequal": "^2.0.3"
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -5109,6 +5173,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5329,6 +5394,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5740,6 +5806,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5817,6 +5884,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6232,6 +6300,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6242,6 +6311,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -6761,6 +6831,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -6808,6 +6879,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -7661,6 +7733,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8031,6 +8104,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8181,6 +8255,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8970,6 +9045,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9162,6 +9238,7 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -9236,6 +9313,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -9265,6 +9343,7 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9296,6 +9375,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9396,6 +9476,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10412,6 +10493,7 @@
           "url": "https://opencollective.com/formik"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -15944,6 +16026,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16703,9 +16786,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -16848,6 +16931,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -17994,6 +18078,7 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18356,6 +18441,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18592,6 +18678,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18830,6 +18917,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18852,6 +18940,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -19495,6 +19584,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -20575,6 +20665,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -20693,6 +20784,7 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -21198,6 +21290,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -21372,6 +21465,7 @@
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -22313,6 +22407,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -23128,7 +23223,8 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -23172,6 +23268,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23865,6 +23962,7 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -23933,6 +24031,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -23982,6 +24081,7 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -24040,6 +24140,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24370,6 +24471,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24819,6 +24921,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -25216,6 +25319,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
       }
@@ -25699,6 +25803,7 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
+      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -27235,7 +27340,8 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
     },
     "@reactflow/background": {
       "version": "11.3.14",
@@ -27538,28 +27644,68 @@
       }
     },
     "@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "aria-query": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "dequal": "^2.0.3"
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -28283,6 +28429,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28472,6 +28619,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -28782,7 +28930,8 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "peer": true
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -28838,6 +28987,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -29124,6 +29274,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "peer": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -29134,6 +29285,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -29530,6 +29682,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
       "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "peer": true,
       "requires": {}
     },
     "brace-expansion": {
@@ -29558,6 +29711,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -30154,6 +30308,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -30414,7 +30569,8 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -30518,7 +30674,8 @@
     "date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true
     },
     "date-fns-tz": {
       "version": "3.2.0",
@@ -31115,6 +31272,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31364,6 +31522,7 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31416,6 +31575,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "peer": true,
       "requires": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -31439,6 +31599,7 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -31484,6 +31645,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "peer": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {
@@ -31525,6 +31687,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -32158,6 +32321,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
       "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "peer": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -36134,6 +36298,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -36691,9 +36856,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -36780,6 +36945,7 @@
       "version": "8.4.27",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
       "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -37419,6 +37585,7 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -37673,6 +37840,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37849,6 +38017,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -38038,7 +38207,8 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true
     },
     "react-router": {
       "version": "6.27.0",
@@ -38052,6 +38222,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "peer": true,
       "requires": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -38536,6 +38707,7 @@
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
           "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+          "peer": true,
           "requires": {
             "@jest/core": "^27.5.1",
             "import-local": "^3.0.2",
@@ -39358,6 +39530,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
+      "peer": true,
       "requires": {}
     },
     "react-textarea-autosize": {
@@ -39443,6 +39616,7 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -39823,6 +39997,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -39936,6 +40111,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
+      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -40653,6 +40829,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -41283,7 +41460,8 @@
     "tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "peer": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -41316,7 +41494,8 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -41790,6 +41969,7 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -41849,6 +42029,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41886,6 +42067,7 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -41923,6 +42105,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -42163,6 +42346,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "reactflow": "^11.11.4",
     "reactstrap": "^9.2.3",
     "recharts": "^2.13.0",
+    "remark-gfm": "^3.0.1",
     "zustand": "^4.5.4"
   },
   "scripts": {

--- a/frontend/src/components/chat/ChatComposer.jsx
+++ b/frontend/src/components/chat/ChatComposer.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, Input } from "reactstrap";
+import { IoSend } from "react-icons/io5";
+
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+
+// Mirror MessageRequestSerializer(message=CharField(max_length=4096)) so the UI caps input before
+// the server rejects it with INVALID_MESSAGE.
+const MAX_MESSAGE_LEN = 4096;
+
+/**
+ * Message input. Enter sends, Shift+Enter inserts a newline. Disabled while a turn is streaming or
+ * the socket is not connected, so the user can't fire a second turn before the first finishes.
+ */
+export function ChatComposer({ onSend }) {
+  const [text, setText] = React.useState("");
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const connectionState = useChatStore((state) => state.connectionState);
+  const disabled = isStreaming || connectionState !== ConnectionState.CONNECTED;
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setText("");
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="d-flex align-items-end p-2 border-top">
+      <Input
+        id="chat-composer-input"
+        type="textarea"
+        rows={1}
+        value={text}
+        maxLength={MAX_MESSAGE_LEN}
+        placeholder="Ask about your threat intel data…"
+        onChange={(event) => setText(event.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      <Button
+        color="primary"
+        className="ms-2"
+        onClick={submit}
+        disabled={disabled || !text.trim()}
+        aria-label="Send message"
+      >
+        <IoSend />
+      </Button>
+    </div>
+  );
+}
+
+ChatComposer.propTypes = {
+  onSend: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/chat/ChatMessage.jsx
+++ b/frontend/src/components/chat/ChatMessage.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { chatMarkdownToHtml } from "./chatMarkdown";
+import { MessageRole } from "../../stores/useChatStore";
+
+/**
+ * A single chat bubble. User messages render as plain (newline-preserving) text and align right;
+ * assistant messages render markdown (GFM) and align left.
+ */
+export function ChatMessage({ role, content }) {
+  const isUser = role === MessageRole.USER;
+  return (
+    <div
+      className={`d-flex mb-2 ${
+        isUser ? "justify-content-end" : "justify-content-start"
+      }`}
+    >
+      <div
+        className={`px-3 py-2 rounded ${
+          isUser
+            ? "bg-primary text-white"
+            : "bg-dark text-white border border-secondary"
+        }`}
+        style={{ maxWidth: "85%", wordBreak: "break-word" }}
+      >
+        {isUser ? (
+          <span style={{ whiteSpace: "pre-wrap" }}>{content}</span>
+        ) : (
+          chatMarkdownToHtml(content)
+        )}
+      </div>
+    </div>
+  );
+}
+
+ChatMessage.propTypes = {
+  role: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+};

--- a/frontend/src/components/chat/ChatMessageList.jsx
+++ b/frontend/src/components/chat/ChatMessageList.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Spinner } from "reactstrap";
+
+import { ChatMessage } from "./ChatMessage";
+import { useChatStore, MessageRole } from "../../stores/useChatStore";
+
+/**
+ * Scrollable conversation view: committed messages, plus the in-progress assistant turn (a
+ * "Running <tool>…/Thinking…" indicator before any text arrives, then the live streaming bubble).
+ * Autoscrolls to the bottom as new content lands.
+ */
+export function ChatMessageList() {
+  const messages = useChatStore((state) => state.messages);
+  const streamingText = useChatStore((state) => state.streamingText);
+  const currentTool = useChatStore((state) => state.currentTool);
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const bottomRef = React.useRef(null);
+
+  React.useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingText, currentTool]);
+
+  return (
+    <div className="flex-grow-1 overflow-auto p-3">
+      {messages.map((message, index) => (
+        <ChatMessage
+          // committed assistant messages carry a server id; user messages fall back to position
+          key={message.id ?? `${message.role}-${index}`}
+          role={message.role}
+          content={message.content}
+        />
+      ))}
+      {isStreaming && !streamingText && (
+        <div className="text-muted small mb-2 d-flex align-items-center">
+          <Spinner size="sm" className="me-2" />
+          {currentTool ? `Running ${currentTool}…` : "Thinking…"}
+        </div>
+      )}
+      {isStreaming && streamingText && (
+        <ChatMessage role={MessageRole.ASSISTANT} content={streamingText} />
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  Offcanvas,
+  OffcanvasHeader,
+  OffcanvasBody,
+  Badge,
+  Alert,
+} from "reactstrap";
+
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+import { useChatWebSocket } from "./useChatWebSocket";
+import { ChatMessageList } from "./ChatMessageList";
+import { ChatComposer } from "./ChatComposer";
+
+// Connection-state badge shown in the drawer header.
+const CONNECTION_BADGE = {
+  [ConnectionState.IDLE]: { color: "secondary", label: "Idle" },
+  [ConnectionState.CONNECTING]: { color: "warning", label: "Connecting" },
+  [ConnectionState.CONNECTED]: { color: "success", label: "Connected" },
+  [ConnectionState.RECONNECTING]: { color: "warning", label: "Reconnecting" },
+  [ConnectionState.CLOSED]: { color: "danger", label: "Disconnected" },
+};
+
+/**
+ * The chat drawer. Mounted once, globally (AppMain Layout), so it overlays every authenticated
+ * page and survives open/close; the WebSocket lives in useChatWebSocket, which lazily connects the
+ * first time the drawer opens. `backdrop={false}` keeps the rest of the app usable while open.
+ */
+export function ChatPanel() {
+  const isOpen = useChatStore((state) => state.isOpen);
+  const close = useChatStore((state) => state.close);
+  const connectionState = useChatStore((state) => state.connectionState);
+  const error = useChatStore((state) => state.error);
+  const { sendMessage } = useChatWebSocket();
+
+  const badge =
+    CONNECTION_BADGE[connectionState] ?? CONNECTION_BADGE[ConnectionState.IDLE];
+
+  return (
+    <Offcanvas
+      direction="end"
+      isOpen={isOpen}
+      toggle={close}
+      backdrop={false}
+      scrollable
+      id="chat-panel"
+    >
+      <OffcanvasHeader toggle={close}>
+        Assistant
+        <Badge color={badge.color} className="ms-2">
+          {badge.label}
+        </Badge>
+      </OffcanvasHeader>
+      <OffcanvasBody className="d-flex flex-column p-0">
+        {error && (
+          <Alert color="danger" className="m-2">
+            {error}
+          </Alert>
+        )}
+        <ChatMessageList />
+        <ChatComposer onSend={sendMessage} />
+      </OffcanvasBody>
+    </Offcanvas>
+  );
+}

--- a/frontend/src/components/chat/chatMarkdown.jsx
+++ b/frontend/src/components/chat/chatMarkdown.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Markdown renderer for assistant chat messages.
+ *
+ * Kept separate from the shared `markdownToHtml` on purpose: the chat enables GFM (tables /
+ * strikethrough / task lists) because the agent renders job and analyzer summaries as markdown
+ * tables, which the shared renderer (no GFM) would show as broken pipe-text. Isolating it here
+ * avoids changing how the rest of IntelOwl renders markdown.
+ *
+ * No `rehype-raw`: react-markdown v8 does not render raw HTML by default, so untrusted LLM output
+ * stays XSS-safe without an extra sanitizer.
+ * @param {string} text
+ */
+export function chatMarkdownToHtml(text) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      // eslint-disable-next-line react/no-children-prop
+      children={text}
+      components={{
+        // eslint-disable-next-line id-length
+        em: ({ node: _, ...props }) => <i className="text-code" {...props} />,
+        // eslint-disable-next-line id-length
+        a: ({ node: _, ...props }) => (
+          // eslint-disable-next-line jsx-a11y/anchor-has-content
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            className="link-primary"
+            {...props}
+          />
+        ),
+        table: ({ node: _, ...props }) => (
+          <table className="table table-sm" {...props} />
+        ),
+        // drop react-markdown's `inline` flag so it is not spread onto the DOM node
+        code: ({ node: _, inline: _inline, ...props }) => (
+          <code className="text-code" {...props} />
+        ),
+      }}
+    />
+  );
+}

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -167,15 +167,22 @@ export function useChatWebSocket() {
     };
     socket.onclose = (closeEvent) => {
       websocket.current = null;
-      clearTurnTimers();
+      // Terminal closes (teardown, clean close, reconnect budget exhausted) end the turn for good:
+      // drop the watchdogs so a stale timer can't fire an error minutes later onto a dead socket.
       if (isUnmounting.current || closeEvent.code === NORMAL_CLOSURE) {
+        clearTurnTimers();
         useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
         return;
       }
       if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+        clearTurnTimers();
         useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
         return;
       }
+      // Abnormal mid-turn drop: keep the turn watchdogs armed across the reconnect. The in-flight
+      // turn's `start`/`end` lands in the dead window and is never replayed to the new socket (group
+      // frames aren't buffered), so the watchdog is the only thing that unlocks the composer here —
+      // clearing it on close would strand `isStreaming` forever.
       const delay = Math.min(
         RECONNECT_BASE_MS * 2 ** reconnectAttempts.current,
         RECONNECT_CAP_MS,

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -1,0 +1,222 @@
+import React from "react";
+
+import { WEBSOCKET_CHAT_URI } from "../../constants/apiURLs";
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+
+// Inbound frame types — mirror ChatEventType in api_app/chatbot_manager/events.py.
+const ChatEventType = Object.freeze({
+  ACK: "ack",
+  START: "start",
+  STATUS: "status",
+  TOKEN: "token",
+  END: "end",
+  ERROR: "error",
+});
+
+// Normal WebSocket close code: a clean close must NOT trigger a reconnect.
+const NORMAL_CLOSURE = 1000;
+
+// Capped exponential backoff for the reconnect (chat is long-lived, unlike the Job socket which
+// closes on the final status). Give up after a few attempts and surface a CLOSED badge.
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_CAP_MS = 30000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+
+// Post-ack watchdog: the consumer sends `ack` synchronously *before* enqueuing the Celery turn
+// (process_chat_message.delay), so the ack arrives even when the chatbot worker is down — then no
+// `start`/`end`/`error` ever follows and the composer would stay locked forever. If no `start`
+// lands within this window after an `ack`, give up and unlock the composer.
+const POST_ACK_TIMEOUT_MS = 20000;
+
+// Max-turn watchdog: bounds `start` -> no `end`. Set just above the server soft_time_limit (300s)
+// so the server's own timeout normally wins; this only fires when the socket drops mid-turn (the
+// group `end` is sent into the dead window and is not buffered) or the worker is hard-killed
+// (SIGKILL never reaches the soft limit, so no `chat.error` is emitted).
+const MAX_TURN_TIMEOUT_MS = 310000;
+
+// Client-side error texts (mirror the user-safe strings in ChatErrorDetail).
+const WORKER_UNAVAILABLE_TEXT =
+  "The assistant is currently unavailable. Please try again.";
+const TURN_TIMEOUT_TEXT =
+  "The assistant took too long to respond. Please try again.";
+
+function buildChatWebSocketUrl() {
+  const scheme = window.location.protocol === "https:" ? "wss" : "ws";
+  // Trailing slash matters: the backend route is `ws/chat/`. context_url carries the page the
+  // user is on (captured server-side for later context injection).
+  const contextUrl = encodeURIComponent(window.location.href);
+  return `${scheme}://${window.location.host}/${WEBSOCKET_CHAT_URI}/?context_url=${contextUrl}`;
+}
+
+/**
+ * Owns the chat WebSocket and bridges it to useChatStore.
+ *
+ * The socket, the reconnect timer and the two per-turn watchdog timers all live in refs (never in
+ * the store) so re-renders don't recreate them — the same pattern JobResult uses for the job
+ * socket. The hook lazily connects the first time the drawer opens and then keeps the socket alive
+ * across open/close; it only tears down on unmount. Returns `sendMessage` for the composer.
+ */
+export function useChatWebSocket() {
+  const isOpen = useChatStore((state) => state.isOpen);
+
+  const websocket = React.useRef(null);
+  const reconnectTimer = React.useRef(null);
+  const reconnectAttempts = React.useRef(0);
+  const postAckTimer = React.useRef(null);
+  const maxTurnTimer = React.useRef(null);
+  // Set on unmount so the onclose handler does not schedule a reconnect during teardown.
+  const isUnmounting = React.useRef(false);
+
+  const clearTurnTimers = React.useCallback(() => {
+    if (postAckTimer.current) {
+      clearTimeout(postAckTimer.current);
+      postAckTimer.current = null;
+    }
+    if (maxTurnTimer.current) {
+      clearTimeout(maxTurnTimer.current);
+      maxTurnTimer.current = null;
+    }
+  }, []);
+
+  const dispatchEvent = React.useCallback(
+    (event) => {
+      const store = useChatStore.getState();
+      const activeSession = store.sessionId;
+      switch (event.type) {
+        case ChatEventType.ACK:
+          // `ack` reaches only this socket; bind the (possibly new) session id, then arm the
+          // post-ack watchdog until the agent proves it is alive by emitting `start`.
+          store.applyAck(event);
+          if (postAckTimer.current) clearTimeout(postAckTimer.current);
+          postAckTimer.current = setTimeout(() => {
+            postAckTimer.current = null;
+            useChatStore.getState().applyError(WORKER_UNAVAILABLE_TEXT);
+          }, POST_ACK_TIMEOUT_MS);
+          break;
+        case ChatEventType.START:
+          // Strict demux: `start`/`status`/`token`/`end` fan out to every tab of this user, so a
+          // tab must drop frames that belong to another session. A fresh tab has sessionId === null
+          // and therefore matches nothing.
+          if (event.session_id !== activeSession) return;
+          // The agent answered: cancel the post-ack watchdog and arm the max-turn one.
+          if (postAckTimer.current) {
+            clearTimeout(postAckTimer.current);
+            postAckTimer.current = null;
+          }
+          maxTurnTimer.current = setTimeout(() => {
+            maxTurnTimer.current = null;
+            useChatStore.getState().applyError(TURN_TIMEOUT_TEXT);
+          }, MAX_TURN_TIMEOUT_MS);
+          store.applyStart();
+          break;
+        case ChatEventType.STATUS:
+          if (event.session_id !== activeSession) return;
+          store.applyStatus(event);
+          break;
+        case ChatEventType.TOKEN:
+          if (event.session_id !== activeSession) return;
+          store.applyToken(event);
+          break;
+        case ChatEventType.END:
+          if (event.session_id !== activeSession) return;
+          clearTurnTimers();
+          store.applyEnd(event);
+          break;
+        case ChatEventType.ERROR:
+          // Looser guard than the streaming frames: the consumer's *direct* errors arrive only on
+          // this socket with session_id === null (INVALID_MESSAGE), so the null branch must pass;
+          // the agent errors arrive via the group with the active session id. A different non-null
+          // session id belongs to another tab and is ignored.
+          if (event.session_id != null && event.session_id !== activeSession)
+            return;
+          clearTurnTimers();
+          store.applyError(event.detail);
+          break;
+        default:
+          break;
+      }
+    },
+    [clearTurnTimers],
+  );
+
+  const connect = React.useCallback(() => {
+    if (websocket.current) return;
+    const { setConnectionState } = useChatStore.getState();
+    setConnectionState(ConnectionState.CONNECTING);
+    const url = buildChatWebSocketUrl();
+    console.debug(`connect to chat websocket: ${url}`);
+    const socket = new WebSocket(url);
+    websocket.current = socket;
+
+    socket.onopen = () => {
+      reconnectAttempts.current = 0;
+      useChatStore.getState().setConnectionState(ConnectionState.CONNECTED);
+    };
+    socket.onmessage = (wsData) => {
+      let event;
+      try {
+        event = JSON.parse(wsData.data);
+      } catch (parseError) {
+        console.error("chat ws: unparsable frame", parseError);
+        return;
+      }
+      dispatchEvent(event);
+    };
+    socket.onerror = (wsError) => {
+      console.error("chat ws error", wsError);
+    };
+    socket.onclose = (closeEvent) => {
+      websocket.current = null;
+      clearTurnTimers();
+      if (isUnmounting.current || closeEvent.code === NORMAL_CLOSURE) {
+        useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
+        return;
+      }
+      if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+        useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
+        return;
+      }
+      const delay = Math.min(
+        RECONNECT_BASE_MS * 2 ** reconnectAttempts.current,
+        RECONNECT_CAP_MS,
+      );
+      reconnectAttempts.current += 1;
+      useChatStore.getState().setConnectionState(ConnectionState.RECONNECTING);
+      reconnectTimer.current = setTimeout(connect, delay);
+    };
+  }, [dispatchEvent, clearTurnTimers]);
+
+  // Lazy connect on first open; keep the socket alive afterwards (no idle socket for users who
+  // never open the chat). Teardown happens only on unmount.
+  React.useEffect(() => {
+    if (isOpen && !websocket.current) {
+      connect();
+    }
+  }, [isOpen, connect]);
+
+  React.useEffect(
+    () => () => {
+      isUnmounting.current = true;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      clearTurnTimers();
+      if (websocket.current) {
+        websocket.current.close(NORMAL_CLOSURE);
+        websocket.current = null;
+      }
+    },
+    [clearTurnTimers],
+  );
+
+  const sendMessage = React.useCallback((text) => {
+    const trimmed = text.trim();
+    const socket = websocket.current;
+    if (!trimmed || !socket || socket.readyState !== WebSocket.OPEN) return;
+    const store = useChatStore.getState();
+    store.enqueueUserMessage(trimmed);
+    socket.send(
+      JSON.stringify({ message: trimmed, session_id: store.sessionId }),
+    );
+  }, []);
+
+  return { sendMessage };
+}

--- a/frontend/src/constants/apiURLs.js
+++ b/frontend/src/constants/apiURLs.js
@@ -54,6 +54,7 @@ export const APIACCESS_BASE_URI = `${AUTH_BASE_URI}/apiaccess`;
 // WEBSOCKETS
 const WEBSOCKET_BASE_URI = "ws";
 export const WEBSOCKET_JOBS_URI = `${WEBSOCKET_BASE_URI}/jobs`;
+export const WEBSOCKET_CHAT_URI = `${WEBSOCKET_BASE_URI}/chat`;
 
 // user event
 export const USER_EVENT_BASE_URI = `${API_BASE_URI}/user_event`;

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -20,7 +20,7 @@ import {
   RiTwitterXFill,
 } from "react-icons/ri";
 import { FaGithub, FaGoogle, FaLinkedin } from "react-icons/fa";
-import { IoSearch } from "react-icons/io5";
+import { IoSearch, IoChatbubbleEllipsesOutline } from "react-icons/io5";
 import { TbReport, TbReportSearch, TbDatabaseSearch } from "react-icons/tb";
 
 // lib
@@ -40,6 +40,7 @@ import NotificationPopoverButton from "../components/jobs/notification/Notificat
 import { useAuthStore } from "../stores/useAuthStore";
 import { useGuideContext } from "../contexts/GuideContext";
 import { useOrganizationStore } from "../stores/useOrganizationStore";
+import { useChatStore } from "../stores/useChatStore";
 
 const guestLinks = (
   <>
@@ -120,8 +121,22 @@ function AuthLinks() {
 function RightLinks({ handleClickStart, isAuthenticated }) {
   const location = useLocation();
   const isRootPath = location.pathname === "/";
+  const toggleChat = useChatStore((state) => state.toggle);
   return (
     <>
+      {isAuthenticated && (
+        <NavItem>
+          <button
+            type="button"
+            id="chat-toggle-btn"
+            className="d-flex-start-center btn text-gray"
+            onClick={toggleChat}
+          >
+            <IoChatbubbleEllipsesOutline />
+            <span className="ms-1">Assistant</span>
+          </button>
+        </NavItem>
+      )}
       {isRootPath && isAuthenticated && (
         <NavItem>
           <button

--- a/frontend/src/layouts/AppMain.jsx
+++ b/frontend/src/layouts/AppMain.jsx
@@ -16,6 +16,7 @@ import {
 } from "../components/Routes";
 import AppHeader from "./AppHeader";
 import Toast from "./Toast";
+import { ChatPanel } from "../components/chat/ChatPanel";
 
 const NoMatch = React.lazy(() => import("./NoMatch"));
 
@@ -52,6 +53,8 @@ function Layout() {
       </main>
       {/* Toasts */}
       <Toast />
+      {/* LLM chat assistant drawer (mounted once; connects lazily on first open) */}
+      <ChatPanel />
     </>
   );
 }

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -11,6 +11,13 @@ module.exports = function proxy(app) {
     }),
   );
   app.use(
+    createProxyMiddleware("/ws/chat", {
+      target: TARGET_SERVER,
+      // eslint-disable-next-line id-length
+      ws: true,
+    }),
+  );
+  app.use(
     createProxyMiddleware("/api", {
       target: TARGET_SERVER,
     }),

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -1,0 +1,85 @@
+import { create } from "zustand";
+
+/**
+ * Connection states for the chat WebSocket, surfaced in the UI as a status badge.
+ * The socket itself is NOT held here: per the IntelOwl convention zustand stores keep only
+ * serializable state, so the WebSocket (and its timers) live in the useChatWebSocket hook via
+ * refs. This store is the single source of truth for what the panel renders; the hook owns the
+ * transport and calls the apply* reducers below as frames arrive.
+ */
+export const ConnectionState = Object.freeze({
+  IDLE: "idle",
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  RECONNECTING: "reconnecting",
+  CLOSED: "closed",
+});
+
+export const MessageRole = Object.freeze({
+  USER: "user",
+  ASSISTANT: "assistant",
+});
+
+const initialTurnState = {
+  // text of the assistant answer while it streams token-by-token (committed to messages on `end`)
+  streamingText: "",
+  // name of the tool the agent is currently running, shown as a "Running <tool>…" indicator
+  currentTool: null,
+  // true between sending a message and receiving `end`/`error`; disables the composer
+  isStreaming: false,
+};
+
+export const useChatStore = create((set) => ({
+  // drawer visibility (toggled from the global header, a separate component subtree)
+  isOpen: false,
+  // session id assigned by the server in the `ack` frame; null until the first turn binds it
+  sessionId: null,
+  // committed conversation: [{ id?, role, content }]
+  messages: [],
+  ...initialTurnState,
+  connectionState: ConnectionState.IDLE,
+  // last user-facing error text (cleared when a new turn starts)
+  error: null,
+
+  // --- drawer actions ---
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+
+  // --- outbound ---
+  // Optimistically render the user's message and lock the composer before the server replies.
+  enqueueUserMessage: (text) =>
+    set((state) => ({
+      messages: [...state.messages, { role: MessageRole.USER, content: text }],
+      ...initialTurnState,
+      isStreaming: true,
+      error: null,
+    })),
+
+  // --- inbound frame reducers (called by the hook; demux/filtering happens upstream there) ---
+  applyAck: (event) => set({ sessionId: event.session_id }),
+  applyStart: () =>
+    set({ ...initialTurnState, isStreaming: true, error: null }),
+  applyStatus: (event) => set({ currentTool: event.tool }),
+  applyToken: (event) =>
+    set((state) => ({ streamingText: state.streamingText + event.content })),
+  applyEnd: (event) =>
+    set((state) => ({
+      messages: [
+        ...state.messages,
+        {
+          id: event.message_id,
+          role: MessageRole.ASSISTANT,
+          content: event.content,
+        },
+      ],
+      ...initialTurnState,
+    })),
+  // `detail` is the server's user-safe text, or a client-side message for the watchdog timeouts.
+  // The partial streaming bubble is dropped (the server drops the turn too) but the user's message
+  // stays visible so they can retry.
+  applyError: (detail) => set({ ...initialTurnState, error: detail }),
+
+  // --- connection ---
+  setConnectionState: (connectionState) => set({ connectionState }),
+}));

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -186,3 +186,11 @@ input[type="file"]::file-selector-button {
   position: absolute;
   background: rgb(33, 63, 75);
 }
+
+// chat/
+// Bootstrap's default .btn-close renders a dark glyph that is barely visible on the dark
+// chat drawer. Apply the same filter bootstrap ships in .btn-close-white (reactstrap's
+// OffcanvasHeader hardcodes the btn-close class and exposes no prop to extend it).
+#chat-panel .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}

--- a/frontend/tests/components/chat/ChatComposer.test.jsx
+++ b/frontend/tests/components/chat/ChatComposer.test.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ChatComposer } from "../../../src/components/chat/ChatComposer";
+import {
+  useChatStore,
+  ConnectionState,
+} from "../../../src/stores/useChatStore";
+
+const connectedIdle = {
+  isStreaming: false,
+  connectionState: ConnectionState.CONNECTED,
+};
+
+describe("ChatComposer", () => {
+  beforeEach(() => {
+    useChatStore.setState(connectedIdle);
+  });
+
+  test("Enter sends the trimmed text and clears the input", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "  list my jobs  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("list my jobs");
+    expect(input).toHaveValue("");
+  });
+
+  test("Shift+Enter does not send (newline)", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "first line" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test("empty/whitespace input does not send", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test("disabled while a turn is streaming", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      connectionState: ConnectionState.CONNECTED,
+    });
+    render(<ChatComposer onSend={jest.fn()} />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeDisabled();
+  });
+
+  test("disabled while the socket is not connected", () => {
+    useChatStore.setState({
+      isStreaming: false,
+      connectionState: ConnectionState.RECONNECTING,
+    });
+    render(<ChatComposer onSend={jest.fn()} />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/chat/ChatMessageList.test.jsx
+++ b/frontend/tests/components/chat/ChatMessageList.test.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { ChatMessageList } from "../../../src/components/chat/ChatMessageList";
+import { useChatStore, MessageRole } from "../../../src/stores/useChatStore";
+
+const emptyTurn = {
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+};
+
+describe("ChatMessageList", () => {
+  beforeAll(() => {
+    // jsdom does not implement scrollIntoView; the autoscroll effect calls it.
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    useChatStore.setState(emptyTurn);
+  });
+
+  test("renders committed user and assistant messages", () => {
+    useChatStore.setState({
+      messages: [
+        { role: MessageRole.USER, content: "hello" },
+        { id: 9, role: MessageRole.ASSISTANT, content: "**hi there**" },
+      ],
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hi there").tagName).toBe("STRONG");
+  });
+
+  test("shows the running-tool indicator before any token streams", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      streamingText: "",
+      currentTool: "search_jobs",
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText(/Running search_jobs/i)).toBeInTheDocument();
+  });
+
+  test("shows a generic thinking indicator when no tool is running yet", () => {
+    useChatStore.setState({ isStreaming: true, streamingText: "" });
+    render(<ChatMessageList />);
+    expect(screen.getByText(/Thinking/i)).toBeInTheDocument();
+  });
+
+  test("renders the in-progress streaming bubble", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      streamingText: "partial answer",
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText("partial answer")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/chat/ChatPanel.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.test.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, act } from "@testing-library/react";
+
+import { ChatPanel } from "../../../src/components/chat/ChatPanel";
+import {
+  useChatStore,
+  ConnectionState,
+  MessageRole,
+} from "../../../src/stores/useChatStore";
+
+// No-op WebSocket so the lazily-connecting hook does not touch the network in jsdom. It opens on
+// the next tick so the hook transitions CONNECTING -> CONNECTED like a real socket.
+class StubWebSocket {
+  constructor() {
+    this.readyState = StubWebSocket.OPEN;
+    setTimeout(() => {
+      if (this.onopen) this.onopen({});
+    }, 0);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  send() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  close() {}
+}
+StubWebSocket.OPEN = 1;
+
+const baseState = {
+  isOpen: true,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.CONNECTED,
+  error: null,
+};
+
+describe("ChatPanel", () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    global.WebSocket = StubWebSocket;
+    useChatStore.setState(baseState);
+  });
+
+  test("renders the composer and the connection badge when open", async () => {
+    render(<ChatPanel />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
+    // the hook flips CONNECTING -> CONNECTED once the (stub) socket opens
+    expect(await screen.findByText("Connected")).toBeInTheDocument();
+  });
+
+  test("renders the conversation from store state", () => {
+    useChatStore.setState({
+      messages: [
+        { role: MessageRole.USER, content: "show my jobs" },
+        { id: 1, role: MessageRole.ASSISTANT, content: "Here they are" },
+      ],
+    });
+    render(<ChatPanel />);
+    expect(screen.getByText("show my jobs")).toBeInTheDocument();
+    expect(screen.getByText("Here they are")).toBeInTheDocument();
+  });
+
+  test("surfaces an error banner", () => {
+    render(<ChatPanel />);
+    act(() => {
+      useChatStore
+        .getState()
+        .applyError(
+          "The assistant is currently unavailable. Please try again.",
+        );
+    });
+    expect(screen.getByText(/currently unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/chat/chatMarkdown.test.jsx
+++ b/frontend/tests/components/chat/chatMarkdown.test.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { chatMarkdownToHtml } from "../../../src/components/chat/chatMarkdown";
+
+describe("chatMarkdownToHtml", () => {
+  test("renders a GFM table (the reason remark-gfm is added)", () => {
+    const markdown = "| Job | Status |\n| --- | --- |\n| 1 | success |";
+    render(<div>{chatMarkdownToHtml(markdown)}</div>);
+    const table = screen.getByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table.className).toContain("table");
+    expect(screen.getByText("success")).toBeInTheDocument();
+  });
+
+  test("renders links opening in a new tab", () => {
+    render(<div>{chatMarkdownToHtml("[docs](https://example.com)")}</div>);
+    const link = screen.getByRole("link", { name: "docs" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("href", "https://example.com");
+  });
+
+  test("renders bold text without GFM-specific syntax", () => {
+    render(<div>{chatMarkdownToHtml("This is **bold**")}</div>);
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+  });
+});

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -253,6 +253,35 @@ describe("useChatWebSocket", () => {
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
 
+  test("keeps the max-turn watchdog armed across a mid-turn reconnect", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    // socket drops mid-turn, then reconnects; the in-flight turn's `end` is lost in the dead window
+    act(() => {
+      lastSocket().mockServerClose(1006);
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000); // reconnect backoff
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    act(() => {
+      lastSocket().mockOpen();
+    });
+
+    // the watchdog survived the drop and still unlocks the composer instead of hanging on isStreaming
+    act(() => {
+      jest.advanceTimersByTime(310000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/too long/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
   test("does not reconnect on a clean close", () => {
     connectAndOpen();
     act(() => {

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -1,0 +1,269 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { useChatWebSocket } from "../../../src/components/chat/useChatWebSocket";
+import {
+  useChatStore,
+  ConnectionState,
+} from "../../../src/stores/useChatStore";
+
+// Minimal controllable WebSocket double (jsdom has none). Tests drive the server side via the
+// mock* helpers and inspect what the hook sent.
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close(code) {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code: code ?? 1000 });
+  }
+
+  // --- test helpers ---
+  mockOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    if (this.onopen) this.onopen({});
+  }
+
+  mockMessage(payload) {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(payload) });
+  }
+
+  mockServerClose(code) {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code });
+  }
+}
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.CLOSED = 3;
+FakeWebSocket.instances = [];
+
+function Harness() {
+  const { sendMessage } = useChatWebSocket();
+  return (
+    <button type="button" onClick={() => sendMessage("hello")}>
+      send
+    </button>
+  );
+}
+
+const lastSocket = () =>
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const initialState = {
+  isOpen: false,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.IDLE,
+  error: null,
+};
+
+describe("useChatWebSocket", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    FakeWebSocket.instances = [];
+    global.WebSocket = FakeWebSocket;
+    useChatStore.setState(initialState);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // open the drawer so the hook lazily connects, then complete the handshake
+  function connectAndOpen() {
+    render(<Harness />);
+    act(() => {
+      useChatStore.getState().open();
+    });
+    act(() => {
+      lastSocket().mockOpen();
+    });
+  }
+
+  test("connects lazily on open and reaches CONNECTED", () => {
+    render(<Harness />);
+    expect(FakeWebSocket.instances).toHaveLength(0); // not connected while closed
+    act(() => {
+      useChatStore.getState().open();
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(lastSocket().url).toContain("/ws/chat/?context_url=");
+    act(() => {
+      lastSocket().mockOpen();
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CONNECTED,
+    );
+  });
+
+  test("sendMessage emits {message, session_id} and binds the session on ack", () => {
+    connectAndOpen();
+    act(() => {
+      fireEvent.click(screen.getByText("send"));
+    });
+    expect(lastSocket().sent).toEqual([{ message: "hello", session_id: null }]);
+    expect(useChatStore.getState().messages).toHaveLength(1);
+
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+    });
+    expect(useChatStore.getState().sessionId).toBe(5);
+  });
+
+  test("streams start -> token -> end for the active session", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+      lastSocket().mockMessage({
+        type: "status",
+        session_id: 5,
+        tool: "search_jobs",
+      });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 5,
+        content: "Hi ",
+      });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 5,
+        content: "you",
+      });
+    });
+    expect(useChatStore.getState().streamingText).toBe("Hi you");
+    expect(useChatStore.getState().currentTool).toBe("search_jobs");
+
+    act(() => {
+      lastSocket().mockMessage({
+        type: "end",
+        session_id: 5,
+        message_id: 9,
+        content: "Hi you!",
+      });
+    });
+    const state = useChatStore.getState();
+    expect(state.messages.at(-1)).toEqual({
+      id: 9,
+      role: "assistant",
+      content: "Hi you!",
+    });
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("ignores streaming frames for another session (multi-tab demux)", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 999,
+        content: "X",
+      });
+    });
+    expect(useChatStore.getState().streamingText).toBe("");
+  });
+
+  test("surfaces a null-session error but ignores another session's error", () => {
+    connectAndOpen();
+    act(() => {
+      useChatStore.setState({ sessionId: 5 });
+      lastSocket().mockMessage({
+        type: "error",
+        session_id: 999,
+        detail: "other tab",
+      });
+    });
+    expect(useChatStore.getState().error).toBeNull();
+
+    act(() => {
+      lastSocket().mockMessage({
+        type: "error",
+        session_id: null,
+        detail: "Invalid message payload.",
+      });
+    });
+    expect(useChatStore.getState().error).toBe("Invalid message payload.");
+  });
+
+  test("post-ack watchdog fires when no start follows the ack", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/unavailable/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("post-ack watchdog is cleared once start arrives", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+    expect(useChatStore.getState().error).toBeNull();
+  });
+
+  test("max-turn watchdog fires when no end follows start", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(310000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/too long/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("reconnects with backoff on an unexpected close", () => {
+    connectAndOpen();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    act(() => {
+      lastSocket().mockServerClose(1006); // abnormal closure
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.RECONNECTING,
+    );
+    act(() => {
+      jest.advanceTimersByTime(1000); // first backoff step
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  test("does not reconnect on a clean close", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockServerClose(1000); // normal closure
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CLOSED,
+    );
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -1,0 +1,100 @@
+import {
+  useChatStore,
+  ConnectionState,
+  MessageRole,
+} from "../../src/stores/useChatStore";
+
+const initialState = {
+  isOpen: false,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.IDLE,
+  error: null,
+};
+
+describe("useChatStore reducers", () => {
+  beforeEach(() => {
+    useChatStore.setState(initialState);
+  });
+
+  test("toggle flips isOpen", () => {
+    useChatStore.getState().toggle();
+    expect(useChatStore.getState().isOpen).toBe(true);
+    useChatStore.getState().toggle();
+    expect(useChatStore.getState().isOpen).toBe(false);
+  });
+
+  test("applyAck binds the session id", () => {
+    useChatStore.getState().applyAck({ session_id: 42 });
+    expect(useChatStore.getState().sessionId).toBe(42);
+  });
+
+  test("enqueueUserMessage appends the user message and locks the turn", () => {
+    useChatStore.setState({ error: "stale" });
+    useChatStore.getState().enqueueUserMessage("hello");
+    const state = useChatStore.getState();
+    expect(state.messages).toEqual([
+      { role: MessageRole.USER, content: "hello" },
+    ]);
+    expect(state.isStreaming).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  test("applyStart resets the streaming turn", () => {
+    useChatStore.setState({
+      streamingText: "leftover",
+      currentTool: "search_jobs",
+    });
+    useChatStore.getState().applyStart();
+    const state = useChatStore.getState();
+    expect(state.streamingText).toBe("");
+    expect(state.currentTool).toBeNull();
+    expect(state.isStreaming).toBe(true);
+  });
+
+  test("applyStatus sets the current tool", () => {
+    useChatStore.getState().applyStatus({ tool: "get_job_details" });
+    expect(useChatStore.getState().currentTool).toBe("get_job_details");
+  });
+
+  test("applyToken appends streaming text incrementally", () => {
+    useChatStore.getState().applyToken({ content: "Hel" });
+    useChatStore.getState().applyToken({ content: "lo" });
+    expect(useChatStore.getState().streamingText).toBe("Hello");
+  });
+
+  test("applyEnd commits the assistant message and clears the turn", () => {
+    useChatStore.setState({
+      streamingText: "Hel",
+      currentTool: "search_jobs",
+      isStreaming: true,
+    });
+    useChatStore.getState().applyEnd({ message_id: 7, content: "Hello there" });
+    const state = useChatStore.getState();
+    expect(state.messages).toEqual([
+      { id: 7, role: MessageRole.ASSISTANT, content: "Hello there" },
+    ]);
+    expect(state.streamingText).toBe("");
+    expect(state.currentTool).toBeNull();
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("applyError surfaces the detail and ends the turn", () => {
+    useChatStore.setState({ streamingText: "partial", isStreaming: true });
+    useChatStore.getState().applyError("boom");
+    const state = useChatStore.getState();
+    expect(state.error).toBe("boom");
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingText).toBe("");
+  });
+
+  test("setConnectionState updates the badge state", () => {
+    useChatStore.getState().setConnectionState(ConnectionState.CONNECTED);
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CONNECTED,
+    );
+  });
+});


### PR DESCRIPTION
# (Part of #3763) React chat panel with WebSocket streaming

## Description

Refs #3763

Adds the frontend chat interface that connects to the chatbot WebSocket consumer
(merged in #3757) and renders the agent's streaming responses in real time.

### Components (`frontend/src/components/chat/`)

- **`ChatPanel`**: reactstrap `Offcanvas` drawer mounted once in `AppMain` (survives
  page navigation). Connection-state badge (Idle → Connecting → Connected → Disconnected).
- **`ChatMessageList`**: scrollable conversation with auto-scroll, live "Thinking…" /
  "Running <tool>…" indicator, and a streaming bubble that renders incrementally.
- **`ChatMessage`**: user bubbles (plain text, right-aligned) and assistant bubbles
  (GFM markdown via `react-markdown` + `remark-gfm`, left-aligned). No `rehype-raw`
  (XSS-safe by default).
- **`ChatComposer`**: textarea + send button, Enter sends / Shift+Enter newline, locked
  while a turn is streaming or the socket is not connected. Client-side 4096 char cap
  mirrors `MessageRequestSerializer`.
- **`chatMarkdown`**: isolated GFM renderer (separate from the shared `markdownToHtml` so
  existing markdown rendering is not affected).

### State (`frontend/src/stores/useChatStore.jsx`)

Zustand store following the existing IntelOwl convention (no non-serializable refs in the
store). Owns: drawer visibility, session id, committed messages, streaming text, current
tool, connection state, error text. Reducers mirror the server event types
(`applyAck/Start/Status/Token/End/Error`).

### Transport (`useChatWebSocket` hook)

- Lazy connect on first drawer open; socket stays alive across open/close.
- Capped exponential backoff reconnect (1s → 30s, max 5 attempts).
- Session demux: `start/status/token/end` frames carry `session_id`, the hook drops frames
  that belong to another tab's session.
- Two watchdog timers: post-ack (20s, catches dead chatbot worker) and max-turn (310s,
  catches dropped socket / hard-killed worker).
- Clean teardown on unmount (NORMAL_CLOSURE 1000).

### Integration points

- `AppHeader`: "Assistant" button (chat bubble icon) toggles the drawer for authenticated users.
- `AppMain` Layout: `<ChatPanel />` mounted alongside `<Toast />`.
- `apiURLs.js`: `WEBSOCKET_CHAT_URI` constant (`ws/chat`).
- `setupProxy.js`: `/ws/chat` dev proxy entry (mirrors the existing `/ws/jobs` pattern).

### New dependency

- `remark-gfm` ^3.0.1 (GFM tables/strikethrough for agent markdown output).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin was added or changed, in which case documentation was updated (N/A)
- [x] I have inspected the API schema (N/A: frontend only, no REST changes)
- [x] External libraries: `remark-gfm` is MIT licensed
- [x] Linters (`eslint`, `prettier`) gave 0 errors (pre-commit hooks pass)
- [x] I have added tests for the feature. All tests gave 0 errors (34 new tests, 6 suites).
- [x] If the GUI has been modified:
  - [x] I have provided a screenshot of the result in the PR.
  - [x] I have created new frontend tests for the new components.
