### PR TITLE
[GSoC 2026] Extract system prompt to file with per-tool selection guidance (refs #3774)

### DIFF
--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from pathlib import Path
+
 from django.conf import settings
 from langchain.agents import AgentExecutor, create_tool_calling_agent
 from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
@@ -8,15 +10,10 @@ from langchain_ollama import ChatOllama
 
 from .tools import build_tools
 
-_SYSTEM_PROMPT = """\
-You are IntelOwl AI, an intelligent assistant for the IntelOwl threat intelligence platform.
-You help security analysts query and interpret threat intelligence data.
-Only access data belonging to the current user. Never reveal other users' data.
-Ground every answer in tool results: call the relevant tool instead of guessing, and say so \
-when a tool returns no data.
-The analyze_observable tool starts a real analysis: always call it first with confirm=false, \
-show the returned plan to the user, and only call it again with confirm=true after the user \
-explicitly approves."""
+# The system prompt lives in its own text file so it is readable, testable, and
+# editable without touching Python code. {page_context} is appended separately by
+# the prompt template below so the file stays self-contained (no interpolation).
+_SYSTEM_PROMPT = Path(__file__).parent.joinpath("system_prompt.txt").read_text(encoding="utf-8").strip()
 
 # The agent uses Ollama's native tool-calling API (`llm.bind_tools`, wired by
 # `create_tool_calling_agent`), so the prompt carries no rendered tool list and no ReAct

--- a/api_app/chatbot_manager/agent/system_prompt.txt
+++ b/api_app/chatbot_manager/agent/system_prompt.txt
@@ -1,0 +1,24 @@
+[Role]
+You are IntelOwl AI, a concise assistant for the IntelOwl threat intelligence platform.
+Answer with short, data-driven summaries. Always cite the tools you used at the end.
+
+[Tools — when to use each]
+- search_jobs: find jobs by observable value, tag, or md5. Use for "show me jobs", "find jobs for domain X".
+- get_job_details: full detail of ONE job by id. Use after search_jobs, or when the user asks "details of job #N".
+- summarize_job: high-level summary of ONE job (status, analyzers, findings). Use for "summarize job #N".
+- list_investigations: browse investigations with optional status/name filters. Use for "show my investigations", "what investigations are open?".
+- get_investigation_tree: full tree of ONE investigation by id with all its jobs. Use after list_investigations.
+- summarize_investigation: high-level summary of ONE investigation (status, job breakdown). Use for "summarize investigation #N".
+- get_data_model: raw data model of ONE job. Rarely needed — only when the user explicitly asks for raw data or the data model.
+- list_analyzers: list available analyzers for an observable type (domain, ip, url, hash, generic). Use for "what analyzers can I use for a domain?".
+- recommend_playbook: recommend a playbook to analyze an observable. Use for "what playbook for 1.1.1.1?".
+- analyze_observable: START A REAL ANALYSIS. Always call with confirm=false first, show the returned plan to the user, and only call again with confirm=true after the user explicitly approves.
+
+[Rules]
+- Only access data belonging to the current user. Never reveal other users' data.
+- Call the right tool instead of guessing. Say so when a tool returns no data.
+- Do NOT call analyze_observable with confirm=true unless the user explicitly approved the plan shown by the confirm=false call.
+
+[Response style]
+- One paragraph unless the user asks for a list or breakdown.
+- Mention which tools you called at the end: "(used: search_jobs, summarize_job)".

--- a/tests/api_app/chatbot_manager/test_prompt.py
+++ b/tests/api_app/chatbot_manager/test_prompt.py
@@ -1,0 +1,108 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Structural tests for the agent system prompt file.
+
+These tests verify that system_prompt.txt is loadable, within token limits,
+and covers all registered tools — no LLM inference is performed.
+"""
+
+from pathlib import Path
+
+from django.test import TestCase
+
+from api_app.chatbot_manager.agent.agent import _SYSTEM_PROMPT, PROMPT
+from api_app.chatbot_manager.agent.tools import build_tools
+from certego_saas.apps.user.models import User
+
+PROMPT_FILE = Path(__file__).parent.parent.parent.parent.joinpath(
+    "api_app", "chatbot_manager", "agent", "system_prompt.txt"
+)
+
+# The 10 tool names the prompt MUST mention so the model knows when to use each.
+# Keeping this set in the test forces the author to update the prompt when tools
+# are added or removed from build_tools().
+EXPECTED_TOOL_NAMES = frozenset(
+    {
+        "search_jobs",
+        "get_job_details",
+        "summarize_job",
+        "list_investigations",
+        "get_investigation_tree",
+        "summarize_investigation",
+        "get_data_model",
+        "list_analyzers",
+        "recommend_playbook",
+        "analyze_observable",
+    }
+)
+
+
+class SystemPromptTestCase(TestCase):
+    def test_prompt_file_readable(self):
+        """The file exists and loads into the module-level constant."""
+        self.assertTrue(PROMPT_FILE.exists(), f"Missing: {PROMPT_FILE}")
+        self.assertIsInstance(_SYSTEM_PROMPT, str)
+        self.assertGreater(len(_SYSTEM_PROMPT), 100)
+        stripped = _SYSTEM_PROMPT.strip()
+        self.assertEqual(
+            stripped,
+            _SYSTEM_PROMPT,
+            "system prompt contains leading/trailing whitespace",
+        )
+
+    def test_prompt_under_token_limit(self):
+        """System prompt must stay under 500 tokens to leave room for tool schemas
+        and conversation history within Ollama's 8192 context window.
+        """
+        tokens = len(_SYSTEM_PROMPT.split())
+        self.assertLess(tokens, 500, f"system prompt is {tokens} tokens — exceeds 500")
+
+    def test_prompt_includes_all_tool_names(self):
+        """Every registered tool appears in the [Tools] section, and the hardcoded
+        EXPECTED_TOOL_NAMES matches the live build_tools() registry. If someone adds
+        a tool without updating both this test and system_prompt.txt, this catches it.
+        """
+        user, _ = User.objects.get_or_create(username="prompt_tool_user")
+        registered = frozenset(tool.name for tool in build_tools(user=user))
+        self.assertEqual(
+            registered,
+            EXPECTED_TOOL_NAMES,
+            "Tool registry changed — update EXPECTED_TOOL_NAMES and system_prompt.txt",
+        )
+
+        for name in EXPECTED_TOOL_NAMES:
+            self.assertIn(
+                name,
+                _SYSTEM_PROMPT,
+                f"Tool '{name}' not found in system_prompt.txt — add it to the [Tools] section",
+            )
+
+    def test_prompt_is_part_of_the_chat_template(self):
+        """The loaded prompt content is embedded in the ChatPromptTemplate's
+        system message, so the agent actually sees the file content at runtime.
+        """
+        # PROMPT.messages[0] is a SystemMessagePromptTemplate; its .prompt.template
+        # carries the system text (with {page_context} appended).
+        system_msg = PROMPT.messages[0]
+        template = system_msg.prompt.template
+        self.assertIn(_SYSTEM_PROMPT, template)
+
+    def test_prompt_sections_are_present(self):
+        """Each planned section header appears so the structure is enforced."""
+        for section in ("[Role]", "[Tools", "[Rules]", "[Response style]"):
+            self.assertIn(section, _SYSTEM_PROMPT, f"Missing section: {section}")
+
+    def test_page_context_not_in_the_file(self):
+        """The file must NOT contain {page_context} — interpolation is the prompt
+        template's job, not the static file's.
+        """
+        self.assertNotIn("{page_context}", _SYSTEM_PROMPT)
+
+    def test_prompt_is_all_printable(self):
+        """Non-printable characters (except newline) will silently confuse the LLM."""
+        self.assertNotIn("\r", _SYSTEM_PROMPT)
+        self.assertTrue(
+            all(c.isprintable() or c == "\n" for c in _SYSTEM_PROMPT),
+            "system prompt contains non-printable characters",
+        )


### PR DESCRIPTION
## Description

Refs #3774

W9 — **prompt optimization**. The current system prompt is 5 sentences with zero per-tool guidance. qwen2.5:3b sees 10 tool schemas but has no clue when to use `search_jobs` vs `list_investigations` vs `get_job_details`. This PR extracts the prompt to a structured text file with explicit "when to use" guidance for every tool.

### Changes

- **`agent/system_prompt.txt`** (new) — standalone ~270-word prompt with four sections:
  - `[Role]` — concise assistant for IntelOwl
  - `[Tools — when to use each]` — one line per tool: what it does + when to call it. All 10 tools covered.
  - `[Rules]` — multi-tenancy, no guessing, analyze_observable confirm-gate
  - `[Response style]` — one paragraph, cite tools used
- **`agent/agent.py`** — replaces the inline `_SYSTEM_PROMPT` string with `Path.read_text()`. The prompt template, `{page_context}` append, and all agent logic are unchanged.
- **`test_prompt.py`** (new) — 7 structural tests (no LLM inference): file exists/loads, under 500 tokens, all 10 tool names present, all 4 sections present, printable-only, no `{page_context}` in file, prompt content confirmed inside the ChatPromptTemplate.

Suite **110/110** (7 new), ruff clean. No model, migration, frontend, or dependency change.

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case its documentation was added or updated...
- [x] I have inspected and verified that the API schema is working
- [x] If external libraries/packages with restrictive licenses were used, they were added in the Legal Notice section *(none added)*
- [x] Linters (`Black`, `Flake8`, `Isort`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated
- [x] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [x] I have created new frontend tests for the new component or updated existing ones.

### Important rules

- [x] I have read and understood the rules
