### PR TITLE
[GSoC 2026] Harden chatbot REST + search_jobs (security-review follow-ups)

### DIFF
--- a/api_app/chatbot_manager/agent/tools/list_investigations.py
+++ b/api_app/chatbot_manager/agent/tools/list_investigations.py
@@ -3,13 +3,10 @@
 
 from langchain_core.tools import tool
 
+from api_app.chatbot_manager.agent.tools._common import clamp_limit
 from api_app.chatbot_manager.serializers.investigation import InvestigationsResultSerializer
 from api_app.investigations_manager.choices import InvestigationStatusChoices
 from api_app.investigations_manager.models import Investigation
-
-# Hard cap on the number of results returned to the LLM (mirrors the job tools), so a
-# single call can't pull an unbounded list into the prompt.
-_MAX_RESULTS = 50
 
 
 def make_list_investigations_tool(user):
@@ -47,7 +44,7 @@ def make_list_investigations_tool(user):
                 valid = ", ".join(InvestigationStatusChoices.values)
                 errors.append(f"Unknown status '{status}'; valid values are: {valid}.")
 
-        limit = min(int(limit), _MAX_RESULTS)
+        limit = clamp_limit(limit, errors)
         qs = qs.order_by("-start_time")[:limit]
 
         return InvestigationsResultSerializer({"errors": errors, "investigations": qs}).to_json()

--- a/api_app/chatbot_manager/agent/tools/search_jobs.py
+++ b/api_app/chatbot_manager/agent/tools/search_jobs.py
@@ -4,6 +4,9 @@
 from django.db import models
 from langchain_core.tools import tool
 
+from api_app.chatbot_manager.agent.tools._common import clamp_limit
+from api_app.choices import Status
+
 
 def make_search_jobs_tool(user):
     # The tool is built per-request and closes over `user`: every query is hard-scoped
@@ -16,8 +19,8 @@ def make_search_jobs_tool(user):
 
         Args:
             query: Observable name or MD5 hash to search for (partial match supported).
-            status: Filter by job status. Valid values: pending, running,
-                    reported_without_fails, reported_with_fails, failed, killed.
+            status: Filter by job status (see api_app.choices.Status for valid values).
+                    An unknown value is ignored and reported in `errors`.
             limit: Maximum number of results to return (default 10, max 50).
 
         Returns:
@@ -26,7 +29,8 @@ def make_search_jobs_tool(user):
         from api_app.chatbot_manager.serializers.job import SearchJobsResultSerializer
         from api_app.models import Job
 
-        limit = min(int(limit), 50)
+        errors = []
+        limit = clamp_limit(limit, errors)
         qs = (
             Job.objects.select_related("analyzable")
             .prefetch_related("analyzers_to_execute")
@@ -38,10 +42,18 @@ def make_search_jobs_tool(user):
                 models.Q(analyzable__name__icontains=query) | models.Q(analyzable__md5__iexact=query)
             )
         if status:
-            qs = qs.filter(status=status)
+            # The status string comes from the LLM; validate it against the enum so an
+            # invalid value surfaces a message instead of silently returning 0 results
+            # (mirrors list_investigations).
+            normalized = status.strip().lower()
+            if normalized in set(Status.values):
+                qs = qs.filter(status=normalized)
+            else:
+                valid = ", ".join(Status.values)
+                errors.append(f"Unknown status '{status}'; valid values are: {valid}.")
 
         qs = qs.order_by("-received_request_time")[:limit]
 
-        return SearchJobsResultSerializer({"errors": [], "jobs": qs}).to_json()
+        return SearchJobsResultSerializer({"errors": errors, "jobs": qs}).to_json()
 
     return search_jobs

--- a/api_app/chatbot_manager/consumers.py
+++ b/api_app/chatbot_manager/consumers.py
@@ -40,8 +40,8 @@ class ChatConsumer(JsonWebsocketConsumer):
 
     def connect(self) -> None:
         user = self.scope["user"]
-        # context_url (the page the user is on) is captured for later context injection (W9);
-        # it is intentionally unused for now.
+        # context_url (the page the user is on) is captured and forwarded to the chat turn so the
+        # agent can resolve "this job/investigation" references (see derive_page_context in tasks.py).
         self.context_url = self._parse_context_url()
         self.group_name = chat_group_for_user(user.id)
         self.accept()

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -104,9 +104,19 @@ class ChatSessionViewSet(ModelViewSet):
         history = DjangoChatMessageHistory(session=session)
 
         executor = build_agent_executor(user=request.user)
-        result = executor.invoke(
-            {"input": user_message, "chat_history": history.messages, "page_context": ""}
-        )
+        try:
+            result = executor.invoke(
+                {"input": user_message, "chat_history": history.messages, "page_context": ""}
+            )
+        except Exception:  # noqa: BLE001 - any agent/Ollama failure must reach the client cleanly
+            # Mirror the Celery path (tasks.py): a model/Ollama failure is surfaced as a clean
+            # 503 envelope instead of an unhandled 500. session_id is included so a client that
+            # created the session via this very request can keep using it.
+            logger.exception(f"chatbot message: agent run failed for session {session.pk}")
+            return Response(
+                {"detail": ChatErrorDetail.UNAVAILABLE.value, "session_id": session.pk},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
+            )
         response_text = result.get("output", "")
         if response_text == AGENT_STOPPED_OUTPUT:
             logger.warning(f"chatbot message: iteration cap hit for session {session.pk}")

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -212,6 +212,19 @@ class ChatSessionViewSetTestCase(APITestCase):
             self.assertEqual(error["code"], "rate_limited")
             self.assertGreater(error["retry_after"], 0)
 
+    @patch(
+        "api_app.chatbot_manager.views.build_agent_executor",
+        return_value=MagicMock(invoke=MagicMock(side_effect=RuntimeError("ollama down"))),
+    )
+    def test_message_returns_503_when_agent_unavailable(self, mock_executor):
+        response = self.client.post(
+            self.MESSAGE_URL,
+            data={"message": "Hello"},
+            format="json",
+        )
+        self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
+        self.assertEqual(response.json()["detail"], ChatErrorDetail.UNAVAILABLE.value)
+
     def tearDown(self):
         ChatSession.objects.filter(user=self.user).delete()
 

--- a/tests/api_app/chatbot_manager/tools/test_investigations.py
+++ b/tests/api_app/chatbot_manager/tools/test_investigations.py
@@ -119,6 +119,11 @@ class InvestigationToolsTestCase(TestCase):
         ids = [i["id"] for i in data["investigations"]]
         self.assertIn(self.inv_created.pk, ids)
 
+    def test_list_investigations_limit_over_cap_reports_error(self):
+        result = self.list_investigations.invoke({"limit": 100})
+        data = json.loads(result)
+        self.assertTrue(any("maximum 50" in e for e in data["errors"]))
+
     def test_get_investigation_tree_structure(self):
         data = json.loads(self.get_investigation_tree.invoke({"investigation_id": self.inv_created.pk}))
         self.assertEqual(data["errors"], [])

--- a/tests/api_app/chatbot_manager/tools/test_search_jobs.py
+++ b/tests/api_app/chatbot_manager/tools/test_search_jobs.py
@@ -109,5 +109,21 @@ class SearchJobsToolTestCase(TestCase):
         self.assertIn(config_ko.name, summary)
         self.assertNotIn(config_ok.name, summary)
 
+    def test_search_jobs_invalid_status_reports_error(self):
+        result = self.search_jobs.invoke({"status": "not_a_status"})
+        data = json.loads(result)
+        self.assertTrue(any("Unknown status" in e for e in data["errors"]))
+
+    def test_search_jobs_valid_status_filters(self):
+        result = self.search_jobs.invoke({"status": "reported_without_fails"})
+        data = json.loads(result)
+        self.assertEqual(data["errors"], [])
+        self.assertEqual([d["id"] for d in data["jobs"]], [self.job.pk])
+
+    def test_search_jobs_limit_over_cap_reports_error(self):
+        result = self.search_jobs.invoke({"limit": 100})
+        data = json.loads(result)
+        self.assertTrue(any("maximum 50" in e for e in data["errors"]))
+
     def tearDown(self):
         Job.objects.filter(user__in=[self.user, self.other_user]).delete()


### PR DESCRIPTION
# Description

Batch A of the W10 chatbot security review (`Refs #3779`). Low-risk hardening; the review found **no data-isolation leaks**. The two design-decision findings (job-tool visibility scope; `analyze_observable` confirm-gate) are out of scope here and tracked separately.

Changes:
- `search_jobs`: validate the LLM-supplied `status` against `api_app.choices.Status` and reuse `clamp_limit` — previously an unknown status silently returned 0 rows and an over-cap `limit` truncated silently.
- REST `POST /api/chatbot/sessions/message`: wrap the agent invoke so an Ollama/agent failure returns a 503 envelope instead of an unhandled 500 — parity with the Celery/WebSocket path.
- `ChatConsumer`: correct a stale `context_url` comment.
- `list_investigations`: reuse `clamp_limit` (DRY; removes a duplicated cap).

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).
- [x] Chore (refactoring, code cleanup).

# Checklist
- [x] I have read and understood the rules about how to Contribute to this project.
- [ ] The pull request is for the branch `develop` — N/A: targets the GSoC umbrella `gsoc-2026/llm-chatbot` (`Refs #3779`).
- [ ] A new plugin was added or changed — N/A: no plugin added or changed.
- [x] Copyright banner present — no new files; all modified files already carry it.
- [x] Avoid adding new libraries — no new libraries added.
- [ ] Restrictive-license libraries — N/A.
- [x] Linters (Ruff) gave 0 errors.
- [x] Tests added; all tests (new and old) gave 0 errors (37 tests in the affected modules, OK).
- [ ] GUI modified — N/A: no frontend changes.
- [ ] Will resolve any DeepSource/Django Doctors/CI alerts raised after submission.
- [ ] I have addressed raised Copilot issues.
- [x] I have reviewed and verified the LLM-generated code in this PR. Disclosure: implemented with Claude Code from a reviewed plan; all changes reviewed and verified locally (ruff clean, 37 tests pass).
