### PR TITLE
[GSoC 2026] Add chat sessions list with backend titles and unlocked navigation

### DIFF
--- a/api_app/chatbot_manager/serializers/chat.py
+++ b/api_app/chatbot_manager/serializers/chat.py
@@ -7,10 +7,12 @@ from ..models import ChatMessage, ChatSession
 
 
 class ChatSessionSerializer(serializers.ModelSerializer):
+    title = serializers.CharField(read_only=True, default=None)
+
     class Meta:
         model = ChatSession
-        fields = ["id", "created_at", "updated_at"]
-        read_only_fields = ["id", "created_at", "updated_at"]
+        fields = ["id", "created_at", "updated_at", "title"]
+        read_only_fields = ["id", "created_at", "updated_at", "title"]
 
 
 class ChatMessageSerializer(serializers.ModelSerializer):

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -3,6 +3,8 @@
 
 import logging
 
+from django.db.models import OuterRef, Subquery
+from django.db.models.functions import Substr
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -29,8 +31,27 @@ class ChatSessionViewSet(ModelViewSet):
     permission_classes = [IsAuthenticated]
     http_method_names = ["get", "post", "delete", "head", "options"]
 
+    # Max characters for the annotated session title; keeps list rows single-line.
+    SESSION_TITLE_MAX_LEN = 40
+
     def get_queryset(self):
-        return ChatSession.objects.filter(user=self.request.user)
+        qs = ChatSession.objects.filter(user=self.request.user)
+        # Annotate a title only when listing — single-object GETs (detail/messages) don't need it
+        # and the extra Subquery would be wasted work.
+        if self.action == "list":
+            first_user_msg = (
+                ChatMessage.objects.filter(
+                    session=OuterRef("pk"),
+                    role=ChatMessage.Role.USER,
+                )
+                .order_by("timestamp")
+                .values("content")[:1]
+            )
+            qs = qs.annotate(
+                _raw_title=Subquery(first_user_msg),
+                title=Substr("_raw_title", 1, self.SESSION_TITLE_MAX_LEN),
+            )
+        return qs
 
     def perform_create(self, serializer):
         serializer.save(user=self.request.user)

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intelowl",
-  "version": "6.4.0",
+  "version": "6.6.1",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "intelowl",
-      "version": "6.4.0",
+      "version": "6.6.1",
       "dependencies": {
         "@certego/certego-ui": "^0.1.19",
         "@dagrejs/dagre": "^1.1.4",
@@ -19,6 +19,7 @@
         "date-fns-tz": "^3.2.0",
         "flag-icons": "^7.2.3",
         "formik": "^2.4.6",
+        "http-proxy-middleware": "^2.0.6",
         "js-cookie": "^3.0.5",
         "md5": "^2.3.0",
         "prop-types": "^15.8.1",
@@ -37,11 +38,13 @@
         "reactflow": "^11.11.4",
         "reactstrap": "^9.2.3",
         "recharts": "^2.13.0",
+        "remark-gfm": "^3.0.1",
         "zustand": "^4.5.4"
       },
       "devDependencies": {
         "@babel/preset-env": "^7.25.8",
         "@babel/preset-react": "^7.25.7",
+        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.5.2",
@@ -55,7 +58,6 @@
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-react-hooks": "^4.6.2",
-        "http-proxy-middleware": "^2.0.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.3.3",
@@ -126,7 +128,6 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
-      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -715,7 +716,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -1511,7 +1511,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -3831,7 +3830,6 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4295,92 +4293,31 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=14"
+        "node": ">=18"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
-      "version": "4.3.0",
-      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+    "node_modules/@testing-library/dom/node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
       "dev": true,
       "dependencies": {
-        "color-convert": "^2.0.1"
-      },
-      "engines": {
-        "node": ">=8"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/chalk": {
-      "version": "4.1.2",
-      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-      "dev": true,
-      "dependencies": {
-        "ansi-styles": "^4.1.0",
-        "supports-color": "^7.1.0"
-      },
-      "engines": {
-        "node": ">=10"
-      },
-      "funding": {
-        "url": "https://github.com/chalk/chalk?sponsor=1"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-convert": {
-      "version": "2.0.1",
-      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-      "dev": true,
-      "dependencies": {
-        "color-name": "~1.1.4"
-      },
-      "engines": {
-        "node": ">=7.0.0"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/color-name": {
-      "version": "1.1.4",
-      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-      "dev": true
-    },
-    "node_modules/@testing-library/dom/node_modules/has-flag": {
-      "version": "4.0.0",
-      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-      "dev": true,
-      "engines": {
-        "node": ">=8"
-      }
-    },
-    "node_modules/@testing-library/dom/node_modules/supports-color": {
-      "version": "7.2.0",
-      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-      "dev": true,
-      "dependencies": {
-        "has-flag": "^4.0.0"
-      },
-      "engines": {
-        "node": ">=8"
+        "dequal": "^2.0.3"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -5172,7 +5109,6 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5393,7 +5329,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5805,7 +5740,6 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5883,7 +5817,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6299,7 +6232,6 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6310,7 +6242,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -6830,7 +6761,6 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
-      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -6878,7 +6808,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -7028,6 +6957,15 @@
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw==",
       "engines": {
         "node": ">=4"
+      }
+    },
+    "node_modules/ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
       }
     },
     "node_modules/chalk": {
@@ -7723,7 +7661,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8094,7 +8031,6 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8245,7 +8181,6 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -9035,7 +8970,6 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
-      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9228,7 +9162,6 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -9303,7 +9236,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
-      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -9333,7 +9265,6 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
-      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9365,7 +9296,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9466,7 +9396,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10483,7 +10412,6 @@
           "url": "https://opencollective.com/formik"
         }
       ],
-      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -14938,6 +14866,15 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "node_modules/longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -15046,6 +14983,15 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
+    },
     "node_modules/match-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
@@ -15089,6 +15035,32 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-find-and-replace/node_modules/escape-string-regexp": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+      "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/mdast-util-from-markdown": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
@@ -15112,6 +15084,107 @@
         "url": "https://opencollective.com/unified"
       }
     },
+    "node_modules/mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "dependencies": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/mdast-util-to-hast": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
@@ -15125,6 +15198,25 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
       },
       "funding": {
         "type": "opencollective",
@@ -15301,6 +15393,120 @@
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
         "uvu": "^0.5.0"
+      }
+    },
+    "node_modules/micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "dependencies": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "dependencies": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "dependencies": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "dependencies": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "dependencies": {
+        "micromark-util-types": "^1.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
+    "node_modules/micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "dependencies": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
       }
     },
     "node_modules/micromark-factory-destination": {
@@ -15738,7 +15944,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16498,9 +16703,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -16643,7 +16848,6 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
-      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -17790,7 +17994,6 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18153,7 +18356,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18390,7 +18592,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18629,7 +18830,6 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18652,7 +18852,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
-      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -19296,7 +19495,6 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -20377,7 +20575,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -20496,7 +20693,6 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
-      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -20788,6 +20984,21 @@
         "node": ">= 0.10"
       }
     },
+    "node_modules/remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "dependencies": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/unified"
+      }
+    },
     "node_modules/remark-parse": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
@@ -20987,7 +21198,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -21162,7 +21372,6 @@
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
       "license": "MIT",
-      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -22104,7 +22313,6 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
-      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -22920,8 +23128,7 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "peer": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -22965,7 +23172,6 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23659,7 +23865,6 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
-      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -23728,7 +23933,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -23778,7 +23982,6 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
-      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -23837,7 +24040,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24168,7 +24370,6 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24563,6 +24764,15 @@
           "optional": true
         }
       }
+    },
+    "node_modules/zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==",
+      "funding": {
+        "type": "github",
+        "url": "https://github.com/sponsors/wooorm"
+      }
     }
   },
   "dependencies": {
@@ -24609,7 +24819,6 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
-      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -25007,7 +25216,6 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
-      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
       }
@@ -25491,7 +25699,6 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
-      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -27028,8 +27235,7 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
-      "peer": true
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
     },
     "@reactflow/background": {
       "version": "11.3.14",
@@ -27332,68 +27538,28 @@
       }
     },
     "@testing-library/dom": {
-      "version": "9.3.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
-      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.1.3",
-        "chalk": "^4.1.0",
+        "aria-query": "5.3.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "ansi-styles": {
-          "version": "4.3.0",
-          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
-          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
+        "aria-query": {
+          "version": "5.3.0",
+          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
           "dev": true,
           "requires": {
-            "color-convert": "^2.0.1"
-          }
-        },
-        "chalk": {
-          "version": "4.1.2",
-          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
-          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "^4.1.0",
-            "supports-color": "^7.1.0"
-          }
-        },
-        "color-convert": {
-          "version": "2.0.1",
-          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
-          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
-          "dev": true,
-          "requires": {
-            "color-name": "~1.1.4"
-          }
-        },
-        "color-name": {
-          "version": "1.1.4",
-          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
-          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
-          "dev": true
-        },
-        "has-flag": {
-          "version": "4.0.0",
-          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
-          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
-          "dev": true
-        },
-        "supports-color": {
-          "version": "7.2.0",
-          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
-          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
-          "dev": true,
-          "requires": {
-            "has-flag": "^4.0.0"
+            "dequal": "^2.0.3"
           }
         }
       }
@@ -28117,7 +28283,6 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
-      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28307,7 +28472,6 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
-      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -28618,8 +28782,7 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
-      "peer": true
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -28675,7 +28838,6 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
-      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -28962,7 +29124,6 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
-      "peer": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -28973,7 +29134,6 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -29370,7 +29530,6 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
       "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
-      "peer": true,
       "requires": {}
     },
     "brace-expansion": {
@@ -29399,7 +29558,6 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
-      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -29497,6 +29655,11 @@
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/case-sensitive-paths-webpack-plugin/-/case-sensitive-paths-webpack-plugin-2.4.0.tgz",
       "integrity": "sha512-roIFONhcxog0JSSWbvVAh3OocukmSgpqOH6YpMkCvav/ySIV3JKg4Dc8vYtQjYi/UxpNE36r/9v+VqTQqgkYmw=="
+    },
+    "ccount": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/ccount/-/ccount-2.0.1.tgz",
+      "integrity": "sha512-eyrF0jiFpY+3drT6383f1qhkbGsLSifNAjA61IUjZjmLCWjItY6LB9ft9YhoDgwfmclB2zhu51Lc7+95b8NRAg=="
     },
     "chalk": {
       "version": "2.4.2",
@@ -29991,7 +30154,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -30252,8 +30414,7 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
-      "peer": true
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -30357,8 +30518,7 @@
     "date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
-      "peer": true
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
     },
     "date-fns-tz": {
       "version": "3.2.0",
@@ -30955,7 +31115,6 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
-      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31205,7 +31364,6 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
-      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31258,7 +31416,6 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
-      "peer": true,
       "requires": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -31282,7 +31439,6 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
-      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -31328,7 +31484,6 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
-      "peer": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {
@@ -31370,7 +31525,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -32004,7 +32158,6 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
       "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
-      "peer": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -35287,6 +35440,11 @@
       "resolved": "https://registry.npmjs.org/lodash.uniq/-/lodash.uniq-4.5.0.tgz",
       "integrity": "sha512-xfBaXQd9ryd9dlSDvnvI0lvxfLJlYAZzXomUYzLKtUeOQvOP5piqAWuGtrhWeqaXK9hhoM/iyJc5AV+XfsX3HQ=="
     },
+    "longest-streak": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/longest-streak/-/longest-streak-3.1.0.tgz",
+      "integrity": "sha512-9Ri+o0JYgehTaVBBDoMqIl8GXtbWg711O3srftcHhZ0dqnETqLaoIK0x17fUw9rFSlK/0NlsKe0Ahhyl5pXE2g=="
+    },
     "loose-envify": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.4.0.tgz",
@@ -35370,6 +35528,11 @@
       "integrity": "sha512-hdN1wVrZbb29eBGiGjJbeP8JbKjq1urkHJ/LIP/NY48MZ1QVXUsQBV1G1zvYFHn1XE06cwjBsOI2K3Ulnj1YXQ==",
       "dev": true
     },
+    "markdown-table": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/markdown-table/-/markdown-table-3.0.4.tgz",
+      "integrity": "sha512-wiYz4+JrLyb/DqW2hkFJxP7Vd7JuTDm77fvbM8VfEQdmSMqcImWeeRbHwZjBjIFki/VaMK2BhFi7oUUZeM5bqw=="
+    },
     "match-sorter": {
       "version": "6.3.1",
       "resolved": "https://registry.npmjs.org/match-sorter/-/match-sorter-6.3.1.tgz",
@@ -35405,6 +35568,24 @@
         "unist-util-visit": "^4.0.0"
       }
     },
+    "mdast-util-find-and-replace": {
+      "version": "2.2.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-find-and-replace/-/mdast-util-find-and-replace-2.2.2.tgz",
+      "integrity": "sha512-MTtdFRz/eMDHXzeK6W3dO7mXUlF82Gom4y0oOgvHhh/HXZAGvIQDUvQ0SuUx+j2tv44b8xTHOm8K/9OoRFnXKw==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "escape-string-regexp": "^5.0.0",
+        "unist-util-is": "^5.0.0",
+        "unist-util-visit-parents": "^5.0.0"
+      },
+      "dependencies": {
+        "escape-string-regexp": {
+          "version": "5.0.0",
+          "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-5.0.0.tgz",
+          "integrity": "sha512-/veY75JbMK4j1yjvuUxuVsiS/hr/4iHs9FTT6cgTexxdE0Ly/glccBAkloH/DofkjRbZU3bnoj38mOmhkZ0lHw=="
+        }
+      }
+    },
     "mdast-util-from-markdown": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/mdast-util-from-markdown/-/mdast-util-from-markdown-1.3.1.tgz",
@@ -35424,6 +35605,79 @@
         "uvu": "^0.5.0"
       }
     },
+    "mdast-util-gfm": {
+      "version": "2.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm/-/mdast-util-gfm-2.0.2.tgz",
+      "integrity": "sha512-qvZ608nBppZ4icQlhQQIAdc6S3Ffj9RGmzwUKUWuEICFnd1LVkN3EktF7ZHAgfcEdvZB5owU9tQgt99e2TlLjg==",
+      "requires": {
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-gfm-autolink-literal": "^1.0.0",
+        "mdast-util-gfm-footnote": "^1.0.0",
+        "mdast-util-gfm-strikethrough": "^1.0.0",
+        "mdast-util-gfm-table": "^1.0.0",
+        "mdast-util-gfm-task-list-item": "^1.0.0",
+        "mdast-util-to-markdown": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-autolink-literal": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-autolink-literal/-/mdast-util-gfm-autolink-literal-1.0.3.tgz",
+      "integrity": "sha512-My8KJ57FYEy2W2LyNom4n3E7hKTuQk/0SES0u16tjA9Z3oFkF4RrC/hPAPgjlSpezsOvI8ObcXcElo92wn5IGA==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "ccount": "^2.0.0",
+        "mdast-util-find-and-replace": "^2.0.0",
+        "micromark-util-character": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-footnote": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-footnote/-/mdast-util-gfm-footnote-1.0.2.tgz",
+      "integrity": "sha512-56D19KOGbE00uKVj3sgIykpwKL179QsVFwx/DCW0u/0+URsryacI4MAdNJl0dh+u2PSsD9FtxPFbHCzJ78qJFQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0",
+        "micromark-util-normalize-identifier": "^1.0.0"
+      }
+    },
+    "mdast-util-gfm-strikethrough": {
+      "version": "1.0.3",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-strikethrough/-/mdast-util-gfm-strikethrough-1.0.3.tgz",
+      "integrity": "sha512-DAPhYzTYrRcXdMjUtUjKvW9z/FNAMTdU0ORyMcbmkwYNbKocDpdk+PX1L1dQgOID/+vVs1uBQ7ElrBQfZ0cuiQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-table/-/mdast-util-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-jjcpmNnQvrmN5Vx7y7lEc2iIOEytYv7rTvu+MeyAsSHTASGCCRA79Igg2uKssgOs1i1po8s3plW0sTu1wkkLGg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "markdown-table": "^3.0.0",
+        "mdast-util-from-markdown": "^1.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-gfm-task-list-item": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/mdast-util-gfm-task-list-item/-/mdast-util-gfm-task-list-item-1.0.2.tgz",
+      "integrity": "sha512-PFTA1gzfp1B1UaiJVyhJZA1rm0+Tzn690frc/L8vNX1Jop4STZgOE6bxUhnzdVSB+vm2GU1tIsuQcA9bxTQpMQ==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-to-markdown": "^1.3.0"
+      }
+    },
+    "mdast-util-phrasing": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/mdast-util-phrasing/-/mdast-util-phrasing-3.0.1.tgz",
+      "integrity": "sha512-WmI1gTXUBJo4/ZmSk79Wcb2HcjPJBzM1nlI/OUWA8yk2X9ik3ffNbBGsU+09BFmXaL1IBb9fiuvq6/KMiNycSg==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "unist-util-is": "^5.0.0"
+      }
+    },
     "mdast-util-to-hast": {
       "version": "12.3.0",
       "resolved": "https://registry.npmjs.org/mdast-util-to-hast/-/mdast-util-to-hast-12.3.0.tgz",
@@ -35437,6 +35691,21 @@
         "unist-util-generated": "^2.0.0",
         "unist-util-position": "^4.0.0",
         "unist-util-visit": "^4.0.0"
+      }
+    },
+    "mdast-util-to-markdown": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/mdast-util-to-markdown/-/mdast-util-to-markdown-1.5.0.tgz",
+      "integrity": "sha512-bbv7TPv/WC49thZPg3jXuqzuvI45IL2EVAr/KxF0BSdHsU0ceFHOmwQn6evxAh1GaoK/6GQ1wp4R4oW2+LFL/A==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "@types/unist": "^2.0.0",
+        "longest-streak": "^3.0.0",
+        "mdast-util-phrasing": "^3.0.0",
+        "mdast-util-to-string": "^3.0.0",
+        "micromark-util-decode-string": "^1.0.0",
+        "unist-util-visit": "^4.0.0",
+        "zwitch": "^2.0.0"
       }
     },
     "mdast-util-to-string": {
@@ -35562,6 +35831,92 @@
         "micromark-util-subtokenize": "^1.0.0",
         "micromark-util-symbol": "^1.0.0",
         "micromark-util-types": "^1.0.1",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm/-/micromark-extension-gfm-2.0.3.tgz",
+      "integrity": "sha512-vb9OoHqrhCmbRidQv/2+Bc6pkP0FrtlhurxZofvOEy5o8RtuuvTq+RQ1Vw5ZDNrVraQZu3HixESqbG+0iKk/MQ==",
+      "requires": {
+        "micromark-extension-gfm-autolink-literal": "^1.0.0",
+        "micromark-extension-gfm-footnote": "^1.0.0",
+        "micromark-extension-gfm-strikethrough": "^1.0.0",
+        "micromark-extension-gfm-table": "^1.0.0",
+        "micromark-extension-gfm-tagfilter": "^1.0.0",
+        "micromark-extension-gfm-task-list-item": "^1.0.0",
+        "micromark-util-combine-extensions": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-autolink-literal": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-autolink-literal/-/micromark-extension-gfm-autolink-literal-1.0.5.tgz",
+      "integrity": "sha512-z3wJSLrDf8kRDOh2qBtoTRD53vJ+CWIyo7uyZuxf/JAbNJjiHsOpG1y5wxk8drtv3ETAHutCu6N3thkOOgueWg==",
+      "requires": {
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-footnote": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-footnote/-/micromark-extension-gfm-footnote-1.1.2.tgz",
+      "integrity": "sha512-Yxn7z7SxgyGWRNa4wzf8AhYYWNrwl5q1Z8ii+CSTTIqVkmGZF1CElX2JI8g5yGoM3GAman9/PVCUFUSJ0kB/8Q==",
+      "requires": {
+        "micromark-core-commonmark": "^1.0.0",
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-normalize-identifier": "^1.0.0",
+        "micromark-util-sanitize-uri": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-strikethrough": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-strikethrough/-/micromark-extension-gfm-strikethrough-1.0.7.tgz",
+      "integrity": "sha512-sX0FawVE1o3abGk3vRjOH50L5TTLr3b5XMqnP9YDRb34M0v5OoZhG+OHFz1OffZ9dlwgpTBKaT4XW/AsUVnSDw==",
+      "requires": {
+        "micromark-util-chunked": "^1.0.0",
+        "micromark-util-classify-character": "^1.0.0",
+        "micromark-util-resolve-all": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-table": {
+      "version": "1.0.7",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-table/-/micromark-extension-gfm-table-1.0.7.tgz",
+      "integrity": "sha512-3ZORTHtcSnMQEKtAOsBQ9/oHp9096pI/UvdPtN7ehKvrmZZ2+bbWhi0ln+I9drmwXMt5boocn6OlwQzNXeVeqw==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
+        "uvu": "^0.5.0"
+      }
+    },
+    "micromark-extension-gfm-tagfilter": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-tagfilter/-/micromark-extension-gfm-tagfilter-1.0.2.tgz",
+      "integrity": "sha512-5XWB9GbAUSHTn8VPU8/1DBXMuKYT5uOgEjJb8gN3mW0PNW5OPHpSdojoqf+iq1xo7vWzw/P8bAHY0n6ijpXF7g==",
+      "requires": {
+        "micromark-util-types": "^1.0.0"
+      }
+    },
+    "micromark-extension-gfm-task-list-item": {
+      "version": "1.0.5",
+      "resolved": "https://registry.npmjs.org/micromark-extension-gfm-task-list-item/-/micromark-extension-gfm-task-list-item-1.0.5.tgz",
+      "integrity": "sha512-RMFXl2uQ0pNQy6Lun2YBYT9g9INXtWJULgbt01D/x8/6yJ2qpKyzdZD3pi6UIkzF++Da49xAelVKUeUMqd5eIQ==",
+      "requires": {
+        "micromark-factory-space": "^1.0.0",
+        "micromark-util-character": "^1.0.0",
+        "micromark-util-symbol": "^1.0.0",
+        "micromark-util-types": "^1.0.0",
         "uvu": "^0.5.0"
       }
     },
@@ -35779,7 +36134,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -36337,9 +36691,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -36426,7 +36780,6 @@
       "version": "8.4.27",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
       "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
-      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -37066,7 +37419,6 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
-      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -37321,7 +37673,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37498,7 +37849,6 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
-      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -37688,8 +38038,7 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
-      "peer": true
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
     },
     "react-router": {
       "version": "6.27.0",
@@ -37703,7 +38052,6 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
-      "peer": true,
       "requires": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -38188,7 +38536,6 @@
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
           "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
-          "peer": true,
           "requires": {
             "@jest/core": "^27.5.1",
             "import-local": "^3.0.2",
@@ -39011,7 +39358,6 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
-      "peer": true,
       "requires": {}
     },
     "react-textarea-autosize": {
@@ -39097,7 +39443,6 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
-      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -39330,6 +39675,17 @@
       "resolved": "https://registry.npmjs.org/relateurl/-/relateurl-0.2.7.tgz",
       "integrity": "sha512-G08Dxvm4iDN3MLM0EsP62EDV9IuhXPR6blNz6Utcp7zyV3tr4HVNINt6MpaRWbxoOHT3Q7YN2P+jaHX8vUbgog=="
     },
+    "remark-gfm": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/remark-gfm/-/remark-gfm-3.0.1.tgz",
+      "integrity": "sha512-lEFDoi2PICJyNrACFOfDD3JlLkuSbOa5Wd8EPt06HUdptv8Gn0bxYTdbU/XXQ3swAPkEaGxxPN9cbnMHvVu1Ig==",
+      "requires": {
+        "@types/mdast": "^3.0.0",
+        "mdast-util-gfm": "^2.0.0",
+        "micromark-extension-gfm": "^2.0.0",
+        "unified": "^10.0.0"
+      }
+    },
     "remark-parse": {
       "version": "10.0.2",
       "resolved": "https://registry.npmjs.org/remark-parse/-/remark-parse-10.0.2.tgz",
@@ -39467,7 +39823,6 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
-      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -39581,7 +39936,6 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
-      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -40299,7 +40653,6 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
-      "peer": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -40930,8 +41283,7 @@
     "tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
-      "peer": true
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
     },
     "tsutils": {
       "version": "3.21.0",
@@ -40964,8 +41316,7 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
-      "peer": true
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
     },
     "type-is": {
       "version": "1.6.18",
@@ -41439,7 +41790,6 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
-      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -41499,7 +41849,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41537,7 +41886,6 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
-      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -41575,7 +41923,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41816,7 +42163,6 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
-          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -42127,6 +42473,11 @@
       "requires": {
         "use-sync-external-store": "1.2.2"
       }
+    },
+    "zwitch": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/zwitch/-/zwitch-2.0.4.tgz",
+      "integrity": "sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A=="
     }
   }
 }

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "intelowl",
-  "version": "6.6.1",
+  "version": "6.4.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "intelowl",
-      "version": "6.6.1",
+      "version": "6.4.0",
       "dependencies": {
         "@certego/certego-ui": "^0.1.19",
         "@dagrejs/dagre": "^1.1.4",
@@ -19,7 +19,6 @@
         "date-fns-tz": "^3.2.0",
         "flag-icons": "^7.2.3",
         "formik": "^2.4.6",
-        "http-proxy-middleware": "^2.0.6",
         "js-cookie": "^3.0.5",
         "md5": "^2.3.0",
         "prop-types": "^15.8.1",
@@ -44,7 +43,6 @@
       "devDependencies": {
         "@babel/preset-env": "^7.25.8",
         "@babel/preset-react": "^7.25.7",
-        "@testing-library/dom": "^10.4.1",
         "@testing-library/jest-dom": "^6.6.3",
         "@testing-library/react": "^12.1.5",
         "@testing-library/user-event": "^14.5.2",
@@ -58,6 +56,7 @@
         "eslint-plugin-jsx-a11y": "^6.10.0",
         "eslint-plugin-react": "^7.37.1",
         "eslint-plugin-react-hooks": "^4.6.2",
+        "http-proxy-middleware": "^2.0.6",
         "jest": "^29.7.0",
         "jest-environment-jsdom": "^29.7.0",
         "prettier": "^3.3.3",
@@ -128,6 +127,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "dependencies": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -716,6 +716,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-plugin-utils": "^7.22.5"
       },
@@ -1511,6 +1512,7 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
+      "peer": true,
       "dependencies": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -3830,6 +3832,7 @@
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
       "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true,
       "funding": {
         "type": "opencollective",
         "url": "https://opencollective.com/popperjs"
@@ -4293,31 +4296,92 @@
       }
     },
     "node_modules/@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
       "dev": true,
       "dependencies": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "engines": {
-        "node": ">=18"
+        "node": ">=14"
       }
     },
-    "node_modules/@testing-library/dom/node_modules/aria-query": {
-      "version": "5.3.0",
-      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+    "node_modules/@testing-library/dom/node_modules/ansi-styles": {
+      "version": "4.3.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+      "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
       "dev": true,
       "dependencies": {
-        "dequal": "^2.0.3"
+        "color-convert": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/chalk": {
+      "version": "4.1.2",
+      "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+      "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+      "dev": true,
+      "dependencies": {
+        "ansi-styles": "^4.1.0",
+        "supports-color": "^7.1.0"
+      },
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-convert": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+      "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+      "dev": true,
+      "dependencies": {
+        "color-name": "~1.1.4"
+      },
+      "engines": {
+        "node": ">=7.0.0"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/color-name": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+      "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+      "dev": true
+    },
+    "node_modules/@testing-library/dom/node_modules/has-flag": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+      "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+      "dev": true,
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/@testing-library/dom/node_modules/supports-color": {
+      "version": "7.2.0",
+      "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+      "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+      "dev": true,
+      "dependencies": {
+        "has-flag": "^4.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/@testing-library/jest-dom": {
@@ -5109,6 +5173,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
+      "peer": true,
       "dependencies": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -5329,6 +5394,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "dependencies": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -5740,6 +5806,7 @@
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
       "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "peer": true,
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -5817,6 +5884,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -6232,6 +6300,7 @@
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -6242,6 +6311,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -6761,6 +6831,7 @@
           "url": "https://opencollective.com/bootstrap"
         }
       ],
+      "peer": true,
       "peerDependencies": {
         "@popperjs/core": "^2.11.8"
       }
@@ -6808,6 +6879,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -7661,6 +7733,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -8031,6 +8104,7 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
       "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true,
       "engines": {
         "node": ">=12"
       }
@@ -8181,6 +8255,7 @@
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
       "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
       "license": "MIT",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/kossnocorp"
@@ -8970,6 +9045,7 @@
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
       "deprecated": "This version is no longer supported. Please see https://eslint.org/version-support for other options.",
+      "peer": true,
       "dependencies": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -9162,6 +9238,7 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "peer": true,
       "dependencies": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -9236,6 +9313,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "peer": true,
       "dependencies": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -9265,6 +9343,7 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "peer": true,
       "dependencies": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -9296,6 +9375,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -9396,6 +9476,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -10412,6 +10493,7 @@
           "url": "https://opencollective.com/formik"
         }
       ],
+      "peer": true,
       "dependencies": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -15944,6 +16026,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -16703,9 +16786,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "node_modules/picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -16848,6 +16931,7 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "peer": true,
       "dependencies": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -17994,6 +18078,7 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "peer": true,
       "dependencies": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -18356,6 +18441,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -18592,6 +18678,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "dependencies": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -18830,6 +18917,7 @@
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
       "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true,
       "engines": {
         "node": ">=0.10.0"
       }
@@ -18852,6 +18940,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "peer": true,
       "dependencies": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -19495,6 +19584,7 @@
       "version": "27.5.1",
       "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
       "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+      "peer": true,
       "dependencies": {
         "@jest/core": "^27.5.1",
         "import-local": "^3.0.2",
@@ -20575,6 +20665,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
+      "peer": true,
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/tannerlinsley"
@@ -20693,6 +20784,7 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
+      "peer": true,
       "dependencies": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -21198,6 +21290,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "bin": {
         "rollup": "dist/bin/rollup"
       },
@@ -21372,6 +21465,7 @@
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
       "license": "MIT",
+      "peer": true,
       "dependencies": {
         "chokidar": "^4.0.0",
         "immutable": "^5.0.2",
@@ -22313,6 +22407,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "peer": true,
       "dependencies": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -23128,7 +23223,8 @@
     "node_modules/tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "peer": true
     },
     "node_modules/tsutils": {
       "version": "3.21.0",
@@ -23172,6 +23268,7 @@
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
       "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true,
       "engines": {
         "node": ">=10"
       },
@@ -23865,6 +23962,7 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+      "peer": true,
       "dependencies": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -23933,6 +24031,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -23982,6 +24081,7 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "peer": true,
       "dependencies": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -24040,6 +24140,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24370,6 +24471,7 @@
       "version": "8.12.0",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
       "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+      "peer": true,
       "dependencies": {
         "fast-deep-equal": "^3.1.1",
         "json-schema-traverse": "^1.0.0",
@@ -24819,6 +24921,7 @@
       "version": "7.22.9",
       "resolved": "https://registry.npmjs.org/@babel/core/-/core-7.22.9.tgz",
       "integrity": "sha512-G2EgeufBcYw27U4hhoIwFcgc1XU7TlXJ3mv04oOv1WCuo900U/anZSPzEqNjwdjgffkk2Gs0AN0dW1CKVLcG7w==",
+      "peer": true,
       "requires": {
         "@ampproject/remapping": "^2.2.0",
         "@babel/code-frame": "^7.22.5",
@@ -25216,6 +25319,7 @@
       "version": "7.22.5",
       "resolved": "https://registry.npmjs.org/@babel/plugin-syntax-flow/-/plugin-syntax-flow-7.22.5.tgz",
       "integrity": "sha512-9RdCl0i+q0QExayk2nOS7853w08yLucnnPML6EN9S8fgMPVtdLDCdx/cOQ/i44Lb9UeQX9A35yaqBBOMMZxPxQ==",
+      "peer": true,
       "requires": {
         "@babel/helper-plugin-utils": "^7.22.5"
       }
@@ -25699,6 +25803,7 @@
       "version": "7.25.7",
       "resolved": "https://registry.npmjs.org/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.25.7.tgz",
       "integrity": "sha512-vILAg5nwGlR9EXE8JIOX4NHXd49lrYbN8hnjffDtoULwpL9hUx/N55nqh2qd0q6FyNDfjl9V79ecKGvFbcSA0Q==",
+      "peer": true,
       "requires": {
         "@babel/helper-annotate-as-pure": "^7.25.7",
         "@babel/helper-module-imports": "^7.25.7",
@@ -27235,7 +27340,8 @@
     "@popperjs/core": {
       "version": "2.11.8",
       "resolved": "https://registry.npmjs.org/@popperjs/core/-/core-2.11.8.tgz",
-      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A=="
+      "integrity": "sha512-P1st0aksCrn9sGZhp8GMYwBnQsbvAWsZAX44oXNNvLHGqAOcoVxmjZiohstwQ7SqKnbR47akdNi+uleWD8+g6A==",
+      "peer": true
     },
     "@reactflow/background": {
       "version": "11.3.14",
@@ -27538,28 +27644,68 @@
       }
     },
     "@testing-library/dom": {
-      "version": "10.4.1",
-      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
-      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "version": "9.3.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-9.3.1.tgz",
+      "integrity": "sha512-0DGPd9AR3+iDTjGoMpxIkAsUihHZ3Ai6CneU6bRRrffXMgzCdlNk43jTrD2/5LT6CBb3MWTP8v510JzYtahD2w==",
       "dev": true,
       "requires": {
         "@babel/code-frame": "^7.10.4",
         "@babel/runtime": "^7.12.5",
         "@types/aria-query": "^5.0.1",
-        "aria-query": "5.3.0",
+        "aria-query": "5.1.3",
+        "chalk": "^4.1.0",
         "dom-accessibility-api": "^0.5.9",
         "lz-string": "^1.5.0",
-        "picocolors": "1.1.1",
         "pretty-format": "^27.0.2"
       },
       "dependencies": {
-        "aria-query": {
-          "version": "5.3.0",
-          "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
-          "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+        "ansi-styles": {
+          "version": "4.3.0",
+          "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-4.3.0.tgz",
+          "integrity": "sha512-zbB9rCJAT1rbjiVDb2hqKFHNYLxgtk8NURxZ3IZwD3F6NtxbXZQCnnSi1Lkx+IDohdPlFp222wVALIheZJQSEg==",
           "dev": true,
           "requires": {
-            "dequal": "^2.0.3"
+            "color-convert": "^2.0.1"
+          }
+        },
+        "chalk": {
+          "version": "4.1.2",
+          "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
+          "integrity": "sha512-oKnbhFyRIXpUuez8iBMmyEa4nbj4IOQyuhc/wy9kY7/WVPcwIO9VA668Pu8RkO7+0G76SLROeyw9CpQ061i4mA==",
+          "dev": true,
+          "requires": {
+            "ansi-styles": "^4.1.0",
+            "supports-color": "^7.1.0"
+          }
+        },
+        "color-convert": {
+          "version": "2.0.1",
+          "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-2.0.1.tgz",
+          "integrity": "sha512-RRECPsj7iu/xb5oKYcsFHSppFNnsj/52OVTRKb4zP5onXwVF3zVmmToNcOfGC+CRDpfK/U584fMg38ZHCaElKQ==",
+          "dev": true,
+          "requires": {
+            "color-name": "~1.1.4"
+          }
+        },
+        "color-name": {
+          "version": "1.1.4",
+          "resolved": "https://registry.npmjs.org/color-name/-/color-name-1.1.4.tgz",
+          "integrity": "sha512-dOy+3AuW3a2wNbZHIuMZpTcgjGuLU/uBL/ubcZF9OXbDo8ff4O8yVp5Bf0efS8uEoYo5q4Fx7dY9OgQGXgAsQA==",
+          "dev": true
+        },
+        "has-flag": {
+          "version": "4.0.0",
+          "resolved": "https://registry.npmjs.org/has-flag/-/has-flag-4.0.0.tgz",
+          "integrity": "sha512-EykJT/Q1KjTWctppgIAgfSO0tKVuZUjhgMr17kqTumMl6Afv3EISleU7qZUzoXDFTAHTDC4NOoG/ZxU3EvlMPQ==",
+          "dev": true
+        },
+        "supports-color": {
+          "version": "7.2.0",
+          "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
+          "integrity": "sha512-qpCAvRl9stuOHveKsn7HncJRvv501qIacKzQlO/+Lwxc9+0q2wLyv4Dfvt80/DPn2pqOBsJdDiogXGR9+OvwRw==",
+          "dev": true,
+          "requires": {
+            "has-flag": "^4.0.0"
           }
         }
       }
@@ -28283,6 +28429,7 @@
       "version": "18.2.16",
       "resolved": "https://registry.npmjs.org/@types/react/-/react-18.2.16.tgz",
       "integrity": "sha512-LLFWr12ZhBJ4YVw7neWLe6Pk7Ey5R9OCydfuMsz1L8bZxzaawJj2p06Q8/EFEHDeTBQNFLF62X+CG7B2zIyu0Q==",
+      "peer": true,
       "requires": {
         "@types/prop-types": "*",
         "@types/scheduler": "*",
@@ -28472,6 +28619,7 @@
       "version": "5.62.0",
       "resolved": "https://registry.npmjs.org/@typescript-eslint/parser/-/parser-5.62.0.tgz",
       "integrity": "sha512-VlJEV0fOQ7BExOsHYAGrgbEiZoi8D+Bl2+f6V2RrXerRSylnp+ZBHmPvaIa8cz0Ajx7WO7Z5RqfgYg7ED1nRhA==",
+      "peer": true,
       "requires": {
         "@typescript-eslint/scope-manager": "5.62.0",
         "@typescript-eslint/types": "5.62.0",
@@ -28782,7 +28930,8 @@
     "acorn": {
       "version": "8.10.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.10.0.tgz",
-      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw=="
+      "integrity": "sha512-F0SAmZ8iUtS//m8DmCTA0jlh6TDKkHQyK6xc6V4KDTyZKA9dnvX9/3sRTVQrWm79glUAZbnmmNcdYwUIHWVybw==",
+      "peer": true
     },
     "acorn-globals": {
       "version": "7.0.1",
@@ -28838,6 +28987,7 @@
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
       "integrity": "sha512-j3fVLgvTo527anyYyJOGTYJbG+vnnQYvE0m5mmkc1TK+nxAppkCLMIL0aZ4dblVCNoGShhm+kzE4ZUykBoMg4g==",
+      "peer": true,
       "requires": {
         "fast-deep-equal": "^3.1.1",
         "fast-json-stable-stringify": "^2.0.0",
@@ -29124,6 +29274,7 @@
       "version": "1.8.3",
       "resolved": "https://registry.npmjs.org/axios/-/axios-1.8.3.tgz",
       "integrity": "sha512-iP4DebzoNlP/YN2dpwCgb8zoCmhtkajzS48JvwmkSkXvPI3DHc7m+XYL5tGnSlJtR6nImXZmdCuN5aP8dh1d8A==",
+      "peer": true,
       "requires": {
         "follow-redirects": "^1.15.6",
         "form-data": "^4.0.0",
@@ -29134,6 +29285,7 @@
       "version": "3.1.5",
       "resolved": "https://registry.npmjs.org/axios-hooks/-/axios-hooks-3.1.5.tgz",
       "integrity": "sha512-mU4WZ9c6YiOTxgTIKbswoHvb/b9fWXa2FxNFKI/hVcfD9Qemz1r9KLfRSVZf1GZg8nFry7oTM5gxNmPSn5PG0Q==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "7.18.9",
         "dequal": "2.0.3",
@@ -29530,6 +29682,7 @@
       "version": "5.3.3",
       "resolved": "https://registry.npmjs.org/bootstrap/-/bootstrap-5.3.3.tgz",
       "integrity": "sha512-8HLCdWgyoMguSO9o+aH+iuZ+aht+mzW0u3HIMzVu7Srrpv7EBBxTnrFlSCskwdY1+EOFQSm7uMJhNQHkdPcmjg==",
+      "peer": true,
       "requires": {}
     },
     "brace-expansion": {
@@ -29558,6 +29711,7 @@
       "version": "4.24.0",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.0.tgz",
       "integrity": "sha512-Rmb62sR1Zpjql25eSanFGEhAxcFwfA1K0GuQcLoaJBAcENegrQut3hYdhXFF1obQfiDyqIW/cLM5HSJ/9k884A==",
+      "peer": true,
       "requires": {
         "caniuse-lite": "^1.0.30001663",
         "electron-to-chromium": "^1.5.28",
@@ -30154,6 +30308,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -30414,7 +30569,8 @@
     "d3-selection": {
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/d3-selection/-/d3-selection-3.0.0.tgz",
-      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ=="
+      "integrity": "sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==",
+      "peer": true
     },
     "d3-shape": {
       "version": "3.2.0",
@@ -30518,7 +30674,8 @@
     "date-fns": {
       "version": "4.1.0",
       "resolved": "https://registry.npmjs.org/date-fns/-/date-fns-4.1.0.tgz",
-      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg=="
+      "integrity": "sha512-Ukq0owbQXxa/U3EGtsdVBkR1w7KOQ5gIBqdH2hkvknzZPYvBxb/aa6E8L7tmjFtkwZBu3UXBbjIgPo/Ez4xaNg==",
+      "peer": true
     },
     "date-fns-tz": {
       "version": "3.2.0",
@@ -31115,6 +31272,7 @@
       "version": "8.57.1",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-8.57.1.tgz",
       "integrity": "sha512-ypowyDxpVSYpkXr9WPv2PAZCtNip1Mv5KTW0SCurXv/9iOpcrH9PaqUElksqEB6pChqHGDRCFTyrZlGhnLNGiA==",
+      "peer": true,
       "requires": {
         "@eslint-community/eslint-utils": "^4.2.0",
         "@eslint-community/regexpp": "^4.6.1",
@@ -31364,6 +31522,7 @@
       "version": "2.31.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.31.0.tgz",
       "integrity": "sha512-ixmkI62Rbc2/w8Vfxyh1jQRTdRTF52VxwRVHl/ykPAmqG+Nb7/kNn+byLP0LxPgI7zWA16Jt82SybJInmMia3A==",
+      "peer": true,
       "requires": {
         "@rtsao/scc": "^1.1.0",
         "array-includes": "^3.1.8",
@@ -31416,6 +31575,7 @@
       "version": "6.10.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-jsx-a11y/-/eslint-plugin-jsx-a11y-6.10.0.tgz",
       "integrity": "sha512-ySOHvXX8eSN6zz8Bywacm7CvGNhUtdjvqfQDVe6020TUK34Cywkw7m0KsCCk1Qtm9G1FayfTN1/7mMYnYO2Bhg==",
+      "peer": true,
       "requires": {
         "aria-query": "~5.1.3",
         "array-includes": "^3.1.8",
@@ -31439,6 +31599,7 @@
       "version": "7.37.1",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react/-/eslint-plugin-react-7.37.1.tgz",
       "integrity": "sha512-xwTnwDqzbDRA8uJ7BMxPs/EXRB3i8ZfnOIp8BsxEQkT0nHPp+WWceqGgo6rKb9ctNi8GJLDT4Go5HAWELa/WMg==",
+      "peer": true,
       "requires": {
         "array-includes": "^3.1.8",
         "array.prototype.findlast": "^1.2.5",
@@ -31484,6 +31645,7 @@
       "version": "4.6.2",
       "resolved": "https://registry.npmjs.org/eslint-plugin-react-hooks/-/eslint-plugin-react-hooks-4.6.2.tgz",
       "integrity": "sha512-QzliNJq4GinDBcD8gPB5v0wh6g8q3SUi6EFF0x8N/BL9PoVs0atuGc47ozMRyOWAKdwaZ5OnbOEa3WR+dSGKuQ==",
+      "peer": true,
       "requires": {}
     },
     "eslint-plugin-testing-library": {
@@ -31525,6 +31687,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -32158,6 +32321,7 @@
       "version": "2.4.6",
       "resolved": "https://registry.npmjs.org/formik/-/formik-2.4.6.tgz",
       "integrity": "sha512-A+2EI7U7aG296q2TLGvNapDNTZp1khVt5Vk0Q/fyfSROss0V/V6+txt2aJnwEos44IxTCW/LYAi/zgWzlevj+g==",
+      "peer": true,
       "requires": {
         "@types/hoist-non-react-statics": "^3.3.1",
         "deepmerge": "^2.1.1",
@@ -36134,6 +36298,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -36691,9 +36856,9 @@
       "integrity": "sha512-7EAHlyLHI56VEIdK57uwHdHKIaAGbnXPiw0yWbarQZOKaKpvUIgW0jWRVLiatnM+XXlSwsanIBH/hzGMJulMow=="
     },
     "picocolors": {
-      "version": "1.1.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
-      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA=="
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
+      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
     },
     "picomatch": {
       "version": "2.3.1",
@@ -36780,6 +36945,7 @@
       "version": "8.4.27",
       "resolved": "https://registry.npmjs.org/postcss/-/postcss-8.4.27.tgz",
       "integrity": "sha512-gY/ACJtJPSmUFPDCHtX78+01fHa64FaU4zaaWfuh1MhGJISufJAH4cun6k/8fwsHYeK4UQmENQK+tRLCFJE8JQ==",
+      "peer": true,
       "requires": {
         "nanoid": "^3.3.6",
         "picocolors": "^1.0.0",
@@ -37419,6 +37585,7 @@
       "version": "6.0.13",
       "resolved": "https://registry.npmjs.org/postcss-selector-parser/-/postcss-selector-parser-6.0.13.tgz",
       "integrity": "sha512-EaV1Gl4mUEV4ddhDnv/xtj7sxwrwxdetHdWUGnT4VJQf+4d05v6lHYZr8N573k5Z0BViss7BDhfWtKS3+sfAqQ==",
+      "peer": true,
       "requires": {
         "cssesc": "^3.0.0",
         "util-deprecate": "^1.0.2"
@@ -37673,6 +37840,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react/-/react-17.0.2.tgz",
       "integrity": "sha512-gnhPt75i/dq/z3/6q/0asP78D0u592D5L1pd7M8P+dck6Fu/jJeL6iVVK23fptSUZj8Vjf++7wXA8UNclGQcbA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1"
@@ -37849,6 +38017,7 @@
       "version": "17.0.2",
       "resolved": "https://registry.npmjs.org/react-dom/-/react-dom-17.0.2.tgz",
       "integrity": "sha512-s4h96KtLDUQlsENhMn1ar8t2bEa+q/YAtj8pPPdIjPDGBDIVNsrD9aXNWqspUe6AzKCIG0C1HZZLqLV7qpOBGA==",
+      "peer": true,
       "requires": {
         "loose-envify": "^1.1.0",
         "object-assign": "^4.1.1",
@@ -38038,7 +38207,8 @@
     "react-refresh": {
       "version": "0.11.0",
       "resolved": "https://registry.npmjs.org/react-refresh/-/react-refresh-0.11.0.tgz",
-      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A=="
+      "integrity": "sha512-F27qZr8uUqwhWZboondsPx8tnC3Ct3SxZA3V5WyEvujRyyNv0VYPhoBg1gZ8/MV5tubQp76Trw8lTv9hzRBa+A==",
+      "peer": true
     },
     "react-router": {
       "version": "6.27.0",
@@ -38052,6 +38222,7 @@
       "version": "6.27.0",
       "resolved": "https://registry.npmjs.org/react-router-dom/-/react-router-dom-6.27.0.tgz",
       "integrity": "sha512-+bvtFWMC0DgAFrfKXKG9Fc+BcXWRUO1aJIihbB79xaeq0v5UzfvnM5houGUm1Y461WVRcgAQ+Clh5rdb1eCx4g==",
+      "peer": true,
       "requires": {
         "@remix-run/router": "1.20.0",
         "react-router": "6.27.0"
@@ -38536,6 +38707,7 @@
           "version": "27.5.1",
           "resolved": "https://registry.npmjs.org/jest/-/jest-27.5.1.tgz",
           "integrity": "sha512-Yn0mADZB89zTtjkPJEXwrac3LHudkQMR+Paqa8uxJHCBr9agxztUifWCyiYrjhMPBoUVBjyny0I7XH6ozDr7QQ==",
+          "peer": true,
           "requires": {
             "@jest/core": "^27.5.1",
             "import-local": "^3.0.2",
@@ -39358,6 +39530,7 @@
       "version": "7.8.0",
       "resolved": "https://registry.npmjs.org/react-table/-/react-table-7.8.0.tgz",
       "integrity": "sha512-hNaz4ygkZO4bESeFfnfOft73iBUj8K5oKi1EcSHPAibEydfsX2MyU6Z8KCr3mv3C9Kqqh71U+DhZkFvibbnPbA==",
+      "peer": true,
       "requires": {}
     },
     "react-textarea-autosize": {
@@ -39443,6 +39616,7 @@
       "version": "9.2.3",
       "resolved": "https://registry.npmjs.org/reactstrap/-/reactstrap-9.2.3.tgz",
       "integrity": "sha512-1nXy7FIBIoOgXr3AIHOpgzcZXdj6rZE5YvNSPd1hYgwv8X64m6TAJsU0ExlieJdlRXhaRfTYRSZoTWa127b0gw==",
+      "peer": true,
       "requires": {
         "@babel/runtime": "^7.12.5",
         "@popperjs/core": "^2.6.0",
@@ -39823,6 +39997,7 @@
       "version": "2.79.1",
       "resolved": "https://registry.npmjs.org/rollup/-/rollup-2.79.1.tgz",
       "integrity": "sha512-uKxbd0IhMZOhjAiD5oAFp7BqvkA4Dv47qpOCtaNvng4HBwdbWtdOh8f5nZNuk2rp51PMGk3bzfWu5oayNEuYnw==",
+      "peer": true,
       "requires": {
         "fsevents": "~2.3.2"
       }
@@ -39936,6 +40111,7 @@
       "resolved": "https://registry.npmjs.org/sass/-/sass-1.83.0.tgz",
       "integrity": "sha512-qsSxlayzoOjdvXMVLkzF84DJFc2HZEL/rFyGIKbbilYtAvlCxyuzUeff9LawTn4btVnLKg75Z8MMr1lxU1lfGw==",
       "devOptional": true,
+      "peer": true,
       "requires": {
         "@parcel/watcher": "^2.4.1",
         "chokidar": "^4.0.0",
@@ -40653,6 +40829,7 @@
       "resolved": "https://registry.npmjs.org/stylelint/-/stylelint-14.16.1.tgz",
       "integrity": "sha512-ErlzR/T3hhbV+a925/gbfc3f3Fep9/bnspMiJPorfGEmcBbXdS+oo6LrVtoUZ/w9fqD6o6k7PtUlCOsCRdjX/A==",
       "dev": true,
+      "peer": true,
       "requires": {
         "@csstools/selector-specificity": "^2.0.2",
         "balanced-match": "^2.0.0",
@@ -41283,7 +41460,8 @@
     "tslib": {
       "version": "2.6.1",
       "resolved": "https://registry.npmjs.org/tslib/-/tslib-2.6.1.tgz",
-      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig=="
+      "integrity": "sha512-t0hLfiEKfMUoqhG+U1oid7Pva4bbDPHYfJNiB7BiIjRkj1pyC++4N3huJfqY6aRH6VTB0rvtzQwjM4K6qpfOig==",
+      "peer": true
     },
     "tsutils": {
       "version": "3.21.0",
@@ -41316,7 +41494,8 @@
     "type-fest": {
       "version": "0.21.3",
       "resolved": "https://registry.npmjs.org/type-fest/-/type-fest-0.21.3.tgz",
-      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w=="
+      "integrity": "sha512-t0rzBq87m3fVcduHDUFhKmyyX+9eo6WQjZvf51Ea/M0Q7+T374Jp1aUiyUl0GKxp8M/OETVHSDvmkyPgvX+X2w==",
+      "peer": true
     },
     "type-is": {
       "version": "1.6.18",
@@ -41790,6 +41969,7 @@
       "version": "5.88.2",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.88.2.tgz",
       "integrity": "sha512-JmcgNZ1iKj+aiR0OvTYtWQqJwq37Pf683dY9bVORwVbUrDhLhdn/PlO2sHsFHPkj7sHNQF3JwaAkp49V+Sq1tQ==",
+      "peer": true,
       "requires": {
         "@types/eslint-scope": "^3.7.3",
         "@types/estree": "^1.0.0",
@@ -41849,6 +42029,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -41886,6 +42067,7 @@
       "version": "4.15.1",
       "resolved": "https://registry.npmjs.org/webpack-dev-server/-/webpack-dev-server-4.15.1.tgz",
       "integrity": "sha512-5hbAst3h3C3L8w6W4P96L5vaV0PxSmJhxZvWKYIdgxOQm8pNZ5dEOmmSLBVpP85ReeyRt6AS1QJNyo/oFFPeVA==",
+      "peer": true,
       "requires": {
         "@types/bonjour": "^3.5.9",
         "@types/connect-history-api-fallback": "^1.3.5",
@@ -41923,6 +42105,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",
@@ -42163,6 +42346,7 @@
           "version": "8.12.0",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-8.12.0.tgz",
           "integrity": "sha512-sRu1kpcO9yLtYxBKvqfTeh9KzZEwO3STyX1HT+4CaDzC6HpTGYhIhPIzj9XuKU7KYDwnaeh5hcOwjy1QuJzBPA==",
+          "peer": true,
           "requires": {
             "fast-deep-equal": "^3.1.1",
             "json-schema-traverse": "^1.0.0",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -33,6 +33,7 @@
     "reactflow": "^11.11.4",
     "reactstrap": "^9.2.3",
     "recharts": "^2.13.0",
+    "remark-gfm": "^3.0.1",
     "zustand": "^4.5.4"
   },
   "scripts": {

--- a/frontend/src/components/chat/ChatComposer.jsx
+++ b/frontend/src/components/chat/ChatComposer.jsx
@@ -1,0 +1,64 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, Input } from "reactstrap";
+import { IoSend } from "react-icons/io5";
+
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+
+// Mirror MessageRequestSerializer(message=CharField(max_length=4096)) so the UI caps input before
+// the server rejects it with INVALID_MESSAGE.
+const MAX_MESSAGE_LEN = 4096;
+
+/**
+ * Message input. Enter sends, Shift+Enter inserts a newline. Disabled while a turn is streaming or
+ * the socket is not connected, so the user can't fire a second turn before the first finishes.
+ */
+export function ChatComposer({ onSend }) {
+  const [text, setText] = React.useState("");
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const connectionState = useChatStore((state) => state.connectionState);
+  const disabled = isStreaming || connectionState !== ConnectionState.CONNECTED;
+
+  const submit = () => {
+    const trimmed = text.trim();
+    if (!trimmed || disabled) return;
+    onSend(trimmed);
+    setText("");
+  };
+
+  const handleKeyDown = (event) => {
+    if (event.key === "Enter" && !event.shiftKey) {
+      event.preventDefault();
+      submit();
+    }
+  };
+
+  return (
+    <div className="d-flex align-items-end p-2 border-top">
+      <Input
+        id="chat-composer-input"
+        type="textarea"
+        rows={1}
+        value={text}
+        maxLength={MAX_MESSAGE_LEN}
+        placeholder="Ask about your threat intel data…"
+        onChange={(event) => setText(event.target.value)}
+        onKeyDown={handleKeyDown}
+        disabled={disabled}
+      />
+      <Button
+        color="primary"
+        className="ms-2"
+        onClick={submit}
+        disabled={disabled || !text.trim()}
+        aria-label="Send message"
+      >
+        <IoSend />
+      </Button>
+    </div>
+  );
+}
+
+ChatComposer.propTypes = {
+  onSend: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/chat/ChatMessage.jsx
+++ b/frontend/src/components/chat/ChatMessage.jsx
@@ -1,0 +1,40 @@
+import React from "react";
+import PropTypes from "prop-types";
+
+import { chatMarkdownToHtml } from "./chatMarkdown";
+import { MessageRole } from "../../stores/useChatStore";
+
+/**
+ * A single chat bubble. User messages render as plain (newline-preserving) text and align right;
+ * assistant messages render markdown (GFM) and align left.
+ */
+export function ChatMessage({ role, content }) {
+  const isUser = role === MessageRole.USER;
+  return (
+    <div
+      className={`d-flex mb-2 ${
+        isUser ? "justify-content-end" : "justify-content-start"
+      }`}
+    >
+      <div
+        className={`px-3 py-2 rounded ${
+          isUser
+            ? "bg-primary text-white"
+            : "bg-dark text-white border border-secondary"
+        }`}
+        style={{ maxWidth: "85%", wordBreak: "break-word" }}
+      >
+        {isUser ? (
+          <span style={{ whiteSpace: "pre-wrap" }}>{content}</span>
+        ) : (
+          chatMarkdownToHtml(content)
+        )}
+      </div>
+    </div>
+  );
+}
+
+ChatMessage.propTypes = {
+  role: PropTypes.string.isRequired,
+  content: PropTypes.string.isRequired,
+};

--- a/frontend/src/components/chat/ChatMessageList.jsx
+++ b/frontend/src/components/chat/ChatMessageList.jsx
@@ -14,6 +14,7 @@ export function ChatMessageList() {
   const streamingText = useChatStore((state) => state.streamingText);
   const currentTool = useChatStore((state) => state.currentTool);
   const isStreaming = useChatStore((state) => state.isStreaming);
+  const historyLoading = useChatStore((state) => state.historyLoading);
   const bottomRef = React.useRef(null);
 
   React.useEffect(() => {
@@ -22,6 +23,11 @@ export function ChatMessageList() {
 
   return (
     <div className="flex-grow-1 overflow-auto p-3">
+      {historyLoading && (
+        <div className="text-center p-3">
+          <Spinner size="sm" />
+        </div>
+      )}
       {messages.map((message, index) => (
         <ChatMessage
           // committed assistant messages carry a server id; user messages fall back to position

--- a/frontend/src/components/chat/ChatMessageList.jsx
+++ b/frontend/src/components/chat/ChatMessageList.jsx
@@ -1,0 +1,45 @@
+import React from "react";
+import { Spinner } from "reactstrap";
+
+import { ChatMessage } from "./ChatMessage";
+import { useChatStore, MessageRole } from "../../stores/useChatStore";
+
+/**
+ * Scrollable conversation view: committed messages, plus the in-progress assistant turn (a
+ * "Running <tool>…/Thinking…" indicator before any text arrives, then the live streaming bubble).
+ * Autoscrolls to the bottom as new content lands.
+ */
+export function ChatMessageList() {
+  const messages = useChatStore((state) => state.messages);
+  const streamingText = useChatStore((state) => state.streamingText);
+  const currentTool = useChatStore((state) => state.currentTool);
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const bottomRef = React.useRef(null);
+
+  React.useEffect(() => {
+    bottomRef.current?.scrollIntoView({ behavior: "smooth" });
+  }, [messages, streamingText, currentTool]);
+
+  return (
+    <div className="flex-grow-1 overflow-auto p-3">
+      {messages.map((message, index) => (
+        <ChatMessage
+          // committed assistant messages carry a server id; user messages fall back to position
+          key={message.id ?? `${message.role}-${index}`}
+          role={message.role}
+          content={message.content}
+        />
+      ))}
+      {isStreaming && !streamingText && (
+        <div className="text-muted small mb-2 d-flex align-items-center">
+          <Spinner size="sm" className="me-2" />
+          {currentTool ? `Running ${currentTool}…` : "Thinking…"}
+        </div>
+      )}
+      {isStreaming && streamingText && (
+        <ChatMessage role={MessageRole.ASSISTANT} content={streamingText} />
+      )}
+      <div ref={bottomRef} />
+    </div>
+  );
+}

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -5,12 +5,15 @@ import {
   OffcanvasBody,
   Badge,
   Alert,
+  Button,
 } from "reactstrap";
+import { IoListOutline, IoArrowBack } from "react-icons/io5";
 
 import { useChatStore, ConnectionState } from "../../stores/useChatStore";
 import { useChatWebSocket } from "./useChatWebSocket";
 import { ChatMessageList } from "./ChatMessageList";
 import { ChatComposer } from "./ChatComposer";
+import { ChatSessionList } from "./ChatSessionList";
 
 // Connection-state badge shown in the drawer header.
 const CONNECTION_BADGE = {
@@ -33,6 +36,14 @@ export function ChatPanel() {
   const error = useChatStore((state) => state.error);
   const { sendMessage } = useChatWebSocket();
 
+  // Master-detail mode: "conversation" (messages + composer) or "sessions" (the session list).
+  // Local state — purely presentational and not shared with the distant header, unlike `isOpen`.
+  const [view, setView] = React.useState("conversation");
+  // Always reopen the drawer on the conversation view.
+  React.useEffect(() => {
+    if (!isOpen) setView("conversation");
+  }, [isOpen]);
+
   const badge =
     CONNECTION_BADGE[connectionState] ?? CONNECTION_BADGE[ConnectionState.IDLE];
 
@@ -46,6 +57,25 @@ export function ChatPanel() {
       id="chat-panel"
     >
       <OffcanvasHeader toggle={close}>
+        {view === "conversation" ? (
+          <Button
+            color="link"
+            className="p-0 me-2 text-reset"
+            aria-label="Show conversations"
+            onClick={() => setView("sessions")}
+          >
+            <IoListOutline />
+          </Button>
+        ) : (
+          <Button
+            color="link"
+            className="p-0 me-2 text-reset"
+            aria-label="Back to conversation"
+            onClick={() => setView("conversation")}
+          >
+            <IoArrowBack />
+          </Button>
+        )}
         Assistant
         <Badge color={badge.color} className="ms-2">
           {badge.label}
@@ -57,8 +87,14 @@ export function ChatPanel() {
             {error}
           </Alert>
         )}
-        <ChatMessageList />
-        <ChatComposer onSend={sendMessage} />
+        {view === "sessions" ? (
+          <ChatSessionList onSessionChosen={() => setView("conversation")} />
+        ) : (
+          <>
+            <ChatMessageList />
+            <ChatComposer onSend={sendMessage} />
+          </>
+        )}
       </OffcanvasBody>
     </Offcanvas>
   );

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -1,0 +1,65 @@
+import React from "react";
+import {
+  Offcanvas,
+  OffcanvasHeader,
+  OffcanvasBody,
+  Badge,
+  Alert,
+} from "reactstrap";
+
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+import { useChatWebSocket } from "./useChatWebSocket";
+import { ChatMessageList } from "./ChatMessageList";
+import { ChatComposer } from "./ChatComposer";
+
+// Connection-state badge shown in the drawer header.
+const CONNECTION_BADGE = {
+  [ConnectionState.IDLE]: { color: "secondary", label: "Idle" },
+  [ConnectionState.CONNECTING]: { color: "warning", label: "Connecting" },
+  [ConnectionState.CONNECTED]: { color: "success", label: "Connected" },
+  [ConnectionState.RECONNECTING]: { color: "warning", label: "Reconnecting" },
+  [ConnectionState.CLOSED]: { color: "danger", label: "Disconnected" },
+};
+
+/**
+ * The chat drawer. Mounted once, globally (AppMain Layout), so it overlays every authenticated
+ * page and survives open/close; the WebSocket lives in useChatWebSocket, which lazily connects the
+ * first time the drawer opens. `backdrop={false}` keeps the rest of the app usable while open.
+ */
+export function ChatPanel() {
+  const isOpen = useChatStore((state) => state.isOpen);
+  const close = useChatStore((state) => state.close);
+  const connectionState = useChatStore((state) => state.connectionState);
+  const error = useChatStore((state) => state.error);
+  const { sendMessage } = useChatWebSocket();
+
+  const badge =
+    CONNECTION_BADGE[connectionState] ?? CONNECTION_BADGE[ConnectionState.IDLE];
+
+  return (
+    <Offcanvas
+      direction="end"
+      isOpen={isOpen}
+      toggle={close}
+      backdrop={false}
+      scrollable
+      id="chat-panel"
+    >
+      <OffcanvasHeader toggle={close}>
+        Assistant
+        <Badge color={badge.color} className="ms-2">
+          {badge.label}
+        </Badge>
+      </OffcanvasHeader>
+      <OffcanvasBody className="d-flex flex-column p-0">
+        {error && (
+          <Alert color="danger" className="m-2">
+            {error}
+          </Alert>
+        )}
+        <ChatMessageList />
+        <ChatComposer onSend={sendMessage} />
+      </OffcanvasBody>
+    </Offcanvas>
+  );
+}

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -6,8 +6,10 @@ import {
   Badge,
   Alert,
   Button,
+  UncontrolledTooltip,
 } from "reactstrap";
 import { IoListOutline, IoArrowBack } from "react-icons/io5";
+import { MdInfoOutline } from "react-icons/md";
 
 import { useChatStore, ConnectionState } from "../../stores/useChatStore";
 import { useChatWebSocket } from "./useChatWebSocket";
@@ -24,6 +26,16 @@ const CONNECTION_BADGE = {
   [ConnectionState.CLOSED]: { color: "danger", label: "Disconnected" },
 };
 
+// Shown instead of the green "Connected" badge when the socket is up but the chatbot worker isn't
+// serving turns (see useChatStore.assistantUnavailable).
+const UNAVAILABLE_BADGE = { color: "warning", label: "Unavailable" };
+
+// One-line description behind the header info icon, mirroring the MdInfoOutline + tooltip pattern
+// used elsewhere in IntelOwl (e.g. TLPSelectInput).
+const ASSISTANT_INFO_TEXT =
+  "Privacy-preserving assistant: ask about your IntelOwl data in natural language. " +
+  "All inference runs locally via Ollama — nothing is sent to external services.";
+
 /**
  * The chat drawer. Mounted once, globally (AppMain Layout), so it overlays every authenticated
  * page and survives open/close; the WebSocket lives in useChatWebSocket, which lazily connects the
@@ -33,6 +45,9 @@ export function ChatPanel() {
   const isOpen = useChatStore((state) => state.isOpen);
   const close = useChatStore((state) => state.close);
   const connectionState = useChatStore((state) => state.connectionState);
+  const assistantUnavailable = useChatStore(
+    (state) => state.assistantUnavailable,
+  );
   const error = useChatStore((state) => state.error);
   const { sendMessage } = useChatWebSocket();
 
@@ -44,8 +59,13 @@ export function ChatPanel() {
     if (!isOpen) setView("conversation");
   }, [isOpen]);
 
+  // The badge reflects assistant availability, not just transport: a connected socket whose worker
+  // isn't serving turns (assistantUnavailable) must not keep reading green "Connected".
   const badge =
-    CONNECTION_BADGE[connectionState] ?? CONNECTION_BADGE[ConnectionState.IDLE];
+    assistantUnavailable && connectionState === ConnectionState.CONNECTED
+      ? UNAVAILABLE_BADGE
+      : CONNECTION_BADGE[connectionState] ??
+        CONNECTION_BADGE[ConnectionState.IDLE];
 
   return (
     <Offcanvas
@@ -77,6 +97,16 @@ export function ChatPanel() {
           </Button>
         )}
         Assistant
+        <MdInfoOutline id="chat-assistant-info" className="ms-1" />
+        <UncontrolledTooltip
+          target="chat-assistant-info"
+          placement="bottom"
+          fade={false}
+          autohide={false}
+          innerClassName="p-2 text-start"
+        >
+          {ASSISTANT_INFO_TEXT}
+        </UncontrolledTooltip>
         <Badge color={badge.color} className="ms-2">
           {badge.label}
         </Badge>

--- a/frontend/src/components/chat/ChatSessionList.jsx
+++ b/frontend/src/components/chat/ChatSessionList.jsx
@@ -1,0 +1,118 @@
+import React from "react";
+import PropTypes from "prop-types";
+import { Button, ListGroup, ListGroupItem, Spinner, Alert } from "reactstrap";
+import { IoAdd, IoTrashOutline } from "react-icons/io5";
+import { format } from "date-fns-tz";
+
+import { useChatStore, deriveSessionLabel } from "../../stores/useChatStore";
+import { areYouSureConfirmDialog } from "../common/areYouSureConfirmDialog";
+
+/**
+ * The sessions view of the chat drawer (master-detail counterpart of the conversation view). Lists
+ * the user's conversations with a backend-provided title + creation time, lets them start a new
+ * chat, switch to an existing one, or delete one. `onSessionChosen` flips the parent panel back to
+ * the conversation view after a switch/new.
+ *
+ * Switching/new are allowed while a turn streams: the store bumps navEpoch to abandon the in-flight
+ * turn (see useChatStore). Delete is still blocked for the active-streaming session (the server is
+ * persisting that session's messages). The WebSocket hook is untouched—it reads the bound sessionId
+ * live.
+ */
+export function ChatSessionList({ onSessionChosen }) {
+  const sessions = useChatStore((state) => state.sessions);
+  const loading = useChatStore((state) => state.sessionsLoading);
+  const error = useChatStore((state) => state.sessionsError);
+  const sessionId = useChatStore((state) => state.sessionId);
+  const fetchSessions = useChatStore((state) => state.fetchSessions);
+  const switchSession = useChatStore((state) => state.switchSession);
+  const newChat = useChatStore((state) => state.newChat);
+  const deleteSession = useChatStore((state) => state.deleteSession);
+
+  // Refetch every time the list is shown so deletes/new sessions from other tabs are reflected.
+  React.useEffect(() => {
+    fetchSessions();
+  }, [fetchSessions]);
+
+  const handleSelect = (id) => {
+    switchSession(id);
+    onSessionChosen();
+  };
+
+  const handleNew = () => {
+    newChat();
+    onSessionChosen();
+  };
+
+  const handleDelete = async (id) => {
+    const sure = await areYouSureConfirmDialog("delete this conversation");
+    if (sure) deleteSession(id);
+  };
+
+  return (
+    <div
+      className="d-flex flex-column overflow-auto p-2"
+      id="chat-session-list"
+    >
+      <Button color="primary" className="mb-2" onClick={handleNew}>
+        <IoAdd className="me-1" /> New chat
+      </Button>
+      {error && (
+        <Alert color="danger" className="m-0 mb-2">
+          {error}
+        </Alert>
+      )}
+      {loading && (
+        <div className="text-center p-3">
+          <Spinner size="sm" />
+        </div>
+      )}
+      {!loading && !error && sessions.length === 0 && (
+        <div className="text-muted text-center p-3">No conversations yet.</div>
+      )}
+      <ListGroup flush>
+        {sessions.map((session) => (
+          <ListGroupItem
+            key={session.id}
+            tag="button"
+            type="button"
+            action
+            active={session.id === sessionId}
+            onClick={() => handleSelect(session.id)}
+            className="d-flex justify-content-between align-items-center"
+          >
+            <div className="text-truncate">
+              <div className="text-truncate">{deriveSessionLabel(session)}</div>
+              <small className="text-muted">
+                {format(new Date(session.created_at), "yyyy-MM-dd HH:mm")}
+              </small>
+            </div>
+            {/* A <button> nested in the tag="button" row is invalid HTML, so the delete control is a
+                role="button" span that stops propagation to avoid also triggering the row switch. */}
+            <span
+              role="button"
+              tabIndex={0}
+              aria-label="Delete conversation"
+              className="ms-2 text-danger"
+              onClick={(event) => {
+                event.stopPropagation();
+                handleDelete(session.id);
+              }}
+              onKeyDown={(event) => {
+                if (event.key === "Enter") {
+                  event.stopPropagation();
+                  handleDelete(session.id);
+                }
+              }}
+            >
+              <IoTrashOutline />
+            </span>
+          </ListGroupItem>
+        ))}
+      </ListGroup>
+    </div>
+  );
+}
+
+ChatSessionList.propTypes = {
+  onSessionChosen: PropTypes.func.isRequired,
+};

--- a/frontend/src/components/chat/chatMarkdown.jsx
+++ b/frontend/src/components/chat/chatMarkdown.jsx
@@ -1,0 +1,46 @@
+import React from "react";
+import ReactMarkdown from "react-markdown";
+import remarkGfm from "remark-gfm";
+
+/**
+ * Markdown renderer for assistant chat messages.
+ *
+ * Kept separate from the shared `markdownToHtml` on purpose: the chat enables GFM (tables /
+ * strikethrough / task lists) because the agent renders job and analyzer summaries as markdown
+ * tables, which the shared renderer (no GFM) would show as broken pipe-text. Isolating it here
+ * avoids changing how the rest of IntelOwl renders markdown.
+ *
+ * No `rehype-raw`: react-markdown v8 does not render raw HTML by default, so untrusted LLM output
+ * stays XSS-safe without an extra sanitizer.
+ * @param {string} text
+ */
+export function chatMarkdownToHtml(text) {
+  return (
+    <ReactMarkdown
+      remarkPlugins={[remarkGfm]}
+      // eslint-disable-next-line react/no-children-prop
+      children={text}
+      components={{
+        // eslint-disable-next-line id-length
+        em: ({ node: _, ...props }) => <i className="text-code" {...props} />,
+        // eslint-disable-next-line id-length
+        a: ({ node: _, ...props }) => (
+          // eslint-disable-next-line jsx-a11y/anchor-has-content
+          <a
+            target="_blank"
+            rel="noopener noreferrer"
+            className="link-primary"
+            {...props}
+          />
+        ),
+        table: ({ node: _, ...props }) => (
+          <table className="table table-sm" {...props} />
+        ),
+        // drop react-markdown's `inline` flag so it is not spread onto the DOM node
+        code: ({ node: _, inline: _inline, ...props }) => (
+          <code className="text-code" {...props} />
+        ),
+      }}
+    />
+  );
+}

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -96,7 +96,8 @@ export function useChatWebSocket() {
               // orphan that timer past clearTurnTimers and fire a stale error on the new turn.
               if (useChatStore.getState().navEpoch !== epoch) return;
               postAckTimer.current = null;
-              useChatStore.getState().applyError(WORKER_UNAVAILABLE_TEXT);
+              // worker-down signal: flip the availability badge, not just the error banner
+              useChatStore.getState().applyUnavailable(WORKER_UNAVAILABLE_TEXT);
             }, POST_ACK_TIMEOUT_MS);
           }
           break;

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -88,10 +88,17 @@ export function useChatWebSocket() {
           // post-ack watchdog until the agent proves it is alive by emitting `start`.
           store.applyAck(event);
           if (postAckTimer.current) clearTimeout(postAckTimer.current);
-          postAckTimer.current = setTimeout(() => {
-            postAckTimer.current = null;
-            useChatStore.getState().applyError(WORKER_UNAVAILABLE_TEXT);
-          }, POST_ACK_TIMEOUT_MS);
+          {
+            const epoch = store.navEpoch;
+            postAckTimer.current = setTimeout(() => {
+              // Check the epoch BEFORE clearing the ref: if the user navigated away this turn is
+              // abandoned and the ref may already hold a newer turn's timer — nulling it here would
+              // orphan that timer past clearTurnTimers and fire a stale error on the new turn.
+              if (useChatStore.getState().navEpoch !== epoch) return;
+              postAckTimer.current = null;
+              useChatStore.getState().applyError(WORKER_UNAVAILABLE_TEXT);
+            }, POST_ACK_TIMEOUT_MS);
+          }
           break;
         case ChatEventType.START:
           // Strict demux: `start`/`status`/`token`/`end` fan out to every tab of this user, so a
@@ -103,10 +110,16 @@ export function useChatWebSocket() {
             clearTimeout(postAckTimer.current);
             postAckTimer.current = null;
           }
-          maxTurnTimer.current = setTimeout(() => {
-            maxTurnTimer.current = null;
-            useChatStore.getState().applyError(TURN_TIMEOUT_TEXT);
-          }, MAX_TURN_TIMEOUT_MS);
+          {
+            const epoch = store.navEpoch;
+            maxTurnTimer.current = setTimeout(() => {
+              // See the post-ack watchdog: epoch-check first so a stale callback can't null a ref
+              // that a newer overlapping turn has since taken over.
+              if (useChatStore.getState().navEpoch !== epoch) return;
+              maxTurnTimer.current = null;
+              useChatStore.getState().applyError(TURN_TIMEOUT_TEXT);
+            }, MAX_TURN_TIMEOUT_MS);
+          }
           store.applyStart();
           break;
         case ChatEventType.STATUS:

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -167,15 +167,22 @@ export function useChatWebSocket() {
     };
     socket.onclose = (closeEvent) => {
       websocket.current = null;
-      clearTurnTimers();
+      // Terminal closes (teardown, clean close, reconnect budget exhausted) end the turn for good:
+      // drop the watchdogs so a stale timer can't fire an error minutes later onto a dead socket.
       if (isUnmounting.current || closeEvent.code === NORMAL_CLOSURE) {
+        clearTurnTimers();
         useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
         return;
       }
       if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+        clearTurnTimers();
         useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
         return;
       }
+      // Abnormal mid-turn drop: keep the turn watchdogs armed across the reconnect. The in-flight
+      // turn's `start`/`end` lands in the dead window and is never replayed to the new socket (group
+      // frames aren't buffered), so the watchdog is the only thing that unlocks the composer here —
+      // clearing it on close would strand `isStreaming` forever.
       const delay = Math.min(
         RECONNECT_BASE_MS * 2 ** reconnectAttempts.current,
         RECONNECT_CAP_MS,

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -1,0 +1,222 @@
+import React from "react";
+
+import { WEBSOCKET_CHAT_URI } from "../../constants/apiURLs";
+import { useChatStore, ConnectionState } from "../../stores/useChatStore";
+
+// Inbound frame types — mirror ChatEventType in api_app/chatbot_manager/events.py.
+const ChatEventType = Object.freeze({
+  ACK: "ack",
+  START: "start",
+  STATUS: "status",
+  TOKEN: "token",
+  END: "end",
+  ERROR: "error",
+});
+
+// Normal WebSocket close code: a clean close must NOT trigger a reconnect.
+const NORMAL_CLOSURE = 1000;
+
+// Capped exponential backoff for the reconnect (chat is long-lived, unlike the Job socket which
+// closes on the final status). Give up after a few attempts and surface a CLOSED badge.
+const RECONNECT_BASE_MS = 1000;
+const RECONNECT_CAP_MS = 30000;
+const MAX_RECONNECT_ATTEMPTS = 5;
+
+// Post-ack watchdog: the consumer sends `ack` synchronously *before* enqueuing the Celery turn
+// (process_chat_message.delay), so the ack arrives even when the chatbot worker is down — then no
+// `start`/`end`/`error` ever follows and the composer would stay locked forever. If no `start`
+// lands within this window after an `ack`, give up and unlock the composer.
+const POST_ACK_TIMEOUT_MS = 20000;
+
+// Max-turn watchdog: bounds `start` -> no `end`. Set just above the server soft_time_limit (300s)
+// so the server's own timeout normally wins; this only fires when the socket drops mid-turn (the
+// group `end` is sent into the dead window and is not buffered) or the worker is hard-killed
+// (SIGKILL never reaches the soft limit, so no `chat.error` is emitted).
+const MAX_TURN_TIMEOUT_MS = 310000;
+
+// Client-side error texts (mirror the user-safe strings in ChatErrorDetail).
+const WORKER_UNAVAILABLE_TEXT =
+  "The assistant is currently unavailable. Please try again.";
+const TURN_TIMEOUT_TEXT =
+  "The assistant took too long to respond. Please try again.";
+
+function buildChatWebSocketUrl() {
+  const scheme = window.location.protocol === "https:" ? "wss" : "ws";
+  // Trailing slash matters: the backend route is `ws/chat/`. context_url carries the page the
+  // user is on (captured server-side for later context injection).
+  const contextUrl = encodeURIComponent(window.location.href);
+  return `${scheme}://${window.location.host}/${WEBSOCKET_CHAT_URI}/?context_url=${contextUrl}`;
+}
+
+/**
+ * Owns the chat WebSocket and bridges it to useChatStore.
+ *
+ * The socket, the reconnect timer and the two per-turn watchdog timers all live in refs (never in
+ * the store) so re-renders don't recreate them — the same pattern JobResult uses for the job
+ * socket. The hook lazily connects the first time the drawer opens and then keeps the socket alive
+ * across open/close; it only tears down on unmount. Returns `sendMessage` for the composer.
+ */
+export function useChatWebSocket() {
+  const isOpen = useChatStore((state) => state.isOpen);
+
+  const websocket = React.useRef(null);
+  const reconnectTimer = React.useRef(null);
+  const reconnectAttempts = React.useRef(0);
+  const postAckTimer = React.useRef(null);
+  const maxTurnTimer = React.useRef(null);
+  // Set on unmount so the onclose handler does not schedule a reconnect during teardown.
+  const isUnmounting = React.useRef(false);
+
+  const clearTurnTimers = React.useCallback(() => {
+    if (postAckTimer.current) {
+      clearTimeout(postAckTimer.current);
+      postAckTimer.current = null;
+    }
+    if (maxTurnTimer.current) {
+      clearTimeout(maxTurnTimer.current);
+      maxTurnTimer.current = null;
+    }
+  }, []);
+
+  const dispatchEvent = React.useCallback(
+    (event) => {
+      const store = useChatStore.getState();
+      const activeSession = store.sessionId;
+      switch (event.type) {
+        case ChatEventType.ACK:
+          // `ack` reaches only this socket; bind the (possibly new) session id, then arm the
+          // post-ack watchdog until the agent proves it is alive by emitting `start`.
+          store.applyAck(event);
+          if (postAckTimer.current) clearTimeout(postAckTimer.current);
+          postAckTimer.current = setTimeout(() => {
+            postAckTimer.current = null;
+            useChatStore.getState().applyError(WORKER_UNAVAILABLE_TEXT);
+          }, POST_ACK_TIMEOUT_MS);
+          break;
+        case ChatEventType.START:
+          // Strict demux: `start`/`status`/`token`/`end` fan out to every tab of this user, so a
+          // tab must drop frames that belong to another session. A fresh tab has sessionId === null
+          // and therefore matches nothing.
+          if (event.session_id !== activeSession) return;
+          // The agent answered: cancel the post-ack watchdog and arm the max-turn one.
+          if (postAckTimer.current) {
+            clearTimeout(postAckTimer.current);
+            postAckTimer.current = null;
+          }
+          maxTurnTimer.current = setTimeout(() => {
+            maxTurnTimer.current = null;
+            useChatStore.getState().applyError(TURN_TIMEOUT_TEXT);
+          }, MAX_TURN_TIMEOUT_MS);
+          store.applyStart();
+          break;
+        case ChatEventType.STATUS:
+          if (event.session_id !== activeSession) return;
+          store.applyStatus(event);
+          break;
+        case ChatEventType.TOKEN:
+          if (event.session_id !== activeSession) return;
+          store.applyToken(event);
+          break;
+        case ChatEventType.END:
+          if (event.session_id !== activeSession) return;
+          clearTurnTimers();
+          store.applyEnd(event);
+          break;
+        case ChatEventType.ERROR:
+          // Looser guard than the streaming frames: the consumer's *direct* errors arrive only on
+          // this socket with session_id === null (INVALID_MESSAGE), so the null branch must pass;
+          // the agent errors arrive via the group with the active session id. A different non-null
+          // session id belongs to another tab and is ignored.
+          if (event.session_id != null && event.session_id !== activeSession)
+            return;
+          clearTurnTimers();
+          store.applyError(event.detail);
+          break;
+        default:
+          break;
+      }
+    },
+    [clearTurnTimers],
+  );
+
+  const connect = React.useCallback(() => {
+    if (websocket.current) return;
+    const { setConnectionState } = useChatStore.getState();
+    setConnectionState(ConnectionState.CONNECTING);
+    const url = buildChatWebSocketUrl();
+    console.debug(`connect to chat websocket: ${url}`);
+    const socket = new WebSocket(url);
+    websocket.current = socket;
+
+    socket.onopen = () => {
+      reconnectAttempts.current = 0;
+      useChatStore.getState().setConnectionState(ConnectionState.CONNECTED);
+    };
+    socket.onmessage = (wsData) => {
+      let event;
+      try {
+        event = JSON.parse(wsData.data);
+      } catch (parseError) {
+        console.error("chat ws: unparsable frame", parseError);
+        return;
+      }
+      dispatchEvent(event);
+    };
+    socket.onerror = (wsError) => {
+      console.error("chat ws error", wsError);
+    };
+    socket.onclose = (closeEvent) => {
+      websocket.current = null;
+      clearTurnTimers();
+      if (isUnmounting.current || closeEvent.code === NORMAL_CLOSURE) {
+        useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
+        return;
+      }
+      if (reconnectAttempts.current >= MAX_RECONNECT_ATTEMPTS) {
+        useChatStore.getState().setConnectionState(ConnectionState.CLOSED);
+        return;
+      }
+      const delay = Math.min(
+        RECONNECT_BASE_MS * 2 ** reconnectAttempts.current,
+        RECONNECT_CAP_MS,
+      );
+      reconnectAttempts.current += 1;
+      useChatStore.getState().setConnectionState(ConnectionState.RECONNECTING);
+      reconnectTimer.current = setTimeout(connect, delay);
+    };
+  }, [dispatchEvent, clearTurnTimers]);
+
+  // Lazy connect on first open; keep the socket alive afterwards (no idle socket for users who
+  // never open the chat). Teardown happens only on unmount.
+  React.useEffect(() => {
+    if (isOpen && !websocket.current) {
+      connect();
+    }
+  }, [isOpen, connect]);
+
+  React.useEffect(
+    () => () => {
+      isUnmounting.current = true;
+      if (reconnectTimer.current) clearTimeout(reconnectTimer.current);
+      clearTurnTimers();
+      if (websocket.current) {
+        websocket.current.close(NORMAL_CLOSURE);
+        websocket.current = null;
+      }
+    },
+    [clearTurnTimers],
+  );
+
+  const sendMessage = React.useCallback((text) => {
+    const trimmed = text.trim();
+    const socket = websocket.current;
+    if (!trimmed || !socket || socket.readyState !== WebSocket.OPEN) return;
+    const store = useChatStore.getState();
+    store.enqueueUserMessage(trimmed);
+    socket.send(
+      JSON.stringify({ message: trimmed, session_id: store.sessionId }),
+    );
+  }, []);
+
+  return { sendMessage };
+}

--- a/frontend/src/constants/apiURLs.js
+++ b/frontend/src/constants/apiURLs.js
@@ -54,6 +54,7 @@ export const APIACCESS_BASE_URI = `${AUTH_BASE_URI}/apiaccess`;
 // WEBSOCKETS
 const WEBSOCKET_BASE_URI = "ws";
 export const WEBSOCKET_JOBS_URI = `${WEBSOCKET_BASE_URI}/jobs`;
+export const WEBSOCKET_CHAT_URI = `${WEBSOCKET_BASE_URI}/chat`;
 
 // user event
 export const USER_EVENT_BASE_URI = `${API_BASE_URI}/user_event`;

--- a/frontend/src/constants/apiURLs.js
+++ b/frontend/src/constants/apiURLs.js
@@ -51,6 +51,10 @@ export const NOTIFICATION_BASE_URI = `${API_BASE_URI}/notification`;
 export const AUTH_BASE_URI = `${API_BASE_URI}/auth`;
 export const APIACCESS_BASE_URI = `${AUTH_BASE_URI}/apiaccess`;
 
+// chatbot (router uses trailing_slash=False, so these paths carry no trailing slash)
+export const CHATBOT_BASE_URI = `${API_BASE_URI}/chatbot`;
+export const CHATBOT_SESSIONS_URI = `${CHATBOT_BASE_URI}/sessions`;
+
 // WEBSOCKETS
 const WEBSOCKET_BASE_URI = "ws";
 export const WEBSOCKET_JOBS_URI = `${WEBSOCKET_BASE_URI}/jobs`;

--- a/frontend/src/layouts/AppHeader.jsx
+++ b/frontend/src/layouts/AppHeader.jsx
@@ -20,7 +20,7 @@ import {
   RiTwitterXFill,
 } from "react-icons/ri";
 import { FaGithub, FaGoogle, FaLinkedin } from "react-icons/fa";
-import { IoSearch } from "react-icons/io5";
+import { IoSearch, IoChatbubbleEllipsesOutline } from "react-icons/io5";
 import { TbReport, TbReportSearch, TbDatabaseSearch } from "react-icons/tb";
 
 // lib
@@ -40,6 +40,7 @@ import NotificationPopoverButton from "../components/jobs/notification/Notificat
 import { useAuthStore } from "../stores/useAuthStore";
 import { useGuideContext } from "../contexts/GuideContext";
 import { useOrganizationStore } from "../stores/useOrganizationStore";
+import { useChatStore } from "../stores/useChatStore";
 
 const guestLinks = (
   <>
@@ -120,8 +121,22 @@ function AuthLinks() {
 function RightLinks({ handleClickStart, isAuthenticated }) {
   const location = useLocation();
   const isRootPath = location.pathname === "/";
+  const toggleChat = useChatStore((state) => state.toggle);
   return (
     <>
+      {isAuthenticated && (
+        <NavItem>
+          <button
+            type="button"
+            id="chat-toggle-btn"
+            className="d-flex-start-center btn text-gray"
+            onClick={toggleChat}
+          >
+            <IoChatbubbleEllipsesOutline />
+            <span className="ms-1">Assistant</span>
+          </button>
+        </NavItem>
+      )}
       {isRootPath && isAuthenticated && (
         <NavItem>
           <button

--- a/frontend/src/layouts/AppMain.jsx
+++ b/frontend/src/layouts/AppMain.jsx
@@ -16,6 +16,7 @@ import {
 } from "../components/Routes";
 import AppHeader from "./AppHeader";
 import Toast from "./Toast";
+import { ChatPanel } from "../components/chat/ChatPanel";
 
 const NoMatch = React.lazy(() => import("./NoMatch"));
 
@@ -52,6 +53,8 @@ function Layout() {
       </main>
       {/* Toasts */}
       <Toast />
+      {/* LLM chat assistant drawer (mounted once; connects lazily on first open) */}
+      <ChatPanel />
     </>
   );
 }

--- a/frontend/src/setupProxy.js
+++ b/frontend/src/setupProxy.js
@@ -11,6 +11,13 @@ module.exports = function proxy(app) {
     }),
   );
   app.use(
+    createProxyMiddleware("/ws/chat", {
+      target: TARGET_SERVER,
+      // eslint-disable-next-line id-length
+      ws: true,
+    }),
+  );
+  app.use(
     createProxyMiddleware("/api", {
       target: TARGET_SERVER,
     }),

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -1,4 +1,8 @@
 import { create } from "zustand";
+import axios from "axios";
+import { format } from "date-fns-tz";
+
+import { CHATBOT_SESSIONS_URI } from "../constants/apiURLs";
 
 /**
  * Connection states for the chat WebSocket, surfaced in the UI as a status badge.
@@ -20,6 +24,45 @@ export const MessageRole = Object.freeze({
   ASSISTANT: "assistant",
 });
 
+// User-facing error strings for the REST session operations (same plain style as the WS hook).
+const SESSIONS_LOAD_ERROR =
+  "Could not load your conversations. Please try again.";
+const HISTORY_LOAD_ERROR =
+  "Could not load this conversation. Please try again.";
+const SESSION_DELETE_ERROR =
+  "Could not delete this conversation. Please try again.";
+
+// Fetch every page of a session's messages. The backend orders by timestamp asc and returns pages
+// in order, so concatenation preserves chronological (oldest-first) order. Mirrors the paginated
+// download pattern in usePluginConfigurationStore.jsx.
+async function fetchAllMessages(sessionId) {
+  const url = `${CHATBOT_SESSIONS_URI}/${sessionId}/messages`;
+  const first = await axios.get(url, { params: { page: 1 } });
+  let { results } = first.data;
+  if (first.data.total_pages > 1) {
+    const requests = [];
+    for (let page = 2; page <= first.data.total_pages; page += 1) {
+      requests.push(axios.get(url, { params: { page } }));
+    }
+    (await Promise.all(requests)).forEach((resp) => {
+      results = results.concat(resp.data.results);
+    });
+  }
+  // ChatMessageSerializer -> { id, role, content, timestamp }; store shape is { id, role, content }.
+  return results.map(({ id, role, content }) => ({ id, role, content }));
+}
+
+/**
+ * Label for a session row in the list. The backend annotates each listed session with `title` (its
+ * first user message, truncated); fall back to the formatted created_at for a session that has no
+ * user message yet. Pure and exported so the component and tests share one source of truth.
+ */
+export function deriveSessionLabel(session) {
+  const title = session.title?.trim();
+  if (title) return title;
+  return format(new Date(session.created_at), "yyyy-MM-dd HH:mm");
+}
+
 const initialTurnState = {
   // text of the assistant answer while it streams token-by-token (committed to messages on `end`)
   streamingText: "",
@@ -29,7 +72,7 @@ const initialTurnState = {
   isStreaming: false,
 };
 
-export const useChatStore = create((set) => ({
+export const useChatStore = create((set, get) => ({
   // drawer visibility (toggled from the global header, a separate component subtree)
   isOpen: false,
   // session id assigned by the server in the `ack` frame; null until the first turn binds it
@@ -40,6 +83,19 @@ export const useChatStore = create((set) => ({
   connectionState: ConnectionState.IDLE,
   // last user-facing error text (cleared when a new turn starts)
   error: null,
+
+  // --- session list (serializable; the WS hook is untouched — these only change
+  // sessionId/messages, which the hook reads live for demux and send) ---
+  // [{ id, created_at, updated_at, title }] in -created_at order, as returned by the API
+  sessions: [],
+  sessionsLoading: false,
+  sessionsError: null,
+  // true while a session's messages are being (re)loaded on switch
+  historyLoading: false,
+  // Monotonic navigation counter, bumped whenever the user switches/opens/abandons a conversation.
+  // The WS hook captures it when arming a turn's watchdog and skips the watchdog if it has moved,
+  // so navigating away mid-turn can't fire a stale "unavailable"/"timeout" error onto the new view.
+  navEpoch: 0,
 
   // --- drawer actions ---
   toggle: () => set((state) => ({ isOpen: !state.isOpen })),
@@ -79,6 +135,98 @@ export const useChatStore = create((set) => ({
   // The partial streaming bubble is dropped (the server drops the turn too) but the user's message
   // stays visible so they can retry.
   applyError: (detail) => set({ ...initialTurnState, error: detail }),
+
+  // --- session management (REST) ---
+  // Load the user's sessions (every page) for the list view; the queryset is user-scoped server-side.
+  fetchSessions: async () => {
+    set({ sessionsLoading: true, sessionsError: null });
+    try {
+      const first = await axios.get(CHATBOT_SESSIONS_URI, {
+        params: { page: 1 },
+      });
+      let sessions = first.data.results;
+      if (first.data.total_pages > 1) {
+        const requests = [];
+        for (let page = 2; page <= first.data.total_pages; page += 1) {
+          requests.push(axios.get(CHATBOT_SESSIONS_URI, { params: { page } }));
+        }
+        (await Promise.all(requests)).forEach((resp) => {
+          sessions = sessions.concat(resp.data.results);
+        });
+      }
+      set({ sessions, sessionsLoading: false });
+    } catch (error) {
+      set({ sessionsError: SESSIONS_LOAD_ERROR, sessionsLoading: false });
+    }
+  },
+
+  // Open an existing session: bump navEpoch (abandoning any in-flight turn — see navEpoch above and
+  // the WS hook's watchdogs), reset the turn, bind sessionId (so the WS demux routes this session's
+  // frames) and load its history oldest-first. Allowed mid-turn so the list stays usable while a
+  // reply streams; only a no-op when the session is already active.
+  switchSession: async (sessionId) => {
+    const state = get();
+    if (sessionId === state.sessionId) return;
+    set({
+      sessionId,
+      messages: [],
+      ...initialTurnState,
+      error: null,
+      historyLoading: true,
+      navEpoch: state.navEpoch + 1,
+    });
+    try {
+      const messages = await fetchAllMessages(sessionId);
+      // Race guard: the user may have switched again while this request was in flight.
+      if (get().sessionId !== sessionId) return;
+      set({ messages, historyLoading: false });
+    } catch (error) {
+      if (get().sessionId !== sessionId) return;
+      set({ historyLoading: false, error: HISTORY_LOAD_ERROR });
+    }
+  },
+
+  // Start a fresh conversation: the next send goes with session_id=null and the server creates +
+  // binds the session in its `ack`. Allowed mid-turn (bumps navEpoch to abandon the in-flight turn).
+  newChat: () =>
+    set((state) => ({
+      sessionId: null,
+      messages: [],
+      ...initialTurnState,
+      error: null,
+      navEpoch: state.navEpoch + 1,
+    })),
+
+  // Delete a session; on success drop it from the list and, if it was the active one, fall back to a
+  // fresh chat. Guarded against deleting the very session a turn is streaming into (that would race
+  // the server's persistence) — deleting any other session mid-turn is fine.
+  deleteSession: async (sessionId) => {
+    const state = get();
+    if (state.isStreaming && sessionId === state.sessionId) return;
+    try {
+      await axios.delete(`${CHATBOT_SESSIONS_URI}/${sessionId}`);
+    } catch (error) {
+      set({ sessionsError: SESSION_DELETE_ERROR });
+      return;
+    }
+    set((current) => {
+      const wasActive = current.sessionId === sessionId;
+      return {
+        sessions: current.sessions.filter(
+          (session) => session.id !== sessionId,
+        ),
+        ...(wasActive
+          ? {
+              sessionId: null,
+              messages: [],
+              ...initialTurnState,
+              error: null,
+              navEpoch: current.navEpoch + 1,
+            }
+          : {}),
+      };
+    });
+  },
 
   // --- connection ---
   setConnectionState: (connectionState) => set({ connectionState }),

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -1,0 +1,85 @@
+import { create } from "zustand";
+
+/**
+ * Connection states for the chat WebSocket, surfaced in the UI as a status badge.
+ * The socket itself is NOT held here: per the IntelOwl convention zustand stores keep only
+ * serializable state, so the WebSocket (and its timers) live in the useChatWebSocket hook via
+ * refs. This store is the single source of truth for what the panel renders; the hook owns the
+ * transport and calls the apply* reducers below as frames arrive.
+ */
+export const ConnectionState = Object.freeze({
+  IDLE: "idle",
+  CONNECTING: "connecting",
+  CONNECTED: "connected",
+  RECONNECTING: "reconnecting",
+  CLOSED: "closed",
+});
+
+export const MessageRole = Object.freeze({
+  USER: "user",
+  ASSISTANT: "assistant",
+});
+
+const initialTurnState = {
+  // text of the assistant answer while it streams token-by-token (committed to messages on `end`)
+  streamingText: "",
+  // name of the tool the agent is currently running, shown as a "Running <tool>…" indicator
+  currentTool: null,
+  // true between sending a message and receiving `end`/`error`; disables the composer
+  isStreaming: false,
+};
+
+export const useChatStore = create((set) => ({
+  // drawer visibility (toggled from the global header, a separate component subtree)
+  isOpen: false,
+  // session id assigned by the server in the `ack` frame; null until the first turn binds it
+  sessionId: null,
+  // committed conversation: [{ id?, role, content }]
+  messages: [],
+  ...initialTurnState,
+  connectionState: ConnectionState.IDLE,
+  // last user-facing error text (cleared when a new turn starts)
+  error: null,
+
+  // --- drawer actions ---
+  toggle: () => set((state) => ({ isOpen: !state.isOpen })),
+  open: () => set({ isOpen: true }),
+  close: () => set({ isOpen: false }),
+
+  // --- outbound ---
+  // Optimistically render the user's message and lock the composer before the server replies.
+  enqueueUserMessage: (text) =>
+    set((state) => ({
+      messages: [...state.messages, { role: MessageRole.USER, content: text }],
+      ...initialTurnState,
+      isStreaming: true,
+      error: null,
+    })),
+
+  // --- inbound frame reducers (called by the hook; demux/filtering happens upstream there) ---
+  applyAck: (event) => set({ sessionId: event.session_id }),
+  applyStart: () =>
+    set({ ...initialTurnState, isStreaming: true, error: null }),
+  applyStatus: (event) => set({ currentTool: event.tool }),
+  applyToken: (event) =>
+    set((state) => ({ streamingText: state.streamingText + event.content })),
+  applyEnd: (event) =>
+    set((state) => ({
+      messages: [
+        ...state.messages,
+        {
+          id: event.message_id,
+          role: MessageRole.ASSISTANT,
+          content: event.content,
+        },
+      ],
+      ...initialTurnState,
+    })),
+  // `detail` is the server's user-safe text, or a client-side message for the watchdog timeouts.
+  // The partial streaming bubble is dropped (the server drops the turn too) but the user's message
+  // stays visible so they can retry.
+  applyError: (detail) => set({ ...initialTurnState, error: detail }),
+
+  // --- connection ---
+  setConnectionState: (connectionState) => set({ connectionState }),
+}));

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -83,6 +83,10 @@ export const useChatStore = create((set, get) => ({
   connectionState: ConnectionState.IDLE,
   // last user-facing error text (cleared when a new turn starts)
   error: null,
+  // true when a turn was acked but the worker produced no output (post-ack watchdog). The transport
+  // is still up, so this — not connectionState — is what tells the badge the assistant itself can't
+  // serve a turn right now. Cleared on the next `start` (the worker proving it is alive again).
+  assistantUnavailable: false,
 
   // --- session list (serializable; the WS hook is untouched — these only change
   // sessionId/messages, which the hook reads live for demux and send) ---
@@ -115,7 +119,12 @@ export const useChatStore = create((set, get) => ({
   // --- inbound frame reducers (called by the hook; demux/filtering happens upstream there) ---
   applyAck: (event) => set({ sessionId: event.session_id }),
   applyStart: () =>
-    set({ ...initialTurnState, isStreaming: true, error: null }),
+    set({
+      ...initialTurnState,
+      isStreaming: true,
+      error: null,
+      assistantUnavailable: false,
+    }),
   applyStatus: (event) => set({ currentTool: event.tool }),
   applyToken: (event) =>
     set((state) => ({ streamingText: state.streamingText + event.content })),
@@ -135,6 +144,10 @@ export const useChatStore = create((set, get) => ({
   // The partial streaming bubble is dropped (the server drops the turn too) but the user's message
   // stays visible so they can retry.
   applyError: (detail) => set({ ...initialTurnState, error: detail }),
+  // Like applyError, but specifically for the post-ack watchdog: the turn was acked yet the worker
+  // produced nothing, so the assistant is unavailable — flag the badge in addition to the banner.
+  applyUnavailable: (detail) =>
+    set({ ...initialTurnState, error: detail, assistantUnavailable: true }),
 
   // --- session management (REST) ---
   // Load the user's sessions (every page) for the list view; the queryset is user-scoped server-side.

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -186,3 +186,11 @@ input[type="file"]::file-selector-button {
   position: absolute;
   background: rgb(33, 63, 75);
 }
+
+// chat/
+// Bootstrap's default .btn-close renders a dark glyph that is barely visible on the dark
+// chat drawer. Apply the same filter bootstrap ships in .btn-close-white (reactstrap's
+// OffcanvasHeader hardcodes the btn-close class and exposes no prop to extend it).
+#chat-panel .btn-close {
+  filter: invert(1) grayscale(100%) brightness(200%);
+}

--- a/frontend/src/styles/App.scss
+++ b/frontend/src/styles/App.scss
@@ -194,3 +194,10 @@ input[type="file"]::file-selector-button {
 #chat-panel .btn-close {
   filter: invert(1) grayscale(100%) brightness(200%);
 }
+
+// The header "Assistant" toggle is a <button>, so certego's `a.btn:hover { color: inherit }` rule
+// (which lights up the sibling <a> nav links like Docs on hover) doesn't reach it. Mirror it so the
+// entry brightens to white on hover like the others.
+#chat-toggle-btn:hover {
+  color: inherit !important;
+}

--- a/frontend/tests/components/chat/ChatComposer.test.jsx
+++ b/frontend/tests/components/chat/ChatComposer.test.jsx
@@ -1,0 +1,66 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent } from "@testing-library/react";
+
+import { ChatComposer } from "../../../src/components/chat/ChatComposer";
+import {
+  useChatStore,
+  ConnectionState,
+} from "../../../src/stores/useChatStore";
+
+const connectedIdle = {
+  isStreaming: false,
+  connectionState: ConnectionState.CONNECTED,
+};
+
+describe("ChatComposer", () => {
+  beforeEach(() => {
+    useChatStore.setState(connectedIdle);
+  });
+
+  test("Enter sends the trimmed text and clears the input", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "  list my jobs  " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).toHaveBeenCalledWith("list my jobs");
+    expect(input).toHaveValue("");
+  });
+
+  test("Shift+Enter does not send (newline)", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "first line" } });
+    fireEvent.keyDown(input, { key: "Enter", shiftKey: true });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test("empty/whitespace input does not send", () => {
+    const onSend = jest.fn();
+    render(<ChatComposer onSend={onSend} />);
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "   " } });
+    fireEvent.keyDown(input, { key: "Enter" });
+    expect(onSend).not.toHaveBeenCalled();
+  });
+
+  test("disabled while a turn is streaming", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      connectionState: ConnectionState.CONNECTED,
+    });
+    render(<ChatComposer onSend={jest.fn()} />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeDisabled();
+  });
+
+  test("disabled while the socket is not connected", () => {
+    useChatStore.setState({
+      isStreaming: false,
+      connectionState: ConnectionState.RECONNECTING,
+    });
+    render(<ChatComposer onSend={jest.fn()} />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeDisabled();
+  });
+});

--- a/frontend/tests/components/chat/ChatMessageList.test.jsx
+++ b/frontend/tests/components/chat/ChatMessageList.test.jsx
@@ -58,4 +58,10 @@ describe("ChatMessageList", () => {
     render(<ChatMessageList />);
     expect(screen.getByText("partial answer")).toBeInTheDocument();
   });
+
+  test("shows a loading spinner while a session's history is loading", () => {
+    useChatStore.setState({ historyLoading: true });
+    render(<ChatMessageList />);
+    expect(screen.getByRole("status")).toBeInTheDocument();
+  });
 });

--- a/frontend/tests/components/chat/ChatMessageList.test.jsx
+++ b/frontend/tests/components/chat/ChatMessageList.test.jsx
@@ -1,0 +1,61 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { ChatMessageList } from "../../../src/components/chat/ChatMessageList";
+import { useChatStore, MessageRole } from "../../../src/stores/useChatStore";
+
+const emptyTurn = {
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+};
+
+describe("ChatMessageList", () => {
+  beforeAll(() => {
+    // jsdom does not implement scrollIntoView; the autoscroll effect calls it.
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    useChatStore.setState(emptyTurn);
+  });
+
+  test("renders committed user and assistant messages", () => {
+    useChatStore.setState({
+      messages: [
+        { role: MessageRole.USER, content: "hello" },
+        { id: 9, role: MessageRole.ASSISTANT, content: "**hi there**" },
+      ],
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText("hello")).toBeInTheDocument();
+    expect(screen.getByText("hi there").tagName).toBe("STRONG");
+  });
+
+  test("shows the running-tool indicator before any token streams", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      streamingText: "",
+      currentTool: "search_jobs",
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText(/Running search_jobs/i)).toBeInTheDocument();
+  });
+
+  test("shows a generic thinking indicator when no tool is running yet", () => {
+    useChatStore.setState({ isStreaming: true, streamingText: "" });
+    render(<ChatMessageList />);
+    expect(screen.getByText(/Thinking/i)).toBeInTheDocument();
+  });
+
+  test("renders the in-progress streaming bubble", () => {
+    useChatStore.setState({
+      isStreaming: true,
+      streamingText: "partial answer",
+    });
+    render(<ChatMessageList />);
+    expect(screen.getByText("partial answer")).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/chat/ChatPanel.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.test.jsx
@@ -44,6 +44,7 @@ const baseState = {
   sessionsError: null,
   historyLoading: false,
   navEpoch: 0,
+  assistantUnavailable: false,
 };
 
 describe("ChatPanel", () => {
@@ -63,6 +64,20 @@ describe("ChatPanel", () => {
     expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
     // the hook flips CONNECTING -> CONNECTED once the (stub) socket opens
     expect(await screen.findByText("Connected")).toBeInTheDocument();
+  });
+
+  test("shows an Unavailable badge when the assistant is unavailable while connected", async () => {
+    useChatStore.setState({ assistantUnavailable: true });
+    render(<ChatPanel />);
+    // the socket is connected (transport fine) but the assistant can't serve a turn: the badge must
+    // say so instead of staying green "Connected".
+    expect(await screen.findByText("Unavailable")).toBeInTheDocument();
+    expect(screen.queryByText("Connected")).not.toBeInTheDocument();
+  });
+
+  test("renders an info tooltip describing the assistant", () => {
+    render(<ChatPanel />);
+    expect(document.getElementById("chat-assistant-info")).toBeInTheDocument();
   });
 
   test("renders the conversation from store state", () => {

--- a/frontend/tests/components/chat/ChatPanel.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.test.jsx
@@ -1,0 +1,81 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen, act } from "@testing-library/react";
+
+import { ChatPanel } from "../../../src/components/chat/ChatPanel";
+import {
+  useChatStore,
+  ConnectionState,
+  MessageRole,
+} from "../../../src/stores/useChatStore";
+
+// No-op WebSocket so the lazily-connecting hook does not touch the network in jsdom. It opens on
+// the next tick so the hook transitions CONNECTING -> CONNECTED like a real socket.
+class StubWebSocket {
+  constructor() {
+    this.readyState = StubWebSocket.OPEN;
+    setTimeout(() => {
+      if (this.onopen) this.onopen({});
+    }, 0);
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  send() {}
+
+  // eslint-disable-next-line class-methods-use-this
+  close() {}
+}
+StubWebSocket.OPEN = 1;
+
+const baseState = {
+  isOpen: true,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.CONNECTED,
+  error: null,
+};
+
+describe("ChatPanel", () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    global.WebSocket = StubWebSocket;
+    useChatStore.setState(baseState);
+  });
+
+  test("renders the composer and the connection badge when open", async () => {
+    render(<ChatPanel />);
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
+    // the hook flips CONNECTING -> CONNECTED once the (stub) socket opens
+    expect(await screen.findByText("Connected")).toBeInTheDocument();
+  });
+
+  test("renders the conversation from store state", () => {
+    useChatStore.setState({
+      messages: [
+        { role: MessageRole.USER, content: "show my jobs" },
+        { id: 1, role: MessageRole.ASSISTANT, content: "Here they are" },
+      ],
+    });
+    render(<ChatPanel />);
+    expect(screen.getByText("show my jobs")).toBeInTheDocument();
+    expect(screen.getByText("Here they are")).toBeInTheDocument();
+  });
+
+  test("surfaces an error banner", () => {
+    render(<ChatPanel />);
+    act(() => {
+      useChatStore
+        .getState()
+        .applyError(
+          "The assistant is currently unavailable. Please try again.",
+        );
+    });
+    expect(screen.getByText(/currently unavailable/i)).toBeInTheDocument();
+  });
+});

--- a/frontend/tests/components/chat/ChatPanel.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.test.jsx
@@ -1,6 +1,7 @@
 import React from "react";
+import axios from "axios";
 import "@testing-library/jest-dom";
-import { render, screen, act } from "@testing-library/react";
+import { render, screen, act, fireEvent } from "@testing-library/react";
 
 import { ChatPanel } from "../../../src/components/chat/ChatPanel";
 import {
@@ -8,6 +9,8 @@ import {
   ConnectionState,
   MessageRole,
 } from "../../../src/stores/useChatStore";
+
+jest.mock("axios");
 
 // No-op WebSocket so the lazily-connecting hook does not touch the network in jsdom. It opens on
 // the next tick so the hook transitions CONNECTING -> CONNECTED like a real socket.
@@ -36,6 +39,11 @@ const baseState = {
   isStreaming: false,
   connectionState: ConnectionState.CONNECTED,
   error: null,
+  sessions: [],
+  sessionsLoading: false,
+  sessionsError: null,
+  historyLoading: false,
+  navEpoch: 0,
 };
 
 describe("ChatPanel", () => {
@@ -46,6 +54,8 @@ describe("ChatPanel", () => {
   beforeEach(() => {
     global.WebSocket = StubWebSocket;
     useChatStore.setState(baseState);
+    // the sessions view fetches the list on mount
+    axios.get.mockResolvedValue({ data: { total_pages: 1, results: [] } });
   });
 
   test("renders the composer and the connection badge when open", async () => {
@@ -77,5 +87,25 @@ describe("ChatPanel", () => {
         );
     });
     expect(screen.getByText(/currently unavailable/i)).toBeInTheDocument();
+  });
+
+  test("toggles between the conversation and the sessions view", async () => {
+    render(<ChatPanel />);
+    // starts on the conversation view
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Show conversations/i }),
+    );
+    // sessions view: New chat present, composer gone
+    expect(
+      await screen.findByRole("button", { name: /New chat/i }),
+    ).toBeInTheDocument();
+    expect(screen.queryByPlaceholderText(/Ask about/i)).not.toBeInTheDocument();
+
+    fireEvent.click(
+      screen.getByRole("button", { name: /Back to conversation/i }),
+    );
+    expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
   });
 });

--- a/frontend/tests/components/chat/ChatSessionList.test.jsx
+++ b/frontend/tests/components/chat/ChatSessionList.test.jsx
@@ -1,0 +1,123 @@
+import React from "react";
+import axios from "axios";
+import "@testing-library/jest-dom";
+import { render, screen, fireEvent, waitFor } from "@testing-library/react";
+
+import { ChatSessionList } from "../../../src/components/chat/ChatSessionList";
+import { useChatStore } from "../../../src/stores/useChatStore";
+import { areYouSureConfirmDialog } from "../../../src/components/common/areYouSureConfirmDialog";
+
+jest.mock("axios");
+jest.mock("../../../src/components/common/areYouSureConfirmDialog", () => ({
+  areYouSureConfirmDialog: jest.fn(),
+}));
+
+const baseState = {
+  sessions: [],
+  sessionsLoading: false,
+  sessionsError: null,
+  sessionId: null,
+  isStreaming: false,
+  navEpoch: 0,
+};
+
+// Resolve fetchSessions on mount with the given page payload.
+function mockSessionsPage(results) {
+  axios.get.mockResolvedValueOnce({ data: { total_pages: 1, results } });
+}
+
+describe("ChatSessionList", () => {
+  beforeEach(() => {
+    useChatStore.setState(baseState);
+    jest.clearAllMocks();
+  });
+
+  test("renders a row per fetched session with its backend-provided title", async () => {
+    mockSessionsPage([
+      { id: 1, created_at: "2026-06-11T14:02:00Z", title: "my first question" },
+    ]);
+    render(<ChatSessionList onSessionChosen={jest.fn()} />);
+    expect(await screen.findByText("my first question")).toBeInTheDocument();
+    expect(screen.getByText("2026-06-11 14:02")).toBeInTheDocument();
+  });
+
+  test("shows the empty state when there are no sessions", async () => {
+    mockSessionsPage([]);
+    render(<ChatSessionList onSessionChosen={jest.fn()} />);
+    expect(
+      await screen.findByText(/No conversations yet/i),
+    ).toBeInTheDocument();
+  });
+
+  test("shows an error alert when the fetch fails", async () => {
+    axios.get.mockRejectedValueOnce(new Error("boom"));
+    render(<ChatSessionList onSessionChosen={jest.fn()} />);
+    expect(await screen.findByText(/conversations/i)).toBeInTheDocument();
+  });
+
+  test("selecting a row switches session and returns to the conversation", async () => {
+    const switchSession = jest.fn();
+    const onSessionChosen = jest.fn();
+    useChatStore.setState({ switchSession });
+    mockSessionsPage([
+      { id: 7, created_at: "2026-06-11T14:02:00Z", title: "pick me" },
+    ]);
+    render(<ChatSessionList onSessionChosen={onSessionChosen} />);
+    fireEvent.click(await screen.findByText("pick me"));
+    expect(switchSession).toHaveBeenCalledWith(7);
+    expect(onSessionChosen).toHaveBeenCalled();
+  });
+
+  test("New chat starts a fresh conversation and returns to the conversation", async () => {
+    const newChat = jest.fn();
+    const onSessionChosen = jest.fn();
+    useChatStore.setState({ newChat });
+    mockSessionsPage([]);
+    render(<ChatSessionList onSessionChosen={onSessionChosen} />);
+    fireEvent.click(screen.getByRole("button", { name: /New chat/i }));
+    expect(newChat).toHaveBeenCalled();
+    expect(onSessionChosen).toHaveBeenCalled();
+  });
+
+  test("delete asks for confirmation and deletes when confirmed", async () => {
+    const deleteSession = jest.fn();
+    useChatStore.setState({ deleteSession });
+    areYouSureConfirmDialog.mockResolvedValueOnce(true);
+    mockSessionsPage([{ id: 3, created_at: "2026-06-11T14:02:00Z" }]);
+    render(<ChatSessionList onSessionChosen={jest.fn()} />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Delete conversation/i }),
+    );
+    await waitFor(() => expect(deleteSession).toHaveBeenCalledWith(3));
+  });
+
+  test("delete does nothing when the confirmation is dismissed", async () => {
+    const deleteSession = jest.fn();
+    useChatStore.setState({ deleteSession });
+    areYouSureConfirmDialog.mockResolvedValueOnce(false);
+    mockSessionsPage([{ id: 3, created_at: "2026-06-11T14:02:00Z" }]);
+    render(<ChatSessionList onSessionChosen={jest.fn()} />);
+    fireEvent.click(
+      await screen.findByRole("button", { name: /Delete conversation/i }),
+    );
+    await waitFor(() => expect(areYouSureConfirmDialog).toHaveBeenCalled());
+    expect(deleteSession).not.toHaveBeenCalled();
+  });
+
+  test("switching sessions while streaming proceeds (navigation is not locked)", async () => {
+    const switchSession = jest.fn();
+    const onSessionChosen = jest.fn();
+    useChatStore.setState({ isStreaming: true, switchSession });
+    mockSessionsPage([
+      { id: 1, created_at: "2026-06-11T14:02:00Z", title: "a row" },
+    ]);
+    render(<ChatSessionList onSessionChosen={onSessionChosen} />);
+    // New chat is enabled even while streaming
+    expect(
+      screen.getByRole("button", { name: /New chat/i }),
+    ).not.toBeDisabled();
+    fireEvent.click(await screen.findByText("a row"));
+    expect(switchSession).toHaveBeenCalledWith(1);
+    expect(onSessionChosen).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/chat/chatMarkdown.test.jsx
+++ b/frontend/tests/components/chat/chatMarkdown.test.jsx
@@ -1,0 +1,28 @@
+import React from "react";
+import "@testing-library/jest-dom";
+import { render, screen } from "@testing-library/react";
+
+import { chatMarkdownToHtml } from "../../../src/components/chat/chatMarkdown";
+
+describe("chatMarkdownToHtml", () => {
+  test("renders a GFM table (the reason remark-gfm is added)", () => {
+    const markdown = "| Job | Status |\n| --- | --- |\n| 1 | success |";
+    render(<div>{chatMarkdownToHtml(markdown)}</div>);
+    const table = screen.getByRole("table");
+    expect(table).toBeInTheDocument();
+    expect(table.className).toContain("table");
+    expect(screen.getByText("success")).toBeInTheDocument();
+  });
+
+  test("renders links opening in a new tab", () => {
+    render(<div>{chatMarkdownToHtml("[docs](https://example.com)")}</div>);
+    const link = screen.getByRole("link", { name: "docs" });
+    expect(link).toHaveAttribute("target", "_blank");
+    expect(link).toHaveAttribute("href", "https://example.com");
+  });
+
+  test("renders bold text without GFM-specific syntax", () => {
+    render(<div>{chatMarkdownToHtml("This is **bold**")}</div>);
+    expect(screen.getByText("bold").tagName).toBe("STRONG");
+  });
+});

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -253,6 +253,35 @@ describe("useChatWebSocket", () => {
     expect(FakeWebSocket.instances).toHaveLength(2);
   });
 
+  test("keeps the max-turn watchdog armed across a mid-turn reconnect", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    expect(useChatStore.getState().isStreaming).toBe(true);
+
+    // socket drops mid-turn, then reconnects; the in-flight turn's `end` is lost in the dead window
+    act(() => {
+      lastSocket().mockServerClose(1006);
+    });
+    act(() => {
+      jest.advanceTimersByTime(1000); // reconnect backoff
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+    act(() => {
+      lastSocket().mockOpen();
+    });
+
+    // the watchdog survived the drop and still unlocks the composer instead of hanging on isStreaming
+    act(() => {
+      jest.advanceTimersByTime(310000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/too long/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
   test("does not reconnect on a clean close", () => {
     connectAndOpen();
     act(() => {

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -67,6 +67,7 @@ const initialState = {
   isStreaming: false,
   connectionState: ConnectionState.IDLE,
   error: null,
+  navEpoch: 0,
 };
 
 describe("useChatWebSocket", () => {
@@ -294,5 +295,131 @@ describe("useChatWebSocket", () => {
       jest.advanceTimersByTime(60000);
     });
     expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+
+  test("newChat unbinds the session so a previous session's late frame is ignored", () => {
+    connectAndOpen();
+    act(() => {
+      useChatStore.setState({
+        sessionId: 5,
+        messages: [{ role: "user", content: "x" }],
+      });
+    });
+    act(() => {
+      useChatStore.getState().newChat();
+    });
+    expect(useChatStore.getState().sessionId).toBeNull();
+    // a late `end` from the abandoned session must not append to the fresh conversation
+    act(() => {
+      lastSocket().mockMessage({
+        type: "end",
+        session_id: 5,
+        message_id: 1,
+        content: "late",
+      });
+    });
+    expect(useChatStore.getState().messages).toEqual([]);
+  });
+
+  test("the post-ack watchdog does not fire after the user navigates away mid-turn", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+    });
+    // user opens a fresh chat before `start` arrives: the abandoned turn's post-ack watchdog
+    // (armed under the old navEpoch) must not raise an error onto the new conversation
+    act(() => {
+      useChatStore.getState().newChat();
+    });
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+    expect(useChatStore.getState().error).toBeNull();
+  });
+
+  test("the max-turn watchdog does not fire after the user navigates away mid-turn", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      useChatStore.getState().newChat();
+    });
+    act(() => {
+      jest.advanceTimersByTime(310000);
+    });
+    expect(useChatStore.getState().error).toBeNull();
+  });
+
+  test("a stale turn's watchdog does not clobber a newer overlapping turn's timer", () => {
+    connectAndOpen();
+    // turn A starts and arms its max-turn watchdog (epoch 0)
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(100000); // A still in flight
+    });
+    // user abandons A mid-turn and starts turn B (epoch bumped by newChat)
+    act(() => {
+      useChatStore.getState().newChat();
+      fireEvent.click(screen.getByText("send"));
+    });
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 7 });
+      lastSocket().mockMessage({ type: "start", session_id: 7 });
+    });
+    // A's max-turn deadline elapses while B is still streaming: A's stale callback must NOT null
+    // the ref that now holds B's timer (else B's timer is orphaned and clearTurnTimers can't cancel it)
+    act(() => {
+      jest.advanceTimersByTime(210000); // t = 310000 -> A's timer fires
+    });
+    // B completes cleanly
+    act(() => {
+      lastSocket().mockMessage({
+        type: "end",
+        session_id: 7,
+        message_id: 9,
+        content: "done",
+      });
+    });
+    // B's original deadline passes; a cancelled timer must not resurrect a timeout error on B
+    act(() => {
+      jest.advanceTimersByTime(100000); // t = 410000 -> B's (cancelled) timer would have fired
+    });
+    expect(useChatStore.getState().error).toBeNull();
+  });
+
+  test("after newChat, sending starts a fresh session bound by the next ack", () => {
+    connectAndOpen();
+    act(() => {
+      useChatStore.setState({ sessionId: 5 });
+      useChatStore.getState().newChat();
+    });
+    act(() => {
+      fireEvent.click(screen.getByText("send"));
+    });
+    // a fresh chat sends session_id: null; the server creates the session and returns it in `ack`
+    expect(lastSocket().sent).toEqual([{ message: "hello", session_id: null }]);
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 7 });
+      lastSocket().mockMessage({ type: "start", session_id: 7 });
+      lastSocket().mockMessage({ type: "token", session_id: 7, content: "hi" });
+      lastSocket().mockMessage({
+        type: "end",
+        session_id: 7,
+        message_id: 9,
+        content: "hi!",
+      });
+    });
+    const state = useChatStore.getState();
+    expect(state.sessionId).toBe(7);
+    expect(state.messages.at(-1)).toEqual({
+      id: 9,
+      role: "assistant",
+      content: "hi!",
+    });
   });
 });

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -68,6 +68,7 @@ const initialState = {
   connectionState: ConnectionState.IDLE,
   error: null,
   navEpoch: 0,
+  assistantUnavailable: false,
 };
 
 describe("useChatWebSocket", () => {
@@ -211,6 +212,8 @@ describe("useChatWebSocket", () => {
     const state = useChatStore.getState();
     expect(state.error).toMatch(/unavailable/i);
     expect(state.isStreaming).toBe(false);
+    // the worker did not pick up the turn -> the badge must reflect it (not just the error banner)
+    expect(state.assistantUnavailable).toBe(true);
   });
 
   test("post-ack watchdog is cleared once start arrives", () => {
@@ -237,6 +240,8 @@ describe("useChatWebSocket", () => {
     const state = useChatStore.getState();
     expect(state.error).toMatch(/too long/i);
     expect(state.isStreaming).toBe(false);
+    // a mid-turn timeout is not a worker-down signal, so it must NOT flip the availability badge
+    expect(state.assistantUnavailable).toBe(false);
   });
 
   test("reconnects with backoff on an unexpected close", () => {

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -1,0 +1,269 @@
+import React from "react";
+import { render, screen, fireEvent, act } from "@testing-library/react";
+
+import { useChatWebSocket } from "../../../src/components/chat/useChatWebSocket";
+import {
+  useChatStore,
+  ConnectionState,
+} from "../../../src/stores/useChatStore";
+
+// Minimal controllable WebSocket double (jsdom has none). Tests drive the server side via the
+// mock* helpers and inspect what the hook sent.
+class FakeWebSocket {
+  constructor(url) {
+    this.url = url;
+    this.readyState = FakeWebSocket.CONNECTING;
+    this.sent = [];
+    FakeWebSocket.instances.push(this);
+  }
+
+  send(data) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  close(code) {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code: code ?? 1000 });
+  }
+
+  // --- test helpers ---
+  mockOpen() {
+    this.readyState = FakeWebSocket.OPEN;
+    if (this.onopen) this.onopen({});
+  }
+
+  mockMessage(payload) {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(payload) });
+  }
+
+  mockServerClose(code) {
+    this.readyState = FakeWebSocket.CLOSED;
+    if (this.onclose) this.onclose({ code });
+  }
+}
+FakeWebSocket.OPEN = 1;
+FakeWebSocket.CONNECTING = 0;
+FakeWebSocket.CLOSED = 3;
+FakeWebSocket.instances = [];
+
+function Harness() {
+  const { sendMessage } = useChatWebSocket();
+  return (
+    <button type="button" onClick={() => sendMessage("hello")}>
+      send
+    </button>
+  );
+}
+
+const lastSocket = () =>
+  FakeWebSocket.instances[FakeWebSocket.instances.length - 1];
+
+const initialState = {
+  isOpen: false,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.IDLE,
+  error: null,
+};
+
+describe("useChatWebSocket", () => {
+  beforeEach(() => {
+    jest.useFakeTimers();
+    FakeWebSocket.instances = [];
+    global.WebSocket = FakeWebSocket;
+    useChatStore.setState(initialState);
+  });
+
+  afterEach(() => {
+    jest.useRealTimers();
+  });
+
+  // open the drawer so the hook lazily connects, then complete the handshake
+  function connectAndOpen() {
+    render(<Harness />);
+    act(() => {
+      useChatStore.getState().open();
+    });
+    act(() => {
+      lastSocket().mockOpen();
+    });
+  }
+
+  test("connects lazily on open and reaches CONNECTED", () => {
+    render(<Harness />);
+    expect(FakeWebSocket.instances).toHaveLength(0); // not connected while closed
+    act(() => {
+      useChatStore.getState().open();
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    expect(lastSocket().url).toContain("/ws/chat/?context_url=");
+    act(() => {
+      lastSocket().mockOpen();
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CONNECTED,
+    );
+  });
+
+  test("sendMessage emits {message, session_id} and binds the session on ack", () => {
+    connectAndOpen();
+    act(() => {
+      fireEvent.click(screen.getByText("send"));
+    });
+    expect(lastSocket().sent).toEqual([{ message: "hello", session_id: null }]);
+    expect(useChatStore.getState().messages).toHaveLength(1);
+
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+    });
+    expect(useChatStore.getState().sessionId).toBe(5);
+  });
+
+  test("streams start -> token -> end for the active session", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+      lastSocket().mockMessage({
+        type: "status",
+        session_id: 5,
+        tool: "search_jobs",
+      });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 5,
+        content: "Hi ",
+      });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 5,
+        content: "you",
+      });
+    });
+    expect(useChatStore.getState().streamingText).toBe("Hi you");
+    expect(useChatStore.getState().currentTool).toBe("search_jobs");
+
+    act(() => {
+      lastSocket().mockMessage({
+        type: "end",
+        session_id: 5,
+        message_id: 9,
+        content: "Hi you!",
+      });
+    });
+    const state = useChatStore.getState();
+    expect(state.messages.at(-1)).toEqual({
+      id: 9,
+      role: "assistant",
+      content: "Hi you!",
+    });
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("ignores streaming frames for another session (multi-tab demux)", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+      lastSocket().mockMessage({
+        type: "token",
+        session_id: 999,
+        content: "X",
+      });
+    });
+    expect(useChatStore.getState().streamingText).toBe("");
+  });
+
+  test("surfaces a null-session error but ignores another session's error", () => {
+    connectAndOpen();
+    act(() => {
+      useChatStore.setState({ sessionId: 5 });
+      lastSocket().mockMessage({
+        type: "error",
+        session_id: 999,
+        detail: "other tab",
+      });
+    });
+    expect(useChatStore.getState().error).toBeNull();
+
+    act(() => {
+      lastSocket().mockMessage({
+        type: "error",
+        session_id: null,
+        detail: "Invalid message payload.",
+      });
+    });
+    expect(useChatStore.getState().error).toBe("Invalid message payload.");
+  });
+
+  test("post-ack watchdog fires when no start follows the ack", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/unavailable/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("post-ack watchdog is cleared once start arrives", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(20000);
+    });
+    expect(useChatStore.getState().error).toBeNull();
+  });
+
+  test("max-turn watchdog fires when no end follows start", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockMessage({ type: "ack", session_id: 5 });
+      lastSocket().mockMessage({ type: "start", session_id: 5 });
+    });
+    act(() => {
+      jest.advanceTimersByTime(310000);
+    });
+    const state = useChatStore.getState();
+    expect(state.error).toMatch(/too long/i);
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("reconnects with backoff on an unexpected close", () => {
+    connectAndOpen();
+    expect(FakeWebSocket.instances).toHaveLength(1);
+    act(() => {
+      lastSocket().mockServerClose(1006); // abnormal closure
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.RECONNECTING,
+    );
+    act(() => {
+      jest.advanceTimersByTime(1000); // first backoff step
+    });
+    expect(FakeWebSocket.instances).toHaveLength(2);
+  });
+
+  test("does not reconnect on a clean close", () => {
+    connectAndOpen();
+    act(() => {
+      lastSocket().mockServerClose(1000); // normal closure
+    });
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CLOSED,
+    );
+    act(() => {
+      jest.advanceTimersByTime(60000);
+    });
+    expect(FakeWebSocket.instances).toHaveLength(1);
+  });
+});

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -1,0 +1,100 @@
+import {
+  useChatStore,
+  ConnectionState,
+  MessageRole,
+} from "../../src/stores/useChatStore";
+
+const initialState = {
+  isOpen: false,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.IDLE,
+  error: null,
+};
+
+describe("useChatStore reducers", () => {
+  beforeEach(() => {
+    useChatStore.setState(initialState);
+  });
+
+  test("toggle flips isOpen", () => {
+    useChatStore.getState().toggle();
+    expect(useChatStore.getState().isOpen).toBe(true);
+    useChatStore.getState().toggle();
+    expect(useChatStore.getState().isOpen).toBe(false);
+  });
+
+  test("applyAck binds the session id", () => {
+    useChatStore.getState().applyAck({ session_id: 42 });
+    expect(useChatStore.getState().sessionId).toBe(42);
+  });
+
+  test("enqueueUserMessage appends the user message and locks the turn", () => {
+    useChatStore.setState({ error: "stale" });
+    useChatStore.getState().enqueueUserMessage("hello");
+    const state = useChatStore.getState();
+    expect(state.messages).toEqual([
+      { role: MessageRole.USER, content: "hello" },
+    ]);
+    expect(state.isStreaming).toBe(true);
+    expect(state.error).toBeNull();
+  });
+
+  test("applyStart resets the streaming turn", () => {
+    useChatStore.setState({
+      streamingText: "leftover",
+      currentTool: "search_jobs",
+    });
+    useChatStore.getState().applyStart();
+    const state = useChatStore.getState();
+    expect(state.streamingText).toBe("");
+    expect(state.currentTool).toBeNull();
+    expect(state.isStreaming).toBe(true);
+  });
+
+  test("applyStatus sets the current tool", () => {
+    useChatStore.getState().applyStatus({ tool: "get_job_details" });
+    expect(useChatStore.getState().currentTool).toBe("get_job_details");
+  });
+
+  test("applyToken appends streaming text incrementally", () => {
+    useChatStore.getState().applyToken({ content: "Hel" });
+    useChatStore.getState().applyToken({ content: "lo" });
+    expect(useChatStore.getState().streamingText).toBe("Hello");
+  });
+
+  test("applyEnd commits the assistant message and clears the turn", () => {
+    useChatStore.setState({
+      streamingText: "Hel",
+      currentTool: "search_jobs",
+      isStreaming: true,
+    });
+    useChatStore.getState().applyEnd({ message_id: 7, content: "Hello there" });
+    const state = useChatStore.getState();
+    expect(state.messages).toEqual([
+      { id: 7, role: MessageRole.ASSISTANT, content: "Hello there" },
+    ]);
+    expect(state.streamingText).toBe("");
+    expect(state.currentTool).toBeNull();
+    expect(state.isStreaming).toBe(false);
+  });
+
+  test("applyError surfaces the detail and ends the turn", () => {
+    useChatStore.setState({ streamingText: "partial", isStreaming: true });
+    useChatStore.getState().applyError("boom");
+    const state = useChatStore.getState();
+    expect(state.error).toBe("boom");
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingText).toBe("");
+  });
+
+  test("setConnectionState updates the badge state", () => {
+    useChatStore.getState().setConnectionState(ConnectionState.CONNECTED);
+    expect(useChatStore.getState().connectionState).toBe(
+      ConnectionState.CONNECTED,
+    );
+  });
+});

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -24,6 +24,7 @@ const initialState = {
   sessionsError: null,
   historyLoading: false,
   navEpoch: 0,
+  assistantUnavailable: false,
 };
 
 describe("useChatStore reducers", () => {
@@ -100,6 +101,26 @@ describe("useChatStore reducers", () => {
     expect(state.error).toBe("boom");
     expect(state.isStreaming).toBe(false);
     expect(state.streamingText).toBe("");
+  });
+
+  test("applyUnavailable flags the assistant unavailable and ends the turn", () => {
+    useChatStore.setState({ streamingText: "partial", isStreaming: true });
+    useChatStore
+      .getState()
+      .applyUnavailable(
+        "The assistant is currently unavailable. Please try again.",
+      );
+    const state = useChatStore.getState();
+    expect(state.assistantUnavailable).toBe(true);
+    expect(state.error).toMatch(/unavailable/i);
+    expect(state.isStreaming).toBe(false);
+    expect(state.streamingText).toBe("");
+  });
+
+  test("applyStart clears a prior assistantUnavailable flag", () => {
+    useChatStore.setState({ assistantUnavailable: true });
+    useChatStore.getState().applyStart();
+    expect(useChatStore.getState().assistantUnavailable).toBe(false);
   });
 
   test("setConnectionState updates the badge state", () => {

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -1,8 +1,14 @@
+import axios from "axios";
+
 import {
   useChatStore,
   ConnectionState,
   MessageRole,
+  deriveSessionLabel,
 } from "../../src/stores/useChatStore";
+import { CHATBOT_SESSIONS_URI } from "../../src/constants/apiURLs";
+
+jest.mock("axios");
 
 const initialState = {
   isOpen: false,
@@ -13,6 +19,11 @@ const initialState = {
   isStreaming: false,
   connectionState: ConnectionState.IDLE,
   error: null,
+  sessions: [],
+  sessionsLoading: false,
+  sessionsError: null,
+  historyLoading: false,
+  navEpoch: 0,
 };
 
 describe("useChatStore reducers", () => {
@@ -96,5 +107,190 @@ describe("useChatStore reducers", () => {
     expect(useChatStore.getState().connectionState).toBe(
       ConnectionState.CONNECTED,
     );
+  });
+});
+
+describe("deriveSessionLabel", () => {
+  // jest runs with TZ=UTC, so the date fallback is deterministic.
+  const session = { id: 1, created_at: "2026-06-11T14:02:00Z" };
+
+  test("uses the backend-provided title (trimmed) when present", () => {
+    expect(deriveSessionLabel({ ...session, title: "  hello there  " })).toBe(
+      "hello there",
+    );
+  });
+
+  test("falls back to the formatted created_at when there is no title", () => {
+    expect(deriveSessionLabel({ ...session, title: null })).toBe(
+      "2026-06-11 14:02",
+    );
+    expect(deriveSessionLabel(session)).toBe("2026-06-11 14:02");
+  });
+});
+
+describe("useChatStore session management", () => {
+  beforeEach(() => {
+    useChatStore.setState(initialState);
+    jest.clearAllMocks();
+  });
+
+  test("fetchSessions loads a single page", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { total_pages: 1, results: [{ id: 1 }, { id: 2 }] },
+    });
+    await useChatStore.getState().fetchSessions();
+    const state = useChatStore.getState();
+    expect(state.sessions).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(state.sessionsLoading).toBe(false);
+    expect(state.sessionsError).toBeNull();
+  });
+
+  test("fetchSessions concatenates every page", async () => {
+    axios.get
+      .mockResolvedValueOnce({ data: { total_pages: 2, results: [{ id: 1 }] } })
+      .mockResolvedValueOnce({
+        data: { total_pages: 2, results: [{ id: 2 }] },
+      });
+    await useChatStore.getState().fetchSessions();
+    expect(useChatStore.getState().sessions).toEqual([{ id: 1 }, { id: 2 }]);
+    expect(axios.get).toHaveBeenCalledTimes(2);
+  });
+
+  test("fetchSessions surfaces an error and clears loading", async () => {
+    axios.get.mockRejectedValueOnce(new Error("boom"));
+    await useChatStore.getState().fetchSessions();
+    const state = useChatStore.getState();
+    expect(state.sessionsError).toMatch(/conversations/i);
+    expect(state.sessionsLoading).toBe(false);
+  });
+
+  test("switchSession loads history oldest-first and binds the session", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        total_pages: 1,
+        results: [
+          { id: 10, role: "user", content: "hi", timestamp: "t1" },
+          { id: 11, role: "assistant", content: "yo", timestamp: "t2" },
+        ],
+      },
+    });
+    useChatStore.setState({ streamingText: "stale", currentTool: "x" });
+    await useChatStore.getState().switchSession(3);
+    const state = useChatStore.getState();
+    expect(state.sessionId).toBe(3);
+    expect(state.messages).toEqual([
+      { id: 10, role: "user", content: "hi" },
+      { id: 11, role: "assistant", content: "yo" },
+    ]);
+    expect(state.streamingText).toBe("");
+    expect(state.currentTool).toBeNull();
+    expect(state.historyLoading).toBe(false);
+  });
+
+  test("switchSession is a no-op for the already-active session", async () => {
+    useChatStore.setState({ sessionId: 3 });
+    await useChatStore.getState().switchSession(3);
+    expect(axios.get).not.toHaveBeenCalled();
+  });
+
+  test("switchSession proceeds while streaming and bumps navEpoch to abandon the turn", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: {
+        total_pages: 1,
+        results: [{ id: 20, role: "user", content: "hey" }],
+      },
+    });
+    useChatStore.setState({ isStreaming: true, sessionId: 1, navEpoch: 4 });
+    await useChatStore.getState().switchSession(2);
+    const state = useChatStore.getState();
+    expect(state.sessionId).toBe(2);
+    expect(state.messages).toEqual([{ id: 20, role: "user", content: "hey" }]);
+    // the in-flight turn is abandoned: its state is reset and the epoch bumped so the WS hook's
+    // watchdog (armed under epoch 4) no longer applies to the now-active session.
+    expect(state.isStreaming).toBe(false);
+    expect(state.navEpoch).toBe(5);
+  });
+
+  test("switchSession drops a stale result when the user switched again mid-flight", async () => {
+    let resolve;
+    axios.get.mockReturnValueOnce(
+      new Promise((res) => {
+        resolve = res;
+      }),
+    );
+    const pending = useChatStore.getState().switchSession(1);
+    // user switched to another session before the history request resolved
+    useChatStore.setState({ sessionId: 2 });
+    resolve({
+      data: {
+        total_pages: 1,
+        results: [{ id: 1, role: "user", content: "old" }],
+      },
+    });
+    await pending;
+    expect(useChatStore.getState().messages).toEqual([]);
+  });
+
+  test("newChat resets to a fresh, unbound conversation and bumps navEpoch", () => {
+    useChatStore.setState({
+      sessionId: 7,
+      messages: [{ role: "user", content: "x" }],
+      streamingText: "partial",
+      error: "stale",
+      navEpoch: 2,
+    });
+    useChatStore.getState().newChat();
+    const state = useChatStore.getState();
+    expect(state.sessionId).toBeNull();
+    expect(state.messages).toEqual([]);
+    expect(state.streamingText).toBe("");
+    expect(state.isStreaming).toBe(false);
+    expect(state.error).toBeNull();
+    expect(state.navEpoch).toBe(3);
+  });
+
+  test("newChat resets even while a turn is streaming", () => {
+    useChatStore.setState({ isStreaming: true, sessionId: 7, navEpoch: 5 });
+    useChatStore.getState().newChat();
+    const state = useChatStore.getState();
+    expect(state.sessionId).toBeNull();
+    expect(state.isStreaming).toBe(false);
+    expect(state.navEpoch).toBe(6);
+  });
+
+  test("deleteSession removes the active session and falls back to a fresh chat", async () => {
+    axios.delete.mockResolvedValueOnce({});
+    useChatStore.setState({
+      sessions: [{ id: 1 }, { id: 2 }],
+      sessionId: 1,
+      messages: [{ role: "user", content: "x" }],
+    });
+    await useChatStore.getState().deleteSession(1);
+    const state = useChatStore.getState();
+    expect(axios.delete).toHaveBeenCalledWith(`${CHATBOT_SESSIONS_URI}/1`);
+    expect(state.sessions).toEqual([{ id: 2 }]);
+    expect(state.sessionId).toBeNull();
+    expect(state.messages).toEqual([]);
+  });
+
+  test("deleteSession leaves the active session untouched when deleting another", async () => {
+    axios.delete.mockResolvedValueOnce({});
+    useChatStore.setState({
+      sessions: [{ id: 1 }, { id: 2 }],
+      sessionId: 2,
+    });
+    await useChatStore.getState().deleteSession(1);
+    const state = useChatStore.getState();
+    expect(state.sessions).toEqual([{ id: 2 }]);
+    expect(state.sessionId).toBe(2);
+  });
+
+  test("deleteSession surfaces an error and keeps the list intact", async () => {
+    axios.delete.mockRejectedValueOnce(new Error("boom"));
+    useChatStore.setState({ sessions: [{ id: 1 }] });
+    await useChatStore.getState().deleteSession(1);
+    const state = useChatStore.getState();
+    expect(state.sessionsError).toMatch(/delete/i);
+    expect(state.sessions).toEqual([{ id: 1 }]);
   });
 });

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -142,6 +142,32 @@ class ChatSessionViewSetTestCase(APITestCase):
         )
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
+    def test_list_annotates_title_from_first_user_message(self):
+        session = ChatSession.objects.create(user=self.user)
+        ChatMessage.objects.create(session=session, role=ChatMessage.Role.USER, content="Show me recent jobs")
+        ChatMessage.objects.create(session=session, role=ChatMessage.Role.ASSISTANT, content="Here they are.")
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        results = response.json()["results"]
+        self.assertEqual(len(results), 1)
+        self.assertEqual(results[0]["title"], "Show me recent jobs")
+
+    def test_list_truncates_title_to_40_chars(self):
+        session = ChatSession.objects.create(user=self.user)
+        long_msg = "a" * 60
+        ChatMessage.objects.create(session=session, role=ChatMessage.Role.USER, content=long_msg)
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        title = response.json()["results"][0]["title"]
+        self.assertEqual(len(title), 40)
+        self.assertEqual(title, long_msg[:40])
+
+    def test_list_title_is_null_for_empty_session(self):
+        ChatSession.objects.create(user=self.user)
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertIsNone(response.json()["results"][0]["title"])
+
     def tearDown(self):
         ChatSession.objects.filter(user=self.user).delete()
 


### PR DESCRIPTION
# (Part of #3763) Chat Sessions List + Unlocked Navigation

## Description

Refs #3763

This PR implements the Chat Sessions view (W7 PR3) and introduces two major improvements based on maintainer feedback:

### 1. Session title from the backend (`api_app/chatbot_manager`)

- **Backend**: `GET /sessions` now annotates each session with a `title` — the first user message, truncated to 40 chars via a correlated `Subquery` (no N+1, no extra payload). Only runs on the `list` action.
- **Serializer**: `ChatSessionSerializer` exposes `title` (read-only, nullable).
- **Frontend**: `deriveSessionLabel(session)` now takes a single argument — prefers `session.title`, falls back to formatted `created_at`. The old `sessionLabels` cache, `firstUserPreview()`, and the extra store selectors are all removed.
- **3 new backend tests** verify the annotation, 40-char truncation, and null fallback.

### 2. Navigation unlocked during streaming (`frontend/src/stores` & `useChatWebSocket`)

- **Store**: `switchSession` and `newChat` no longer block on `isStreaming`. Both bump `navEpoch` to signal abandonment.
- **WS hook**: The post-ack and max-turn watchdogs now capture `navEpoch` when armed. If the epoch has changed by the time they fire, they silently expire — no stale error fires onto the new conversation.
- **Component**: `ChatSessionList` removes `disabled={isStreaming}` from the "New chat" button and session rows.
- **Tests**: 5 updated + 4 new frontend tests cover the new behavior (63/63 green). 3 new backend tests (15/15 green).

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case its documentation was added or updated...
- [x] I have inspected and verified that the API schema is working
- [x] If external libraries/packages with restrictive licenses were used, they were added in the Legal Notice section
- [x] Linters (`Black`, `Flake8`, `Isort`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated
- [x] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [x] I have created new frontend tests for the new component or updated existing ones.

### Important rules

- [x] I have read and understood the rules
