### PR TITLE
[GSoC 2026] Proactive chatbot availability (health endpoint + drawer probe)

### DIFF
--- a/api_app/chatbot_manager/health.py
+++ b/api_app/chatbot_manager/health.py
@@ -1,0 +1,66 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import logging
+from dataclasses import dataclass
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+
+from intel_owl.celery import app as celery_app
+from intel_owl.celery import get_queue_name
+
+logger = logging.getLogger(__name__)
+
+# Bounds for the two liveness probes, kept small so the endpoint stays snappy under a cache miss.
+WORKER_INSPECT_TIMEOUT = 1  # seconds for the Celery control broadcast round-trip
+OLLAMA_PING_TIMEOUT = 3  # seconds for the Ollama HTTP probe
+# The result is user-agnostic, so cache it briefly: a drawer open / multiple tabs must not re-probe.
+HEALTH_CACHE_KEY = "chatbot_health"
+HEALTH_CACHE_TTL = 15  # seconds; recovery is reflected within at most this window
+# One user-safe message; which component is down is logged, not surfaced to the user.
+HEALTH_UNAVAILABLE_DETAIL = (
+    "The assistant is not available. Make sure the Ollama and chatbot services are running."
+)
+
+
+@dataclass
+class ChatHealth:
+    available: bool
+    detail: str
+
+
+def chatbot_health() -> ChatHealth:
+    """Whether the assistant can serve a turn now (chatbot worker + Ollama), cached briefly."""
+    cached = cache.get(HEALTH_CACHE_KEY)
+    if cached is not None:
+        return cached
+    result = _compute_health()
+    cache.set(HEALTH_CACHE_KEY, result, HEALTH_CACHE_TTL)
+    return result
+
+
+def _compute_health() -> ChatHealth:
+    worker_up = _chatbot_worker_consuming()
+    ollama_up = _ollama_reachable()
+    if worker_up and ollama_up:
+        return ChatHealth(available=True, detail="")
+    logger.warning("chatbot unavailable: worker_up=%s ollama_up=%s", worker_up, ollama_up)
+    return ChatHealth(available=False, detail=HEALTH_UNAVAILABLE_DETAIL)
+
+
+def _chatbot_worker_consuming() -> bool:
+    """True if at least one Celery worker is consuming the chatbot queue."""
+    # active_queues() -> {worker: [{"name": ...}, ...]} or None when no worker replies in time.
+    active = celery_app.control.inspect(timeout=WORKER_INSPECT_TIMEOUT).active_queues() or {}
+    queue = get_queue_name(settings.CHATBOT_QUEUE)
+    return any(q["name"] == queue for queues in active.values() for q in queues)
+
+
+def _ollama_reachable() -> bool:
+    """True if the Ollama daemon answers its version endpoint."""
+    try:
+        return requests.get(f"{settings.OLLAMA_BASE_URL}/api/version", timeout=OLLAMA_PING_TIMEOUT).ok
+    except requests.RequestException:
+        return False

--- a/api_app/chatbot_manager/serializers/health.py
+++ b/api_app/chatbot_manager/serializers/health.py
@@ -1,0 +1,11 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from rest_framework import serializers
+
+
+class ChatHealthSerializer(serializers.Serializer):
+    """Response shape for GET /api/chatbot/health (serializes a ChatHealth dataclass)."""
+
+    available = serializers.BooleanField(read_only=True)
+    detail = serializers.CharField(read_only=True, allow_blank=True)

--- a/api_app/chatbot_manager/urls.py
+++ b/api_app/chatbot_manager/urls.py
@@ -1,11 +1,14 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import ChatSessionViewSet
+from .views import ChatHealthView, ChatSessionViewSet
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r"sessions", ChatSessionViewSet, basename="chat-sessions")
 
-urlpatterns = router.urls
+urlpatterns = router.urls + [
+    path("health", ChatHealthView.as_view(), name="chat-health"),
+]

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -10,11 +10,13 @@ from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
 from rest_framework.permissions import IsAuthenticated
 from rest_framework.response import Response
+from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
 from .agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
 from .agent.memory import DjangoChatMessageHistory
 from .events import ChatErrorDetail
+from .health import chatbot_health
 from .models import ChatMessage, ChatSession
 from .serializers.chat import (
     ChatMessageSerializer,
@@ -22,6 +24,7 @@ from .serializers.chat import (
     MessageRequestSerializer,
     MessageResponseSerializer,
 )
+from .serializers.health import ChatHealthSerializer
 
 logger = logging.getLogger(__name__)
 
@@ -131,3 +134,12 @@ class ChatSessionViewSet(ModelViewSet):
 
         serializer = ChatMessageSerializer(queryset, many=True)
         return Response(serializer.data)
+
+
+class ChatHealthView(APIView):
+    """Proactive availability probe for the chat panel (chatbot worker + Ollama)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def get(self, request):
+        return Response(ChatHealthSerializer(chatbot_health()).data)

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -49,6 +49,7 @@ export function ChatPanel() {
     (state) => state.assistantUnavailable,
   );
   const error = useChatStore((state) => state.error);
+  const checkHealth = useChatStore((state) => state.checkHealth);
   const { sendMessage } = useChatWebSocket();
 
   // Master-detail mode: "conversation" (messages + composer) or "sessions" (the session list).
@@ -58,6 +59,12 @@ export function ChatPanel() {
   React.useEffect(() => {
     if (!isOpen) setView("conversation");
   }, [isOpen]);
+
+  // Proactively probe availability each time the drawer opens, so a down chatbot worker / Ollama is
+  // obvious immediately instead of after the post-ack watchdog.
+  React.useEffect(() => {
+    if (isOpen) checkHealth();
+  }, [isOpen, checkHealth]);
 
   // The badge reflects assistant availability, not just transport: a connected socket whose worker
   // isn't serving turns (assistantUnavailable) must not keep reading green "Connected".

--- a/frontend/src/constants/apiURLs.js
+++ b/frontend/src/constants/apiURLs.js
@@ -54,6 +54,7 @@ export const APIACCESS_BASE_URI = `${AUTH_BASE_URI}/apiaccess`;
 // chatbot (router uses trailing_slash=False, so these paths carry no trailing slash)
 export const CHATBOT_BASE_URI = `${API_BASE_URI}/chatbot`;
 export const CHATBOT_SESSIONS_URI = `${CHATBOT_BASE_URI}/sessions`;
+export const CHATBOT_HEALTH_URI = `${CHATBOT_BASE_URI}/health`;
 
 // WEBSOCKETS
 const WEBSOCKET_BASE_URI = "ws";

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -2,7 +2,7 @@ import { create } from "zustand";
 import axios from "axios";
 import { format } from "date-fns-tz";
 
-import { CHATBOT_SESSIONS_URI } from "../constants/apiURLs";
+import { CHATBOT_HEALTH_URI, CHATBOT_SESSIONS_URI } from "../constants/apiURLs";
 
 /**
  * Connection states for the chat WebSocket, surfaced in the UI as a status badge.
@@ -243,4 +243,25 @@ export const useChatStore = create((set, get) => ({
 
   // --- connection ---
   setConnectionState: (connectionState) => set({ connectionState }),
+
+  // Proactive availability probe, run when the drawer opens: if the chatbot worker or Ollama isn't
+  // up, surface the "Unavailable" badge + a banner at once instead of after the ~20s post-ack
+  // watchdog. A failed request is ignored (no false alarm); composer stays usable either way.
+  checkHealth: async () => {
+    let health;
+    try {
+      ({ data: health } = await axios.get(CHATBOT_HEALTH_URI));
+    } catch (error) {
+      return;
+    }
+    set((state) =>
+      health.available
+        ? {
+            assistantUnavailable: false,
+            // clear only the unavailable banner (on recovery), never an unrelated turn error
+            error: state.assistantUnavailable ? null : state.error,
+          }
+        : { assistantUnavailable: true, error: health.detail },
+    );
+  },
 }));

--- a/frontend/tests/components/chat/ChatPanel.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.test.jsx
@@ -55,8 +55,13 @@ describe("ChatPanel", () => {
   beforeEach(() => {
     global.WebSocket = StubWebSocket;
     useChatStore.setState(baseState);
-    // the sessions view fetches the list on mount
-    axios.get.mockResolvedValue({ data: { total_pages: 1, results: [] } });
+    // the drawer-open effect probes /health (assistant healthy by default) and the sessions view
+    // fetches the list on mount; route by URL so the open-probe never reads a sessions payload.
+    axios.get.mockImplementation((url) =>
+      url.includes("/health")
+        ? Promise.resolve({ data: { available: true, detail: "" } })
+        : Promise.resolve({ data: { total_pages: 1, results: [] } }),
+    );
   });
 
   test("renders the composer and the connection badge when open", async () => {
@@ -67,6 +72,12 @@ describe("ChatPanel", () => {
   });
 
   test("shows an Unavailable badge when the assistant is unavailable while connected", async () => {
+    // the open-probe reports the assistant down, so the flag stays set once it resolves
+    axios.get.mockImplementation((url) =>
+      url.includes("/health")
+        ? Promise.resolve({ data: { available: false, detail: "down" } })
+        : Promise.resolve({ data: { total_pages: 1, results: [] } }),
+    );
     useChatStore.setState({ assistantUnavailable: true });
     render(<ChatPanel />);
     // the socket is connected (transport fine) but the assistant can't serve a turn: the badge must
@@ -122,5 +133,18 @@ describe("ChatPanel", () => {
       screen.getByRole("button", { name: /Back to conversation/i }),
     );
     expect(screen.getByPlaceholderText(/Ask about/i)).toBeInTheDocument();
+  });
+
+  test("probes health when the drawer opens and surfaces an unavailable result", async () => {
+    axios.get.mockImplementation((url) =>
+      url.includes("/health")
+        ? Promise.resolve({
+            data: { available: false, detail: "Services down" },
+          })
+        : Promise.resolve({ data: { total_pages: 1, results: [] } }),
+    );
+    render(<ChatPanel />); // baseState has isOpen: true -> the open effect fires checkHealth
+    expect(await screen.findByText("Services down")).toBeInTheDocument();
+    expect(await screen.findByText("Unavailable")).toBeInTheDocument();
   });
 });

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -315,3 +315,52 @@ describe("useChatStore session management", () => {
     expect(state.sessions).toEqual([{ id: 1 }]);
   });
 });
+
+describe("useChatStore checkHealth", () => {
+  beforeEach(() => {
+    useChatStore.setState(initialState);
+    jest.clearAllMocks();
+  });
+
+  test("flags unavailable and shows the detail banner", async () => {
+    axios.get.mockResolvedValueOnce({
+      data: { available: false, detail: "down" },
+    });
+    await useChatStore.getState().checkHealth();
+    const state = useChatStore.getState();
+    expect(state.assistantUnavailable).toBe(true);
+    expect(state.error).toBe("down");
+  });
+
+  test("clears the unavailable banner when recovering", async () => {
+    useChatStore.setState({ assistantUnavailable: true, error: "down" });
+    axios.get.mockResolvedValueOnce({
+      data: { available: true, detail: "" },
+    });
+    await useChatStore.getState().checkHealth();
+    const state = useChatStore.getState();
+    expect(state.assistantUnavailable).toBe(false);
+    expect(state.error).toBeNull();
+  });
+
+  test("preserves an unrelated turn error when already available", async () => {
+    useChatStore.setState({
+      assistantUnavailable: false,
+      error: "turn failed",
+    });
+    axios.get.mockResolvedValueOnce({
+      data: { available: true, detail: "" },
+    });
+    await useChatStore.getState().checkHealth();
+    expect(useChatStore.getState().error).toBe("turn failed");
+  });
+
+  test("does nothing when the health request fails", async () => {
+    useChatStore.setState({ assistantUnavailable: false, error: null });
+    axios.get.mockRejectedValueOnce(new Error("boom"));
+    await useChatStore.getState().checkHealth();
+    const state = useChatStore.getState();
+    expect(state.assistantUnavailable).toBe(false);
+    expect(state.error).toBeNull();
+  });
+});

--- a/tests/api_app/chatbot_manager/test_health.py
+++ b/tests/api_app/chatbot_manager/test_health.py
@@ -1,0 +1,115 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+import requests
+from django.conf import settings
+from django.core.cache import cache
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api_app.chatbot_manager.health import (
+    HEALTH_UNAVAILABLE_DETAIL,
+    ChatHealth,
+    chatbot_health,
+)
+from certego_saas.apps.user.models import User
+from intel_owl.celery import get_queue_name
+
+CHATBOT_QUEUE_NAME = get_queue_name(settings.CHATBOT_QUEUE)
+
+
+def _celery_app(active_queues_return):
+    """A fake celery_app whose control.inspect().active_queues() returns the given value."""
+    app = MagicMock()
+    app.control.inspect.return_value.active_queues.return_value = active_queues_return
+    return app
+
+
+class ChatbotHealthTestCase(APITestCase):
+    def setUp(self):
+        cache.clear()
+
+    @patch("api_app.chatbot_manager.health.requests.get")
+    @patch(
+        "api_app.chatbot_manager.health.celery_app",
+        _celery_app({"worker1": [{"name": CHATBOT_QUEUE_NAME}]}),
+    )
+    def test_available_when_worker_and_ollama_up(self, mock_get):
+        mock_get.return_value = MagicMock(ok=True)
+        health = chatbot_health()
+        self.assertTrue(health.available)
+        self.assertEqual(health.detail, "")
+
+    @patch("api_app.chatbot_manager.health.requests.get")
+    @patch(
+        "api_app.chatbot_manager.health.celery_app",
+        _celery_app(None),  # no worker replied within the timeout
+    )
+    def test_unavailable_when_no_chatbot_worker(self, mock_get):
+        mock_get.return_value = MagicMock(ok=True)
+        health = chatbot_health()
+        self.assertFalse(health.available)
+        self.assertEqual(health.detail, HEALTH_UNAVAILABLE_DETAIL)
+
+    @patch(
+        "api_app.chatbot_manager.health.requests.get",
+        side_effect=requests.RequestException,
+    )
+    @patch(
+        "api_app.chatbot_manager.health.celery_app",
+        _celery_app({"worker1": [{"name": CHATBOT_QUEUE_NAME}]}),
+    )
+    def test_unavailable_when_ollama_unreachable(self, mock_get):
+        health = chatbot_health()
+        self.assertFalse(health.available)
+        self.assertEqual(health.detail, HEALTH_UNAVAILABLE_DETAIL)
+
+    @patch("api_app.chatbot_manager.health.requests.get")
+    @patch("api_app.chatbot_manager.health.celery_app")
+    def test_result_is_cached(self, mock_celery, mock_get):
+        mock_celery.control.inspect.return_value.active_queues.return_value = {
+            "worker1": [{"name": CHATBOT_QUEUE_NAME}]
+        }
+        mock_get.return_value = MagicMock(ok=True)
+        chatbot_health()
+        chatbot_health()
+        # second call is served from the cache -> the probes ran exactly once
+        mock_celery.control.inspect.assert_called_once()
+        mock_get.assert_called_once()
+
+    @patch("api_app.chatbot_manager.health.requests.get")
+    @patch(
+        "api_app.chatbot_manager.health.celery_app",
+        _celery_app({"worker1": [{"name": "some-other-queue"}]}),
+    )
+    def test_unavailable_when_worker_serves_a_different_queue(self, mock_get):
+        mock_get.return_value = MagicMock(ok=True)
+        self.assertFalse(chatbot_health().available)
+
+
+class ChatHealthViewTestCase(APITestCase):
+    URL = "/api/chatbot/health"
+
+    def setUp(self):
+        cache.clear()
+        self.user, _ = User.objects.get_or_create(username="chatbot_health_user")
+
+    @patch(
+        "api_app.chatbot_manager.views.chatbot_health",
+        return_value=ChatHealth(available=False, detail="nope"),
+    )
+    def test_get_returns_serialized_health(self, _mock):
+        self.client.force_authenticate(user=self.user)
+        response = self.client.get(self.URL)
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        self.assertEqual(response.json(), {"available": False, "detail": "nope"})
+
+    def test_requires_authentication(self):
+        # IntelOwl's session/token auth returns 401 or 403 for an anonymous request.
+        response = self.client.get(self.URL)
+        self.assertIn(
+            response.status_code,
+            (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN),
+        )


### PR DESCRIPTION
# Proactive chatbot availability (health endpoint + drawer probe)

## Description

Refs #3767

W9 edge case — **model / worker unavailability**. Today, if the chatbot Celery worker or Ollama isn't running, the user only finds out after sending a message and waiting for the client-side post-ack watchdog (~20s) to fire the "Unavailable" badge + banner. This PR surfaces that state **immediately when the drawer opens**, by probing a small cached backend health endpoint — no new UI, it reuses the `assistantUnavailable` flag + error banner already introduced in #3765.

### Backend — `GET /api/chatbot/health` (`api_app/chatbot_manager`)

- **`health.py`** — `chatbot_health() -> ChatHealth(available, detail)`, cached briefly (15s `HEALTH_CACHE_KEY`) so a drawer open / multiple tabs don't re-probe. It checks two things, both with small timeouts so the endpoint stays snappy on a cache miss:
  - a Celery worker is actually consuming the chatbot queue — `celery_app.control.inspect().active_queues()` matched against `get_queue_name(settings.CHATBOT_QUEUE)`;
  - Ollama answers — `requests.get(OLLAMA_BASE_URL + "/api/version")`.
  - Which component is down is **logged**, not surfaced; the user gets one safe message (`HEALTH_UNAVAILABLE_DETAIL`).
- **`serializers/health.py`** — `ChatHealthSerializer` (response shape only: `available`, `detail`).
- **`views.py`** — `ChatHealthView(APIView)`, `IsAuthenticated`. No queryset / user data is touched (probe is user-agnostic), so there is nothing to scope.
- **`urls.py`** — `health` path on the existing router (`trailing_slash=False`).

### Frontend — probe on drawer open (`frontend/src`)

- **`constants/apiURLs.js`** — `CHATBOT_HEALTH_URI`.
- **`stores/useChatStore.jsx`** — `checkHealth()` action: on an unavailable result it sets `assistantUnavailable` + the banner; on recovery it clears **only** the unavailable banner (never an unrelated turn error); a failed request is ignored (no false alarm) and the composer stays usable either way.
- **`components/chat/ChatPanel.jsx`** — a `useEffect` that calls `checkHealth()` each time the drawer opens.

### Tests

- **Backend — 7 new** (`tests/api_app/chatbot_manager/test_health.py`): available path, no-worker, Ollama unreachable, result-is-cached, worker-on-a-different-queue, endpoint serialization, auth required. **Full chatbot suite 91/91 green.**
- **Frontend — 5 new** (4 store + 1 panel): unavailable→badge+banner, recovery clears the banner, an unrelated turn error is preserved, silent failure, and the open-probe surfacing an unavailable result end-to-end. **Chat + store jest 73/73 green.**
- Ruff `check` + `format` clean; ESLint clean. The novel bit (`celery inspect` against the real broker) was sanity-checked live on the `--ollama` stack: `available=True` with the worker up, `available=False` after killing it.

No new dependencies, no model/migration.

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case its documentation was added or updated...
- [x] I have inspected and verified that the API schema is working
- [x] If external libraries/packages with restrictive licenses were used, they were added in the Legal Notice section *(none added)*
- [x] Linters (`Black`, `Flake8`, `Isort`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated
- [x] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [x] I have created new frontend tests for the new component or updated existing ones.

### Important rules

- [x] I have read and understood the rules
