### PR TITLE
Refactor Connector Testing framework 2: Migrate MISP tests to base connector test framework

### DIFF
--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
@@ -1,0 +1,131 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from api_app.connectors_manager.connectors.misp import MISP
+from tests.api_app.connectors_manager.unit_tests.base_test_class import BaseConnectorTest
+
+
+class MockPyMISPClient:
+    def __init__(self, *args, **kwargs):
+        pass
+
+    def add_event(self, event, *args, **kwargs):
+        mock_event = MagicMock()
+        mock_event.id = "51"
+        mock_event.attributes = event.attributes
+        return mock_event
+
+    def get_event(self, event_id, *args, **kwargs):
+        if str(event_id) == "51":
+            return {
+                "Event": {
+                    "id": "51",
+                    "info": "Intelowl Job-51: 1.2.3.4",
+                    "Attribute": [
+                        {
+                            "id": "5",
+                            "type": "ip-src",
+                            "value": "1.2.3.4",
+                            "event_id": "3",
+                            "comment": "Analyzers Executed: FireHol_IPList",
+                        },
+                        {
+                            "id": "6",
+                            "type": "link",
+                            "value": "https://misp.test/jobs/51",
+                            "comment": "View Analysis on IntelOwl",
+                            "event_id": "3",
+                        },
+                    ],
+                }
+            }
+        return {"error": "Not Found"}
+
+
+class MISPConnectorTestCase(BaseConnectorTest):
+    connector_class = MISP
+
+    @classmethod
+    def get_extra_config(cls) -> dict:
+        return {
+            "_url_key_name": "https://misp.test",
+            "_api_key_name": "test-api-key",
+            "tlp": "CLEAR",
+            "ssl_check": False,
+            "self_signed_certificate": "",
+            "debug": False,
+            "_job_id": 51,
+        }
+
+    def _setup_connector(self):
+        connector = super()._setup_connector()
+
+        mock_tag = MagicMock()
+        mock_tag.label = "source:intelowl"
+        connector._job.tags = MagicMock()
+        connector._job.tags.all.return_value = [mock_tag]
+
+        connector._job.analyzers_to_execute = MagicMock()
+        connector._job.analyzers_to_execute.all.return_value.values_list.return_value = ["FireHol_IPList"]
+
+        return connector
+
+    @classmethod
+    def get_mocked_response(cls):
+        return [
+            patch(
+                "api_app.connectors_manager.connectors.misp.pymisp.PyMISP",
+                side_effect=MockPyMISPClient,
+            )
+        ]
+
+    def test_bulk_add_event_called_once(self):
+        # verify that add_event is called once and that the event contains all attributes
+        connector = self._setup_connector()
+
+        with patch("api_app.connectors_manager.connectors.misp.pymisp.PyMISP") as mock_misp_cls:
+            mock_instance = MagicMock()
+            mock_misp_cls.return_value = mock_instance
+
+            mock_event = MagicMock()
+            mock_event.id = "51"
+            mock_instance.add_event.return_value = mock_event
+
+            connector.run()
+
+            mock_instance.add_event.assert_called_once()
+            mock_instance.add_attribute.assert_not_called()
+
+    def test_all_attributes_present_on_event(self):
+        # verify that the event sent to MISP contains the base attribute and the link attribute
+        connector = self._setup_connector()
+
+        with patch("api_app.connectors_manager.connectors.misp.pymisp.PyMISP") as mock_misp_cls:
+            mock_instance = MagicMock()
+            mock_misp_cls.return_value = mock_instance
+
+            mock_event = MagicMock()
+            mock_event.id = "51"
+            mock_instance.add_event.return_value = MagicMock(id="51")
+
+            connector.run()
+
+            event_arg = mock_instance.add_event.call_args[0][0]
+            attr_types = [a.type for a in event_arg.attributes]
+
+            self.assertIn("ip-src", attr_types)
+            self.assertIn("link", attr_types)
+
+    def test_add_event_failure_raises_exception(self):
+        connector = self._setup_connector()
+
+        with patch("api_app.connectors_manager.connectors.misp.pymisp.PyMISP") as mock_misp_cls:
+            mock_instance = MagicMock()
+            mock_misp_cls.return_value = mock_instance
+
+            mock_instance.add_event.side_effect = Exception("MISP unreachable")
+
+            with self.assertRaisesRegex(Exception, "MISP unreachable"):
+                connector.run()


### PR DESCRIPTION
Refs #3662 
# Description
- migrated MISP connector tests to the new base connector test framework
<img width="2806" height="663" alt="image" src="https://github.com/user-attachments/assets/1059fd89-b528-4d4e-95a8-8a37345a010c" />


## Type of change

Please delete options that are not relevant.

- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
