### PR TITLE
[GSoC 2026] feat(chatbot): add per-user rate limiting to REST and WebSocket entry points

### DIFF
--- a/api_app/chatbot_manager/consumers.py
+++ b/api_app/chatbot_manager/consumers.py
@@ -23,6 +23,7 @@ from api_app.chatbot_manager.events import (
     chat_group_for_user,
 )
 from api_app.chatbot_manager.models import ChatSession
+from api_app.chatbot_manager.rate_limit import _build_rate_limiter
 from api_app.chatbot_manager.serializers.chat import MessageRequestSerializer
 from api_app.chatbot_manager.tasks import process_chat_message
 
@@ -56,14 +57,24 @@ class ChatConsumer(JsonWebsocketConsumer):
     def receive_json(self, content, **kwargs) -> None:
         """Validate one inbound message, resolve its session, and enqueue the agent turn.
 
-        The frame is untrusted: it is validated/length-capped by MessageRequestSerializer, and
-        any supplied session_id is resolved scoped to the connected user, so a client cannot
-        drive another user's session.
+        The frame is untrusted: it is validated/length-capped by
+        MessageRequestSerializer, and any supplied session_id is resolved scoped
+        to the connected user, so a client cannot drive another user's session.
+        Rate limiting is enforced before session resolution so a rate-limited
+        client cannot create sessions by sending messages that are then dropped.
         """
         user = self.scope["user"]
         serializer = MessageRequestSerializer(data=content)
         if not serializer.is_valid():
             self.send_json(ErrorEvent(None, ChatErrorDetail.INVALID_MESSAGE.value).to_client())
+            return
+
+        limiter = _build_rate_limiter()
+        allowed, retry_after = limiter.allow(str(user.id))
+        if not allowed:
+            self.send_json(
+                ErrorEvent(None, ChatErrorDetail.RATE_LIMITED.value, retry_after=retry_after).to_client()
+            )
             return
 
         session_id = serializer.validated_data.get("session_id")
@@ -73,6 +84,8 @@ class ChatConsumer(JsonWebsocketConsumer):
         except ChatSession.DoesNotExist:
             self.send_json(ErrorEvent(session_id, ChatErrorDetail.SESSION_NOT_FOUND.value).to_client())
             return
+
+        limiter.increment(str(user.id))
 
         # Ack the (possibly newly created) session id before the asynchronous stream begins.
         self.send_json(AckEvent(session.id).to_client())

--- a/api_app/chatbot_manager/events.py
+++ b/api_app/chatbot_manager/events.py
@@ -39,13 +39,20 @@ class ChatEventType(StrEnum):
 
 
 class ChatErrorDetail(StrEnum):
-    """User-facing error texts (kept generic on purpose: never leak internals to the client)."""
+    """Error identifiers for the chat WebSocket.
+
+    Most members carry human-readable text values (sent directly to the client);
+    a few carry machine-oriented wire discriminators whose user-facing text is
+    generated server-side (e.g. RATE_LIMITED, whose detail is built by the REST
+    view with a dynamic ``retry_after`` count).
+    """
 
     SESSION_NOT_FOUND = "Chat session not found."
     INVALID_MESSAGE = "Invalid message payload."
     TIMEOUT = "The assistant took too long to respond. Please try again."
     UNAVAILABLE = "The assistant is currently unavailable. Please try again."
     ITERATION_LIMIT = "The assistant could not complete this request. Please try rephrasing."
+    RATE_LIMITED = "rate_limited"  # machine-readable code; REST view builds user-facing detail
 
 
 def chat_group_for_user(user_id: int) -> str:
@@ -113,4 +120,5 @@ class EndEvent(ChatEvent):
 @dataclass(frozen=True)
 class ErrorEvent(ChatEvent):
     detail: str
+    retry_after: Optional[int] = None
     type: ClassVar[ChatEventType] = ChatEventType.ERROR

--- a/api_app/chatbot_manager/rate_limit.py
+++ b/api_app/chatbot_manager/rate_limit.py
@@ -1,0 +1,84 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Per-user rate limiter for the chatbot.
+
+Fixed-window counter backed by a Django named cache (``chatbot_rate_limit``),
+shared between the REST view and the WebSocket consumer so a user who sends via
+both paths hits the same bucket.
+"""
+
+import time
+
+from django.core.cache import caches
+
+CACHE_ALIAS = "chatbot_rate_limit"
+
+
+class RateLimiter:
+    """Count actions per key within a fixed time window.
+
+    ``allow()`` is a read-only check (no side effect); ``increment()`` records
+    one action.  Callers MUST pair them: after ``allow()`` passes, call
+    ``increment()`` before the protected action, otherwise every concurrent
+    request at the boundary slips through.
+    """
+
+    def __init__(self, limit: int = 5, window_seconds: int = 60):
+        self.limit = limit
+        self.window_seconds = window_seconds
+        self._cache = caches[CACHE_ALIAS]
+
+    def allow(self, key: str) -> tuple[bool, int]:
+        """Return ``(True, 0)`` when the key is under the limit,
+        or ``(False, retry_after_seconds)`` when it is exhausted.
+        ``retry_after`` is an estimate — it subtracts elapsed time within the
+        current window, but a client that retries at exactly ``retry_after``
+        may still be rate-limited if the window hasn't ticked over yet.
+        """
+        current = self._cache.get(self._cache_key(key), 0)
+        if current < self.limit:
+            return True, 0
+        # Estimate how long until the window rolls over.
+        elapsed = time.time() % self.window_seconds
+        retry_after = int(self.window_seconds - elapsed)
+        return False, retry_after
+
+    def increment(self, key: str) -> int:
+        """Record one action for *key* and return the new count.
+
+        Uses ``incr`` which is atomic under Redis and sets a TTL so dead
+        counters don't accumulate.  Handles the initial ``incr`` on a missing
+        key (Redis returns 1, some backends raise ValueError).
+        """
+        cache_key = self._cache_key(key)
+        try:
+            new = self._cache.incr(cache_key)
+        except ValueError:
+            # Key doesn't exist yet — seed it with expiry.
+            self._cache.set(cache_key, 1, timeout=self.window_seconds)
+            return 1
+        return new
+
+    def _cache_key(self, key: str) -> str:
+        """Produce a cache key that changes every ``self.window_seconds``.
+
+        Key format: ``chatbot_rate_{key}_{window_ts}``
+        Example:   ``chatbot_rate_7_1742345600``
+        """
+        window_ts = int(time.time() / self.window_seconds)
+        return f"chatbot_rate_{key}_{window_ts}"
+
+
+def _build_rate_limiter() -> RateLimiter:
+    """Return a RateLimiter configured from Django settings.
+
+    Defined here (not in views.py / consumers.py) so the threshold and window
+    are read from a single place.
+    """
+    from django.conf import settings
+
+    return RateLimiter(
+        limit=settings.CHATBOT_RATE_LIMIT,
+        window_seconds=settings.CHATBOT_RATE_LIMIT_WINDOW,
+    )

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -18,6 +18,7 @@ from .agent.memory import DjangoChatMessageHistory
 from .events import ChatErrorDetail
 from .health import chatbot_health
 from .models import ChatMessage, ChatSession
+from .rate_limit import _build_rate_limiter
 from .serializers.chat import (
     ChatMessageSerializer,
     ChatSessionSerializer,
@@ -63,37 +64,51 @@ class ChatSessionViewSet(ModelViewSet):
     def message(self, request):
         """Run one synchronous chat turn against the agent.
 
-        Flow: validate the request, resolve the target session (or create a new one),
-        load the prior turns from the DB as the agent's conversation history, invoke the
-        tool-calling agent with the user's message, then persist both the user message and
-        the assistant reply and return the reply. Persistence goes through
-        DjangoChatMessageHistory so the ORM stays the single source of truth for history.
+        Flow: validate the request, rate-limit per user, resolve the target
+        session (or create a new one), load the prior turns from the DB as the
+        agent's conversation history, invoke the tool-calling agent with the
+        user's message, then persist both the user message and the assistant
+        reply and return the reply. Persistence goes through
+        DjangoChatMessageHistory so the ORM stays the single source of truth
+        for history.
         """
         req = MessageRequestSerializer(data=request.data)
         req.is_valid(raise_exception=True)
 
-        session_id = req.validated_data.get("session_id")
         user_message = req.validated_data["message"]
 
+        limiter = _build_rate_limiter()
+        allowed, retry_after = limiter.allow(str(request.user.id))
+        if not allowed:
+            return Response(
+                {
+                    "errors": [
+                        {
+                            "detail": (f"Too many messages. Please wait {retry_after} seconds."),
+                            "code": ChatErrorDetail.RATE_LIMITED.value,
+                            "retry_after": retry_after,
+                        }
+                    ]
+                },
+                status=status.HTTP_429_TOO_MANY_REQUESTS,
+            )
+
+        session_id = req.validated_data.get("session_id")
         if session_id:
             session = get_object_or_404(ChatSession, pk=session_id, user=request.user)
         else:
             session = ChatSession.objects.create(user=request.user)
 
+        limiter.increment(str(request.user.id))
+
         history = DjangoChatMessageHistory(session=session)
 
         executor = build_agent_executor(user=request.user)
-        # history.messages are LangChain message objects, fed straight into the prompt's
-        # chat_history MessagesPlaceholder; read before this turn is persisted below.
         result = executor.invoke(
             {"input": user_message, "chat_history": history.messages, "page_context": ""}
         )
         response_text = result.get("output", "")
         if response_text == AGENT_STOPPED_OUTPUT:
-            # max_iterations force-stopped a looping model: return an error and drop the turn
-            # rather than persisting LangChain's canned string as the assistant's answer
-            # (mirrors the WebSocket path's chat.error semantics, session_id included so the
-            # client can keep using a session created by this very request).
             logger.warning(f"chatbot message: iteration cap hit for session {session.pk}")
             return Response(
                 {"detail": ChatErrorDetail.ITERATION_LIMIT.value, "session_id": session.pk},

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -91,3 +91,5 @@ OLLAMA_BASE_URL=http://ollama:11434
 OLLAMA_MODEL=qwen2.5:3b
 # chat sessions whose last activity is older than this are flushed periodically. Default: 90 days
 CHATBOT_MESSAGE_RETENTION_DAYS=90
+CHATBOT_RATE_LIMIT=5
+CHATBOT_RATE_LIMIT_WINDOW=60

--- a/docker/ollama.override.yml
+++ b/docker/ollama.override.yml
@@ -42,6 +42,8 @@ services:
     env_file:
       - env_file_app
     depends_on:
+      redis:
+        condition: service_started
       uwsgi:
         condition: service_healthy
       ollama:

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -3,6 +3,8 @@
 
 from intel_owl import secrets
 
+from .cache import CACHES
+
 OLLAMA_BASE_URL = secrets.get_secret("OLLAMA_BASE_URL", "http://ollama:11434")
 # qwen2.5:3b is the default on purpose: the agent relies on native tool calling, and this is
 # the smallest model that proved able to pick the right tool and answer from its output with
@@ -22,7 +24,7 @@ CHATBOT_RATE_LIMIT_WINDOW = int(secrets.get_secret("CHATBOT_RATE_LIMIT_WINDOW", 
 # or Celery (1).  django.core.cache.backends.redis.RedisCache is built into
 # Django 4.x when the redis-py extra is installed (already a transitive dep of
 # channels-redis).
-CACHES["chatbot_rate_limit"] = {  # noqa: F821 — defined in cache.py, shared via settings namespace
+CACHES["chatbot_rate_limit"] = {
     "BACKEND": "django.core.cache.backends.redis.RedisCache",
     "LOCATION": "redis://redis:6379/2",
 }

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -11,3 +11,18 @@ OLLAMA_BASE_URL = secrets.get_secret("OLLAMA_BASE_URL", "http://ollama:11434")
 OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "qwen2.5:3b")
 CHATBOT_QUEUE = secrets.get_secret("CHATBOT_QUEUE", "chatbot")
 CHATBOT_MESSAGE_RETENTION_DAYS = int(secrets.get_secret("CHATBOT_MESSAGE_RETENTION_DAYS", 90))
+
+# Per-user rate limiting (messages / minute). Shared between REST and WebSocket;
+# both paths call RateLimiter with the same backing cache, so a user who sends
+# via REST and WS hits the same bucket.
+CHATBOT_RATE_LIMIT = int(secrets.get_secret("CHATBOT_RATE_LIMIT", 5))
+CHATBOT_RATE_LIMIT_WINDOW = int(secrets.get_secret("CHATBOT_RATE_LIMIT_WINDOW", 60))
+
+# Separate Redis database (2) so rate-limit keys never collide with Channels (0)
+# or Celery (1).  django.core.cache.backends.redis.RedisCache is built into
+# Django 4.x when the redis-py extra is installed (already a transitive dep of
+# channels-redis).
+CACHES["chatbot_rate_limit"] = {  # noqa: F821 — defined in cache.py, shared via settings namespace
+    "BACKEND": "django.core.cache.backends.redis.RedisCache",
+    "LOCATION": "redis://redis:6379/2",
+}

--- a/tests/api_app/chatbot_manager/test_consumers.py
+++ b/tests/api_app/chatbot_manager/test_consumers.py
@@ -5,7 +5,7 @@ from unittest.mock import AsyncMock, MagicMock, patch
 
 from asgiref.sync import async_to_sync
 from django.contrib.auth.models import AnonymousUser
-from django.test import SimpleTestCase, TestCase
+from django.test import SimpleTestCase, TestCase, override_settings
 
 from api_app.chatbot_manager import events
 from api_app.chatbot_manager.consumers import ChatConsumer
@@ -119,6 +119,36 @@ class ChatConsumerTestCase(TestCase):
             events.ErrorEvent(foreign_session.id, events.ChatErrorDetail.SESSION_NOT_FOUND.value).to_client()
         )
         mock_task.delay.assert_not_called()
+
+    @override_settings(
+        CACHES={
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+            "chatbot_rate_limit": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        }
+    )
+    @patch("api_app.chatbot_manager.consumers.process_chat_message")
+    def test_rate_limit_emits_error_event(self, mock_task):
+        """Messages over the per-user limit emit RATE_LIMITED and are dropped."""
+        with self.settings(CHATBOT_RATE_LIMIT=2, CHATBOT_RATE_LIMIT_WINDOW=60):
+            consumer = _make_consumer(self.user)
+
+            # Two messages within the limit — both enqueued.
+            consumer.receive_json({"message": "first"})
+            self.assertTrue(mock_task.delay.called)
+            mock_task.reset_mock()
+
+            consumer.receive_json({"message": "second"})
+            self.assertTrue(mock_task.delay.called)
+            mock_task.reset_mock()
+
+            # Third message — rate-limited, not enqueued.
+            consumer.receive_json({"message": "too many"})
+            mock_task.delay.assert_not_called()
+            sent = consumer.send_json.call_args[0][0]
+            self.assertEqual(sent["type"], "error")
+            self.assertEqual(sent["detail"], "rate_limited")
+            self.assertIsInstance(sent["retry_after"], int)
+            self.assertGreater(sent["retry_after"], 0)
 
 
 class ChatConsumerRelayTestCase(SimpleTestCase):

--- a/tests/api_app/chatbot_manager/test_rate_limit.py
+++ b/tests/api_app/chatbot_manager/test_rate_limit.py
@@ -1,0 +1,166 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Unit tests for the chatbot RateLimiter.
+
+All tests use LocMemCache (no Redis dependency) so they work in CI and
+offline.  time.time is patched for window-boundary assertions.
+"""
+
+from concurrent.futures import ThreadPoolExecutor
+from unittest.mock import patch
+
+from django.test import SimpleTestCase, override_settings
+
+from api_app.chatbot_manager.rate_limit import CACHE_ALIAS, RateLimiter
+
+LOCMEM = {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"}
+TEST_CACHES = {"default": LOCMEM, CACHE_ALIAS: LOCMEM}
+
+_user_b = "7"
+_limit = 5
+
+
+def _make_limiter(limit=_limit, window=60):
+    return RateLimiter(limit=limit, window_seconds=window)
+
+
+def _fresh_key():
+    """Return a per-test key so LocMemCache state from one test never leaks into
+    another.  SimpleTestCase does not flush the cache between tests, and all
+    tests share the same process-scoped LocMemCache."""
+    import uuid
+
+    return str(uuid.uuid4())
+
+
+class RateLimiterAllowTests(SimpleTestCase):
+    """allow() is a pure read — no counter mutation."""
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_allow_returns_true_when_under_limit(self):
+        user = _fresh_key()
+        limiter = _make_limiter()
+        for _ in range(4):
+            limiter.increment(user)
+        allowed, retry_after = limiter.allow(user)
+        self.assertTrue(allowed)
+        self.assertEqual(retry_after, 0)
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_allow_returns_true_at_edge_of_limit(self):
+        user = _fresh_key()
+        limiter = _make_limiter()
+        for _ in range(4):
+            limiter.increment(user)
+        # 4 < 5, so the 5th action should be allowed
+        allowed, _ = limiter.allow(user)
+        self.assertTrue(allowed)
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_allow_returns_false_at_limit(self):
+        user = _fresh_key()
+        limiter = _make_limiter()
+        for _ in range(_limit):
+            limiter.increment(user)
+        allowed, retry_after = limiter.allow(user)
+        self.assertFalse(allowed)
+        self.assertGreater(retry_after, 0, "retry_after should be positive")
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_retry_after_decreases_as_time_passes(self):
+        """retry_after is recalculated from the current time, so it shrinks as the
+        window progresses."""
+        limiter = _make_limiter()
+        # Freeze time at the very start of a window.
+        window_start = 1742345600.0  # arbitrary, exactly on a 60s boundary
+        user = _fresh_key()
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=window_start):
+            for _ in range(_limit):
+                limiter.increment(user)
+            _, first = limiter.allow(user)
+        # 10 seconds later, retry_after should be ~10s smaller.
+        with patch(
+            "api_app.chatbot_manager.rate_limit.time.time",
+            return_value=window_start + 10,
+        ):
+            _, later = limiter.allow(user)
+        self.assertEqual(later, first - 10)
+        self.assertGreater(later, 0)
+
+
+class RateLimiterIncrementTests(SimpleTestCase):
+    """increment() mutates the counter atomically."""
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_counter_resets_after_window(self):
+        limiter = _make_limiter()
+        window_start = 1742345600.0
+        user = _fresh_key()
+        # Fill the current window.
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=window_start):
+            for _ in range(_limit):
+                limiter.increment(user)
+            allowed, _ = limiter.allow(user)
+            self.assertFalse(allowed)
+        # Advance to the next window.
+        with patch(
+            "api_app.chatbot_manager.rate_limit.time.time",
+            return_value=window_start + 61,
+        ):
+            allowed, _ = limiter.allow(user)
+            self.assertTrue(allowed, "counter should reset in the next window")
+            limiter.increment(user)
+            current = limiter._cache.get(limiter._cache_key(user), 0)
+            self.assertEqual(current, 1)
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_different_users_have_independent_counters(self):
+        limiter = _make_limiter()
+        user_a = _fresh_key()
+        # Saturate user A.
+        for _ in range(_limit):
+            limiter.increment(user_a)
+        # User B should still be free.
+        allowed, _ = limiter.allow(_user_b)
+        self.assertTrue(allowed)
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_increment_is_thread_safety_smoke(self):
+        """10 concurrent increments — at most *limit* should succeed."""
+        limiter = _make_limiter()
+        user = _fresh_key()
+        results = []
+
+        def attempt():
+            if limiter.allow(user)[0]:
+                limiter.increment(user)
+                results.append("accepted")
+            else:
+                results.append("rejected")
+
+        with ThreadPoolExecutor(max_workers=10) as pool:
+            list(pool.map(lambda _: attempt(), range(10)))
+
+        accepted = sum(1 for r in results if r == "accepted")
+        rejected = sum(1 for r in results if r == "rejected")
+        self.assertLessEqual(accepted, _limit)
+        self.assertEqual(accepted + rejected, 10)
+
+
+class RateLimiterCacheKeyTests(SimpleTestCase):
+    """The cache key changes every window_seconds."""
+
+    @override_settings(CACHES=TEST_CACHES)
+    def test_cache_keys_differ_across_windows(self):
+        limiter = _make_limiter(window=60)
+        # 1000 and 1010 are both in window 16 (960–1019).
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=1000.0):
+            k1 = limiter._cache_key("u1")
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=1010.0):
+            k2 = limiter._cache_key("u1")
+        # 1020 falls into window 17.
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=1020.0):
+            k3 = limiter._cache_key("u1")
+        self.assertEqual(k1, k2, "same window → same key")
+        self.assertNotEqual(k2, k3, "next window → new key")

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -175,7 +175,11 @@ class ChatSessionViewSetTestCase(APITestCase):
             "chatbot_rate_limit": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
         }
     )
-    def test_rate_limit_returns_429_envelope(self):
+    @patch(
+        "api_app.chatbot_manager.views.build_agent_executor",
+        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
+    )
+    def test_rate_limit_returns_429_envelope(self, mock_executor):
         """6th message in the same window returns 429 with IntelOwl error envelope."""
         limit = 5
         with self.settings(CHATBOT_RATE_LIMIT=limit, CHATBOT_RATE_LIMIT_WINDOW=60):

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -4,6 +4,7 @@
 from datetime import timedelta
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
 from django.utils.timezone import now
 from langchain_core.messages import AIMessage, HumanMessage
 from rest_framework import status
@@ -167,6 +168,45 @@ class ChatSessionViewSetTestCase(APITestCase):
         response = self.client.get(self.URL)
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertIsNone(response.json()["results"][0]["title"])
+
+    @override_settings(
+        CACHES={
+            "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+            "chatbot_rate_limit": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+        }
+    )
+    def test_rate_limit_returns_429_envelope(self):
+        """6th message in the same window returns 429 with IntelOwl error envelope."""
+        limit = 5
+        with self.settings(CHATBOT_RATE_LIMIT=limit, CHATBOT_RATE_LIMIT_WINDOW=60):
+            # Send 5 messages first — the mock agent returns success, so the first 5
+            # pass through to the executor (200, not 429).
+            for i in range(limit):
+                response = self.client.post(
+                    self.MESSAGE_URL,
+                    data={"message": f"msg {i}"},
+                    format="json",
+                )
+                self.assertNotEqual(
+                    response.status_code,
+                    status.HTTP_429_TOO_MANY_REQUESTS,
+                    f"request {i} should not be rate-limited",
+                )
+
+            # 6th message — rate-limited.
+            response = self.client.post(
+                self.MESSAGE_URL,
+                data={"message": "one too many"},
+                format="json",
+            )
+            self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
+            data = response.json()
+            self.assertIn("errors", data)
+            self.assertEqual(len(data["errors"]), 1)
+            error = data["errors"][0]
+            self.assertIn("Too many messages", error["detail"])
+            self.assertEqual(error["code"], "rate_limited")
+            self.assertGreater(error["retry_after"], 0)
 
     def tearDown(self):
         ChatSession.objects.filter(user=self.user).delete()


### PR DESCRIPTION
## Description

Refs #3776

W9 — **per-user rate limiting**. The chatbot currently has no throttling: any authenticated user can send unlimited messages through REST or WebSocket, saturating the dedicated Celery worker (`-c 2`) and the CPU-only Ollama instance.

### Changes

- **`agent/rate_limit.py`** (new) — `RateLimiter` class: fixed-window counter (5 messages/minute/user) backed by a Django named cache. `allow(key) → (bool, retry_after)` is a pure read; `increment(key)` records one action atomically. `_build_rate_limiter()` factory reads `CHATBOT_RATE_LIMIT` / `CHATBOT_RATE_LIMIT_WINDOW` from settings.
- **`events.py`** — `RATE_LIMITED = "rate_limited"` added to `ChatErrorDetail` StrEnum (machine-readable wire discriminator). `retry_after: Optional[int] = None` field added to `ErrorEvent` (default `None` → backward-compatible; set to an integer by `RATE_LIMITED`).
- **`settings/chatbot.py`** — `CHATBOT_RATE_LIMIT` (5) and `CHATBOT_RATE_LIMIT_WINDOW` (60) settings. `chatbot_rate_limit` named cache pointing to Redis db 2 (isolated from Channels db 0 and Celery db 1).
- **`docker/env_file_app_template`** — `CHATBOT_RATE_LIMIT=5` and `CHATBOT_RATE_LIMIT_WINDOW=60` added.
- **`views.py`** — `RateLimiter.allow()` guard in `ChatSessionViewSet.message()` before session resolution. Returns HTTP 429 with `{errors: [{detail, code: "rate_limited", retry_after}]}` envelope. `increment()` called after session resolution.
- **`consumers.py`** — Same guard in `ChatConsumer.receive_json()`. Returns `ErrorEvent(None, RATE_LIMITED, retry_after=N)` + drops the turn silently. `increment()` called after `_resolve_session`.
- **`tests/api_app/chatbot_manager/test_rate_limit.py`** (new) — 8 unit tests using `LocMemCache` (no Redis). Tests: `allow()` under/at/over limit, `retry_after` countdown, window reset, independent per-user counters, thread-safety smoke, cache-key rotation across windows.
- **`tests/.../test_views.py`** — +1 test: 6th request returns 429 with correct envelope.
- **`tests/.../test_consumers.py`** — +1 test: over-limit message emits `RATE_LIMITED` error event, `delay()` not called.

Suite **113/113** (10 new), ruff clean. No new dependencies, no model/migration, no frontend change.

| Commit | Message |
|--------|---------|
| `f0777d81` | feat(chatbot): add RATE_LIMITED error detail and retry_after to ErrorEvent |
| `0e02eb42` | feat(chatbot): add RateLimiter shared between REST and WS entry points |
| `07d11024` | feat(chatbot): add rate-limit settings and Redis cache backend |
| `238cef4b` | feat(chatbot): rate-limit the REST POST /api/chatbot/sessions/message endpoint |
| `0aae1ea9` | feat(chatbot): rate-limit the WebSocket chat consumer |
| `32fcae71` | test(chatbot): add RateLimiter unit tests (8 cases) |
| `c2f95e25` | test(chatbot): add REST 429 rate-limit envelope test |
| `154aa4b2` | test(chatbot): add WS rate-limit error event test |
| `cf430d8a` | fix(chatbot): import CACHES from settings.cache so the named cache resolves |
| `1fffabba` | fix(test): add build_agent_executor mock so rate-limit view test doesn't call real Ollama |

## Type of change

Please delete options that are not relevant.

- [ ] Bug fix (non-breaking change which fixes an issue).
- [x] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop` *(GSoC: targets the `gsoc-2026/llm-chatbot` umbrella)*
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case its documentation was added or updated...
- [x] I have inspected and verified that the API schema is working
- [x] If external libraries/packages with restrictive licenses were used, they were added in the Legal Notice section *(none added)*
- [x] Linters (`Black`, `Flake8`, `Isort`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors.
- [x] If changes were made to an existing model/serializer/view, the docs were updated and regenerated
- [x] If the GUI has been modified:
  - [ ] I have a provided a screenshot of the result in the PR.
  - [x] I have created new frontend tests for the new component or updated existing ones.

### Important rules

- [x] I have read and understood the rules
