### PR TITLE
[GSoC 2026] Job tools UI parity: scope with visible_for_user (refs I-2)

### DIFF
--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -18,9 +18,9 @@ def build_tools(user) -> list:
 
     Each tool is produced by a factory that closes over `user`, so every ORM query the
     agent can run is hard-scoped to that user's data: multi-tenancy is enforced at build
-    time and cannot be widened by anything the LLM emits. Job tools scope on `user=user`;
-    investigation tools scope on `visible_for_user` (owned + organization-shared); the
-    playbook tool also scopes on `visible_for_user`. Analyzer configs are global plugin
+    time and cannot be widened by anything the LLM emits. Job, investigation, and playbook
+    tools scope on `visible_for_user` (owner + same-org AMBER/RED + globally-visible
+    CLEAR/GREEN), matching the REST viewsets / UI. Analyzer configs are global plugin
     definitions, so `list_analyzers` does not scope by owner -- it lists the enabled
     analyzers and exposes per-user readiness through a `runnable` flag instead. The single
     action tool `analyze_observable` can launch a real analysis; it is confirm-gated (a preview

--- a/api_app/chatbot_manager/agent/tools/get_data_model.py
+++ b/api_app/chatbot_manager/agent/tools/get_data_model.py
@@ -8,10 +8,10 @@ from api_app.models import Job
 
 
 def make_get_data_model_tool(user):
-    # Built per-request and closed over `user`, so the lookup is hard-scoped to that user's
-    # jobs (multi-tenancy enforced here), matching the other job tools' `user=user` scope.
-    # LangChain feeds a tool's return value back as the tool-call observation, so it must be
-    # a string: we return a JSON-serialized envelope.
+    # Built per-request and closed over `user`: scoped with visible_for_user (owner +
+    # same-org AMBER/RED + globally-visible CLEAR/GREEN), matching the other job tools and
+    # the UI (multi-tenancy enforced here). LangChain feeds a tool's return value back as
+    # the tool-call observation, so it must be a string: we return a JSON-serialized envelope.
     @tool("get_data_model")
     def get_data_model(job_id: int) -> str:
         """Get the aggregated data model of an IntelOwl job by its numeric ID.
@@ -28,7 +28,7 @@ def make_get_data_model_tool(user):
             JSON string with shape {"errors": [...], "data_model": {...}}.
         """
         try:
-            job = Job.objects.get(pk=job_id, user=user)
+            job = Job.objects.visible_for_user(user).get(pk=job_id)
         except Job.DoesNotExist:
             return DataModelResultSerializer(
                 {"errors": [f"Job with ID {job_id} not found or not accessible."], "data_model": {}}

--- a/api_app/chatbot_manager/agent/tools/get_job_details.py
+++ b/api_app/chatbot_manager/agent/tools/get_job_details.py
@@ -5,8 +5,9 @@ from langchain_core.tools import tool
 
 
 def make_get_job_details_tool(user):
-    # Built per-request and closed over `user`, so the lookup is hard-scoped to that
-    # user's jobs (multi-tenancy enforced here). LangChain requires a tool to return a
+    # Built per-request and closed over `user`: the lookup is scoped with visible_for_user
+    # (owner + same-org AMBER/RED + globally-visible CLEAR/GREEN), matching the REST
+    # JobViewSet / UI (multi-tenancy enforced here). LangChain requires a tool to return a
     # string (the tool-call observation), so we return a JSON-serialized envelope.
     @tool("get_job_details")
     def get_job_details(job_id: int) -> str:
@@ -25,7 +26,8 @@ def make_get_job_details_tool(user):
             job = (
                 Job.objects.select_related("analyzable")
                 .prefetch_related("analyzerreports__config", "analyzers_to_execute", "tags")
-                .get(pk=job_id, user=user)
+                .visible_for_user(user)
+                .get(pk=job_id)
             )
         except Job.DoesNotExist:
             return JobDetailResultSerializer(

--- a/api_app/chatbot_manager/agent/tools/search_jobs.py
+++ b/api_app/chatbot_manager/agent/tools/search_jobs.py
@@ -9,10 +9,11 @@ from api_app.choices import Status
 
 
 def make_search_jobs_tool(user):
-    # The tool is built per-request and closes over `user`: every query is hard-scoped
-    # to that user's jobs, so multi-tenancy is enforced here and the LLM can never widen
-    # it. LangChain feeds a tool's return value back to the model as the tool-call
-    # observation, so it must be a string; we return a JSON-serialized envelope.
+    # Built per-request and closed over `user`: scoped with visible_for_user (owner +
+    # same-org AMBER/RED + globally-visible CLEAR/GREEN), matching the REST JobViewSet / UI.
+    # The LLM can never widen it. LangChain feeds a tool's return value back to the model
+    # as the tool-call observation, so it must be a string; we return a JSON-serialized
+    # envelope.
     @tool("search_jobs")
     def search_jobs(query: str = "", status: str = "", limit: int = 10) -> str:
         """Search IntelOwl jobs by observable name, MD5, or status.
@@ -34,7 +35,7 @@ def make_search_jobs_tool(user):
         qs = (
             Job.objects.select_related("analyzable")
             .prefetch_related("analyzers_to_execute")
-            .filter(user=user)
+            .visible_for_user(user)
         )
 
         if query:

--- a/api_app/chatbot_manager/agent/tools/summarize_job.py
+++ b/api_app/chatbot_manager/agent/tools/summarize_job.py
@@ -7,8 +7,9 @@ from api_app.choices import ReportStatus
 
 
 def make_summarize_job_tool(user):
-    # Built per-request and closed over `user`, so the lookup is hard-scoped to that
-    # user's jobs (multi-tenancy enforced here). The payload is human-readable prose
+    # Built per-request and closed over `user`: the lookup is scoped with visible_for_user
+    # (owner + same-org AMBER/RED + globally-visible CLEAR/GREEN), matching the REST
+    # JobViewSet / UI (multi-tenancy enforced here). The payload is human-readable prose
     # (meant to be relayed to the user) wrapped in the same envelope as the other tools.
     @tool("summarize_job")
     def summarize_job(job_id: int) -> str:
@@ -27,7 +28,8 @@ def make_summarize_job_tool(user):
             job = (
                 Job.objects.select_related("analyzable")
                 .prefetch_related("analyzerreports__config", "analyzers_to_execute")
-                .get(pk=job_id, user=user)
+                .visible_for_user(user)
+                .get(pk=job_id)
             )
         except Job.DoesNotExist:
             return SummarizeJobResultSerializer(

--- a/tests/api_app/chatbot_manager/tools/test_data_model.py
+++ b/tests/api_app/chatbot_manager/tools/test_data_model.py
@@ -7,9 +7,11 @@ from django.test import TestCase
 
 from api_app.analyzables_manager.models import Analyzable
 from api_app.chatbot_manager.agent.tools import build_tools
-from api_app.choices import Classification
+from api_app.choices import TLP, Classification
 from api_app.data_model_manager.models import DomainDataModel
 from api_app.models import Job
+from certego_saas.apps.organization.membership import Membership
+from certego_saas.apps.organization.organization import Organization
 from certego_saas.apps.user.models import User
 
 
@@ -17,6 +19,10 @@ class DataModelToolTestCase(TestCase):
     def setUp(self):
         self.user, _ = User.objects.get_or_create(username="dm_tool_user")
         self.other_user, _ = User.objects.get_or_create(username="dm_tool_other_user")
+        self.org_member, _ = User.objects.get_or_create(username="dm_tool_org_member")
+        self.org, _ = Organization.objects.get_or_create(name="dm tool org")
+        Membership.objects.get_or_create(user=self.user, organization=self.org, is_owner=True)
+        Membership.objects.get_or_create(user=self.org_member, organization=self.org, is_owner=False)
         self.analyzable, _ = Analyzable.objects.get_or_create(
             name="dm.example.com",
             classification=Classification.DOMAIN,
@@ -36,16 +42,27 @@ class DataModelToolTestCase(TestCase):
             analyzable=self.analyzable,
             status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
         )
-        # Another user's job (must stay inaccessible).
+        # Another user's job, RED so it stays inaccessible under visible_for_user.
         self.other_job = Job.objects.create(
             user=self.other_user,
             analyzable=self.analyzable,
             status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+            tlp=TLP.RED.value,
+        )
+        # Org-mate's RED job: reachable via organization membership (no data model attached;
+        # the point is that it resolves instead of returning "not accessible").
+        self.org_job = Job.objects.create(
+            user=self.org_member,
+            analyzable=self.analyzable,
+            status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
+            tlp=TLP.RED.value,
         )
         self.get_data_model = {t.name: t for t in build_tools(user=self.user)}["get_data_model"]
 
     def tearDown(self):
-        Job.objects.filter(user__in=[self.user, self.other_user]).delete()
+        Job.objects.filter(user__in=[self.user, self.other_user, self.org_member]).delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()
         self.data_model.delete()
 
     def test_get_data_model_returns_serialized(self):
@@ -64,3 +81,10 @@ class DataModelToolTestCase(TestCase):
         self.assertEqual(data["data_model"], {})
         self.assertTrue(data["errors"])
         self.assertIn("not found or not accessible", data["errors"][0])
+
+    def test_get_data_model_org_shared_visible(self):
+        # An org-mate's RED job is reachable via organization membership (UI parity);
+        # the data model is empty because none is attached, but it is NOT "not accessible".
+        data = json.loads(self.get_data_model.invoke({"job_id": self.org_job.pk}))
+        self.assertEqual(data["errors"], [])
+        self.assertEqual(data["data_model"], {})

--- a/tests/api_app/chatbot_manager/tools/test_search_jobs.py
+++ b/tests/api_app/chatbot_manager/tools/test_search_jobs.py
@@ -9,8 +9,10 @@ from django.test import TestCase
 from api_app.analyzables_manager.models import Analyzable
 from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
 from api_app.chatbot_manager.agent.tools import build_tools
-from api_app.choices import Classification
+from api_app.choices import TLP, Classification
 from api_app.models import Job
+from certego_saas.apps.organization.membership import Membership
+from certego_saas.apps.organization.organization import Organization
 from certego_saas.apps.user.models import User
 
 
@@ -18,21 +20,52 @@ class SearchJobsToolTestCase(TestCase):
     def setUp(self):
         self.user, _ = User.objects.get_or_create(username="chatbot_tool_user")
         self.other_user, _ = User.objects.get_or_create(username="chatbot_other_user")
+        # org-mate of self.user, to exercise visible_for_user org sharing.
+        self.org_member, _ = User.objects.get_or_create(username="chatbot_org_member")
+        self.org, _ = Organization.objects.get_or_create(name="chatbot tool org")
+        Membership.objects.get_or_create(user=self.user, organization=self.org, is_owner=True)
+        Membership.objects.get_or_create(user=self.org_member, organization=self.org, is_owner=False)
+
         self.analyzable, _ = Analyzable.objects.get_or_create(
             name="malware.example.com",
             classification=Classification.DOMAIN,
         )
+        self.shared_analyzable, _ = Analyzable.objects.get_or_create(
+            name="shared.example.com",
+            classification=Classification.DOMAIN,
+        )
+        self.public_analyzable, _ = Analyzable.objects.get_or_create(
+            name="public.example.com",
+            classification=Classification.DOMAIN,
+        )
+        # TLP RED on the owner/other jobs so the cross-user isolation assertions stay
+        # meaningful under visible_for_user (CLEAR/GREEN jobs are globally visible by design).
         self.job = Job.objects.create(
             user=self.user,
             analyzable=self.analyzable,
             status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
-            tlp="GREEN",
+            tlp=TLP.RED.value,
         )
         self.other_job = Job.objects.create(
             user=self.other_user,
             analyzable=self.analyzable,
             status=Job.STATUSES.REPORTED_WITHOUT_FAILS,
-            tlp="GREEN",
+            tlp=TLP.RED.value,
+        )
+        # Org-mate's RED job (distinct observable + non-RWF status so it doesn't perturb the
+        # name/status filters above); visible to self.user only via organization membership.
+        self.org_job = Job.objects.create(
+            user=self.org_member,
+            analyzable=self.shared_analyzable,
+            status=Job.STATUSES.RUNNING,
+            tlp=TLP.RED.value,
+        )
+        # Unrelated user's GREEN job: globally visible under UI parity.
+        self.green_job = Job.objects.create(
+            user=self.other_user,
+            analyzable=self.public_analyzable,
+            status=Job.STATUSES.RUNNING,
+            tlp=TLP.GREEN.value,
         )
         tools = build_tools(user=self.user)
         tools_by_name = {t.name: t for t in tools}
@@ -125,5 +158,30 @@ class SearchJobsToolTestCase(TestCase):
         data = json.loads(result)
         self.assertTrue(any("maximum 50" in e for e in data["errors"]))
 
+    def test_search_jobs_includes_org_shared(self):
+        # An org-mate's AMBER/RED job is visible via organization membership (UI parity).
+        result = self.search_jobs.invoke({"query": "shared.example.com"})
+        ids = [d["id"] for d in json.loads(result)["jobs"]]
+        self.assertIn(self.org_job.pk, ids)
+
+    def test_search_jobs_includes_clear_green_globally(self):
+        # An unrelated user's CLEAR/GREEN job surfaces in search results too (UI parity).
+        result = self.search_jobs.invoke({"query": "public.example.com"})
+        ids = [d["id"] for d in json.loads(result)["jobs"]]
+        self.assertIn(self.green_job.pk, ids)
+
+    def test_get_job_details_org_shared_visible(self):
+        data = json.loads(self.get_job_details.invoke({"job_id": self.org_job.pk}))
+        self.assertEqual(data["errors"], [])
+        self.assertEqual(data["job"]["id"], self.org_job.pk)
+
+    def test_get_job_details_clear_green_globally_visible(self):
+        # CLEAR/GREEN jobs are visible to everyone in IntelOwl, matching the UI.
+        data = json.loads(self.get_job_details.invoke({"job_id": self.green_job.pk}))
+        self.assertEqual(data["errors"], [])
+        self.assertEqual(data["job"]["id"], self.green_job.pk)
+
     def tearDown(self):
-        Job.objects.filter(user__in=[self.user, self.other_user]).delete()
+        Job.objects.filter(user__in=[self.user, self.other_user, self.org_member]).delete()
+        Membership.objects.filter(organization=self.org).delete()
+        self.org.delete()


### PR DESCRIPTION
# Description

Follow-up to the W10 chatbot security review (finding **I-2**). Switches the four job read-tools from owner-only `Job.objects.filter(user=user)` to `Job.objects.visible_for_user(user)` — the exact scope the REST `JobViewSet` (`api_app/views.py:395`) uses — so the chatbot shows the user neither more nor less than the IntelOwl UI.

`Refs #3782`

**Behavior change (intended).** `search_jobs`, `get_job_details`, `summarize_job` and `get_data_model` now also surface:
- other users' jobs with TLP **CLEAR or GREEN** (globally visible in IntelOwl), and
- **org-mates'** AMBER/RED jobs,

matching `JobQuerySet.visible_for_user` (`api_app/queryset.py:313`). The investigation and playbook tools already used this scope; this change makes the job tools consistent with them and with the UI. `analyze_observable` is unchanged.

## Type of change
- [x] New feature (non-breaking change which adds functionality).

## Checklist
- [x] I have read and understood the rules about how to Contribute to this project.
- [ ] The pull request is for the branch `develop` — N/A: targets the GSoC umbrella `gsoc-2026/llm-chatbot`.
- [ ] A new plugin was added or changed — N/A.
- [x] Copyright banner present — no new files.
- [x] Avoid adding new libraries — none added.
- [ ] Restrictive-license libraries — N/A.
- [x] Linters (Ruff) gave 0 errors.
- [x] Tests added; all tests pass (full chatbot suite: 130 tests OK on the rebuilt image). New tests cover org-shared and CLEAR/GREEN visibility for `search_jobs`, `get_job_details`, and `get_data_model`.
- [ ] GUI modified — N/A.
- [ ] Will resolve any DeepSource/Django Doctors/CI alerts raised after submission.
- [ ] I have addressed raised Copilot issues.
- [x] I have reviewed and verified the LLM-generated code in this PR. Disclosure: implemented with Claude Code from a reviewed plan; verified locally — ruff clean, 130 chatbot tests pass, and the data-isolation reviewer confirmed no leaks and exact UI-parity (the tools now expose the same scope as `JobViewSet`, no more/less).
