### PR TITLE
[GSoC 2026] M-1 guardrail backend: analyze_observable preview-only + confirm endpoint

### DIFF
--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -11,6 +11,7 @@ pattern ``JobConsumer.serialize_and_send_job`` already uses.
 """
 
 import json
+import logging
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
@@ -23,6 +24,8 @@ from api_app.chatbot_manager.events import (
     TokenEvent,
     chat_group_for_user,
 )
+
+logger = logging.getLogger(__name__)
 
 
 class ChatStreamingCallbackHandler(BaseCallbackHandler):
@@ -74,6 +77,9 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         try:
             data = json.loads(text)
         except (TypeError, ValueError):
+            logger.warning("on_tool_end: cannot parse tool output as JSON (%s)", type(output).__name__)
             return
         if isinstance(data, dict) and data.get("pending_id"):
             self._emit(ActionRequiredEvent(self._session_id, data["pending_id"], data.get("plan") or {}))
+        else:
+            logger.debug("on_tool_end: no pending_id in tool output")

--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -10,11 +10,14 @@ no event loop, so ``async_to_sync`` is the right bridge to the async channel lay
 pattern ``JobConsumer.serialize_and_send_job`` already uses.
 """
 
+import json
+
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
 from langchain_core.callbacks.base import BaseCallbackHandler
 
 from api_app.chatbot_manager.events import (
+    ActionRequiredEvent,
     ChatEvent,
     StatusEvent,
     TokenEvent,
@@ -62,3 +65,15 @@ class ChatStreamingCallbackHandler(BaseCallbackHandler):
         if not tool_name or (self._tool_names is not None and tool_name not in self._tool_names):
             return
         self._emit(StatusEvent(self._session_id, tool_name))
+
+    def on_tool_end(self, output, **kwargs) -> None:
+        # analyze_observable returns an envelope carrying a one-time pending_id; surface it as a
+        # structured action so the frontend can render a Confirm button. Other tools have no
+        # pending_id, so this is a no-op for them.
+        text = getattr(output, "content", output)
+        try:
+            data = json.loads(text)
+        except (TypeError, ValueError):
+            return
+        if isinstance(data, dict) and data.get("pending_id"):
+            self._emit(ActionRequiredEvent(self._session_id, data["pending_id"], data.get("plan") or {}))

--- a/api_app/chatbot_manager/agent/system_prompt.txt
+++ b/api_app/chatbot_manager/agent/system_prompt.txt
@@ -12,12 +12,12 @@ Answer with short, data-driven summaries. Always cite the tools you used at the 
 - get_data_model: raw data model of ONE job. Rarely needed — only when the user explicitly asks for raw data or the data model.
 - list_analyzers: list available analyzers for an observable type (domain, ip, url, hash, generic). Use for "what analyzers can I use for a domain?".
 - recommend_playbook: recommend a playbook to analyze an observable. Use for "what playbook for 1.1.1.1?".
-- analyze_observable: START A REAL ANALYSIS. Always call with confirm=false first, show the returned plan to the user, and only call again with confirm=true after the user explicitly approves.
+- analyze_observable: PREVIEW a real analysis (it never launches one itself). Call it to validate the request and return a plan; then tell the user to approve it with the Confirm button in the chat panel. Never claim you started an analysis.
 
 [Rules]
 - Only access data belonging to the current user. Never reveal other users' data.
 - Call the right tool instead of guessing. Say so when a tool returns no data.
-- Do NOT call analyze_observable with confirm=true unless the user explicitly approved the plan shown by the confirm=false call.
+- analyze_observable only previews; never tell the user an analysis has started — they approve it themselves via the Confirm button.
 
 [Response style]
 - One paragraph unless the user asks for a list or breakdown.

--- a/api_app/chatbot_manager/agent/tools/analyze_observable.py
+++ b/api_app/chatbot_manager/agent/tools/analyze_observable.py
@@ -2,108 +2,63 @@
 # See the file 'LICENSE' for copying permission.
 
 from types import SimpleNamespace
-from typing import List
 
-from django.utils.timezone import now
 from langchain_core.tools import tool
 
-from api_app.chatbot_manager.serializers.analyze_observable import AnalyzeObservableResultSerializer
+from api_app.chatbot_manager.pending_action import create_pending_analysis
+from api_app.chatbot_manager.serializers.analyze_observable import (
+    AnalyzeObservableResultSerializer,
+    flatten_errors,
+)
 from api_app.choices import TLP
 from api_app.playbooks_manager.models import PlaybookConfig
 from api_app.serializers.job import ObservableAnalysisSerializer
 
 
-def _flatten_errors(errors) -> List[str]:
-    """Flatten DRF's ``{field: [msg, ...]}`` error dict into a flat ``list[str]``.
-
-    The reused serializer reports failures (private-IP guardrail, unknown analyzer, "nothing
-    runnable", ...) as nested ``ValidationError`` dicts; the LLM only needs a flat list of messages.
-    """
-    if isinstance(errors, dict):
-        flat = []
-        for field_name, messages in errors.items():
-            if isinstance(messages, (list, tuple)):
-                flat.extend(f"{field_name}: {message}" for message in messages)
-            else:
-                flat.append(f"{field_name}: {messages}")
-        return flat
-    if isinstance(errors, (list, tuple)):
-        return [str(message) for message in errors]
-    return [str(errors)]
-
-
 def make_analyze_observable_tool(user):
-    # Built per-request and closed over `user`. This is the only ACTION tool: it can launch a real
-    # IntelOwl analysis. Safety is two-phase + confirm-gated -- a call without confirm=True can never
-    # reach `job_pipeline.apply_async`, because the create path triggers it only under
-    # `save(send_task=True)`, which we call exclusively on the confirm=True branch. The created
-    # `Job.user` is this closured `user` (via the request shim), so the agent cannot widen scope.
+    # Built per-request and closed over `user`. This is the only action-capable tool, but it now
+    # NEVER launches: it validates and returns a `plan` plus a one-time `pending_id`. The actual
+    # launch happens only when the user confirms via the chat panel (POST /api/chatbot/analysis/
+    # confirm), so a misbehaving model can never start an analysis on its own (guardrail M-1).
     @tool("analyze_observable")
     def analyze_observable(
         observable_name: str,
         playbook: str = "",
         analyzers: str = "",
         tlp: str = TLP.CLEAR.value,
-        confirm: bool = False,
     ) -> str:
-        """Start an IntelOwl analysis of an observable (IP, domain, URL, hash, ...).
+        """Preview an IntelOwl analysis of an observable (IP, domain, URL, hash).
 
-        This tool ACTUALLY launches an analysis, so it is two-phase and must be confirmed:
-        1. Call it first with confirm=false -> it validates the request and returns a `plan` (the
-           analyzers/connectors that would run, the ones skipped, the resolved classification)
-           WITHOUT starting anything. Show that plan to the user.
-        2. Only after the user explicitly approves, call it again with the same arguments and
-           confirm=true -> this starts the analysis. If the same observable was already analyzed
-           recently the existing job is returned instead of launching a duplicate (`reused=true`).
+        This tool does NOT start anything: it validates the request and returns the `plan` that
+        would run plus a `pending_id`. Tell the user to approve it with the Confirm button in the
+        chat panel; you cannot launch the analysis yourself.
 
         Args:
             observable_name: The observable to analyze (an IP, domain, URL or hash).
-            playbook: Optional playbook name to run (must be visible to you). Mutually exclusive
-                    with `analyzers`.
-            analyzers: Optional COMMA-SEPARATED analyzer names (e.g. "Classic_DNS,VirusTotal_v3").
-                    Mutually exclusive with `playbook`. If both are empty the instance defaults run.
-            tlp: Traffic Light Protocol level (CLEAR, GREEN, AMBER, RED; default CLEAR). TLP only
-                    filters which plugins may run -- it never blocks the launch.
-            confirm: Must be true to actually start the analysis. Defaults to false (preview only).
+            playbook: Optional playbook name (must be visible to you). Mutually exclusive with analyzers.
+            analyzers: Optional COMMA-SEPARATED analyzer names. Mutually exclusive with playbook.
+            tlp: TLP level (CLEAR, GREEN, AMBER, RED; default CLEAR). Only filters which plugins run.
 
         Returns:
-            JSON string with shape {"errors": [...], "confirmation_required": bool, "reused": bool,
-            "plan": {...} | null, "job": {...} | null}.
+            JSON string {"errors": [...], "plan": {...} | null, "pending_id": "..." | null}.
         """
-        # The reused serializer reads the requesting user from `context["request"].user`; a shim is
-        # enough since the create path only ever reads `.user`.
         shim = SimpleNamespace(user=user)
-        # No scan_mode override -> the serializer applies the platform default
-        # (CHECK_PREVIOUS_ANALYSIS): a confirmed request reuses a matching analysis from the last 24h
-        # instead of always launching a duplicate (saves analyzer quota; same behaviour as the REST
-        # analyze_observable endpoint). `reused` in the result reports whether that happened.
-        data = {
-            "observable_name": observable_name,
-            "tlp": tlp,
-        }
-
         if playbook:
-            # ISOLATION GUARD: ObservableAnalysisSerializer resolves `playbook_requested` via
-            # PlaybookConfig.objects.all() (no visibility filter) and the create path never re-scopes
-            # it -- so an LLM-supplied name could reference another org's PRIVATE playbook and leak
-            # its existence/composition into the plan. Scope it here against `visible_for_user` (the
-            # same boundary recommend_playbook uses) BEFORE the serializer sees it. Analyzers need no
-            # such guard: AnalyzerConfig is a global config (matches the UI's `.all()`).
+            # ISOLATION GUARD: ObservableAnalysisSerializer resolves playbook_requested via
+            # PlaybookConfig.objects.all() with no visibility filter; scope it here first so another
+            # org's private playbook can't leak into the plan.
             if not PlaybookConfig.objects.visible_for_user(user).filter(name=playbook).exists():
                 return AnalyzeObservableResultSerializer(
                     {
                         "errors": [f"Playbook '{playbook}' not found or not visible to you."],
-                        "confirmation_required": False,
-                        "reused": False,
                         "plan": None,
-                        "job": None,
+                        "pending_id": None,
                     }
                 ).to_json()
-            data["playbook_requested"] = playbook
 
-        # `analyzers` stays a comma-separated string rather than a list[str]: a flat string is
-        # the simplest schema for a small local model to emit reliably, and splitting here keeps
-        # the tool signature stable regardless of how the agent encodes its arguments.
+        data = {"observable_name": observable_name, "tlp": tlp}
+        if playbook:
+            data["playbook_requested"] = playbook
         analyzers_list = [a.strip() for a in analyzers.split(",") if a.strip()]
         if analyzers_list:
             data["analyzers_requested"] = analyzers_list
@@ -111,43 +66,27 @@ def make_analyze_observable_tool(user):
         serializer = ObservableAnalysisSerializer(data=data, context={"request": shim})
         if not serializer.is_valid(raise_exception=False):
             return AnalyzeObservableResultSerializer(
-                {
-                    "errors": _flatten_errors(serializer.errors),
-                    "confirmation_required": False,
-                    "reused": False,
-                    "plan": None,
-                    "job": None,
-                }
+                {"errors": flatten_errors(serializer.errors), "plan": None, "pending_id": None}
             ).to_json()
 
         validated = serializer.validated_data
-        if not confirm:
-            # Preview path: report exactly what a confirmed call would run; trigger nothing. The plan
-            # dict is shaped/validated by AnalysisPlanSerializer (the envelope's `plan` field).
-            plan = {
-                "observable_name": validated["observable_name"],
-                "classification": validated["observable_classification"],
-                "tlp": validated["tlp"],
-                "playbook": validated["playbook_requested"].name
-                if validated.get("playbook_requested")
-                else None,
-                "analyzers": [analyzer.name for analyzer in validated["analyzers_to_execute"]],
-                "connectors": [connector.name for connector in validated["connectors_to_execute"]],
-                # the committed copy of the serializer's filter_warnings (skipped/unrunnable plugins)
-                "skipped": list(validated.get("warnings", [])),
-            }
-            return AnalyzeObservableResultSerializer(
-                {"errors": [], "confirmation_required": True, "reused": False, "plan": plan, "job": None}
-            ).to_json()
-
-        # confirm=True: the only path that may trigger the analysis (job_pipeline.apply_async, via
-        # save(send_task=True)). With the default scan_mode the serializer may instead return a matching
-        # recent job WITHOUT launching anything (dedup); a request time older than this call means reuse.
-        started = now()
-        job = serializer.save(send_task=True)
-        reused = job.received_request_time < started
+        plan = {
+            "observable_name": validated["observable_name"],
+            "classification": validated["observable_classification"],
+            "tlp": validated["tlp"],
+            "playbook": validated["playbook_requested"].name if validated.get("playbook_requested") else None,
+            "analyzers": [analyzer.name for analyzer in validated["analyzers_to_execute"]],
+            "connectors": [connector.name for connector in validated["connectors_to_execute"]],
+            "skipped": list(validated.get("warnings", [])),
+        }
+        # Store the RAW inputs (re-validated at confirm time); the model cannot launch -- only a
+        # user POST of this pending_id to the confirm endpoint can.
+        pending_id = create_pending_analysis(
+            user.id,
+            {"observable_name": observable_name, "tlp": tlp, "playbook": playbook, "analyzers": analyzers},
+        )
         return AnalyzeObservableResultSerializer(
-            {"errors": [], "confirmation_required": False, "reused": reused, "plan": None, "job": job}
+            {"errors": [], "plan": plan, "pending_id": pending_id}
         ).to_json()
 
     return analyze_observable

--- a/api_app/chatbot_manager/consumers.py
+++ b/api_app/chatbot_manager/consumers.py
@@ -118,3 +118,6 @@ class ChatConsumer(JsonWebsocketConsumer):
 
     def chat_error(self, event) -> None:
         self.send_json(event["payload"])
+
+    def chat_action_required(self, event) -> None:
+        self.send_json(event["payload"])

--- a/api_app/chatbot_manager/events.py
+++ b/api_app/chatbot_manager/events.py
@@ -36,6 +36,7 @@ class ChatEventType(StrEnum):
     TOKEN = "token"
     END = "end"
     ERROR = "error"
+    ACTION_REQUIRED = "action_required"
 
 
 class ChatErrorDetail(StrEnum):
@@ -122,3 +123,15 @@ class ErrorEvent(ChatEvent):
     detail: str
     retry_after: Optional[int] = None
     type: ClassVar[ChatEventType] = ChatEventType.ERROR
+
+
+@dataclass(frozen=True)
+class ActionRequiredEvent(ChatEvent):
+    """A tool produced something the user must act on out-of-band (e.g. confirm an analysis).
+
+    Carries the pending id the frontend posts to the confirm endpoint, plus the plan to display.
+    """
+
+    pending_id: str
+    plan: dict
+    type: ClassVar[ChatEventType] = ChatEventType.ACTION_REQUIRED

--- a/api_app/chatbot_manager/pending_action.py
+++ b/api_app/chatbot_manager/pending_action.py
@@ -1,0 +1,43 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Short-lived store for pending analyze_observable confirmations (HITL guardrail).
+
+A preview mints a record keyed by a random id; the confirm endpoint consumes it (one-shot,
+user-scoped). Backed by a dedicated Redis cache so the model can never launch an analysis on
+its own -- only a real user action presenting a valid pending id can.
+"""
+
+import uuid
+
+from django.conf import settings
+from django.core.cache import caches
+
+CACHE_ALIAS = "chatbot_pending_action"
+_KEY_PREFIX = "chatbot_pending_"
+
+
+def create_pending_analysis(user_id: int, payload: dict) -> str:
+    """Store the previewed analysis inputs and return a fresh one-time pending id."""
+    pending_id = uuid.uuid4().hex
+    record = {"user_id": user_id, "payload": payload}
+    caches[CACHE_ALIAS].set(_key(pending_id), record, timeout=settings.CHATBOT_PENDING_ACTION_TTL)
+    return pending_id
+
+
+def consume_pending_analysis(user_id: int, pending_id: str) -> dict | None:
+    """Return and delete the pending payload iff it exists and belongs to `user_id` (one-shot)."""
+    cache = caches[CACHE_ALIAS]
+    key = _key(pending_id)
+    record = cache.get(key)
+    if not record or record.get("user_id") != user_id:
+        return None
+    # delete() reports whether the key still existed: under a concurrent double-submit only the
+    # caller whose delete actually removed it proceeds, keeping the launch strictly one-shot.
+    if not cache.delete(key):
+        return None
+    return record["payload"]
+
+
+def _key(pending_id: str) -> str:
+    return f"{_KEY_PREFIX}{pending_id}"

--- a/api_app/chatbot_manager/serializers/analyze_observable.py
+++ b/api_app/chatbot_manager/serializers/analyze_observable.py
@@ -1,18 +1,36 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from typing import List
+
 from rest_framework import serializers
 
 from .base import ToolResultSerializer
 from .job import JobToolSerializer
 
 
-class AnalysisPlanSerializer(serializers.Serializer):
-    """What a confirmed analyze_observable call would launch (preview, no side effects).
+def flatten_errors(errors) -> List[str]:
+    """Flatten DRF's ``{field: [msg, ...]}`` error dict into a flat ``list[str]``.
 
-    Declared as a serializer (not a free-form dict) so the plan's shape is enforced and documented in
-    one place; the tool feeds it the computed values on the confirm=False path.
+    Shared by the analyze_observable tool (preview validation) and the confirm endpoint
+    (launch validation): the reused ObservableAnalysisSerializer reports failures as nested
+    ValidationError dicts; callers only need a flat list of messages.
     """
+    if isinstance(errors, dict):
+        flat = []
+        for field_name, messages in errors.items():
+            if isinstance(messages, (list, tuple)):
+                flat.extend(f"{field_name}: {message}" for message in messages)
+            else:
+                flat.append(f"{field_name}: {messages}")
+        return flat
+    if isinstance(errors, (list, tuple)):
+        return [str(message) for message in errors]
+    return [str(errors)]
+
+
+class AnalysisPlanSerializer(serializers.Serializer):
+    """What a confirmed analyze_observable call would launch (preview, no side effects)."""
 
     observable_name = serializers.CharField()
     classification = serializers.CharField()
@@ -20,20 +38,23 @@ class AnalysisPlanSerializer(serializers.Serializer):
     playbook = serializers.CharField(allow_null=True)
     analyzers = serializers.ListField(child=serializers.CharField())
     connectors = serializers.ListField(child=serializers.CharField())
-    # plugins dropped by TLP / not runnable for the user (the serializer's filter_warnings)
     skipped = serializers.ListField(child=serializers.CharField())
 
 
 class AnalyzeObservableResultSerializer(ToolResultSerializer):
-    """Envelope for the analyze_observable action tool.
+    """Envelope for the analyze_observable tool, which now ONLY previews.
 
-    Two-phase contract: on the preview call `confirmation_required` is True and `plan` carries what
-    would run; on the confirmed call `job` carries the launched -- or, on platform dedup, the reused
-    recent -- Job, and `reused` says which it is.
+    `plan` is what a confirmed run would do; `pending_id` is the one-time token the user's
+    Confirm button posts to the launch endpoint. The tool never launches an analysis itself.
     """
 
-    confirmation_required = serializers.BooleanField()
-    # True when a confirmed call returned an existing recent job (platform dedup) instead of a new one.
-    reused = serializers.BooleanField()
     plan = AnalysisPlanSerializer(allow_null=True)
-    job = JobToolSerializer(allow_null=True)  # reuse the existing compact, PII-free Job view
+    pending_id = serializers.CharField(allow_null=True)
+
+
+class ConfirmAnalysisResultSerializer(serializers.Serializer):
+    """Response of the analyze-confirm endpoint: the launched (or dedup-reused) job."""
+
+    errors = serializers.ListField(child=serializers.CharField())
+    reused = serializers.BooleanField()
+    job = JobToolSerializer(allow_null=True)

--- a/api_app/chatbot_manager/urls.py
+++ b/api_app/chatbot_manager/urls.py
@@ -4,11 +4,12 @@
 from django.urls import path
 from rest_framework.routers import DefaultRouter
 
-from .views import ChatHealthView, ChatSessionViewSet
+from .views import ChatAnalysisConfirmView, ChatHealthView, ChatSessionViewSet
 
 router = DefaultRouter(trailing_slash=False)
 router.register(r"sessions", ChatSessionViewSet, basename="chat-sessions")
 
 urlpatterns = router.urls + [
     path("health", ChatHealthView.as_view(), name="chat-health"),
+    path("analysis/confirm", ChatAnalysisConfirmView.as_view(), name="chat-analysis-confirm"),
 ]

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -5,6 +5,7 @@ import logging
 
 from django.db.models import OuterRef, Subquery
 from django.db.models.functions import Substr
+from django.utils.timezone import now
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -13,12 +14,17 @@ from rest_framework.response import Response
 from rest_framework.views import APIView
 from rest_framework.viewsets import ModelViewSet
 
+from api_app.playbooks_manager.models import PlaybookConfig
+from api_app.serializers.job import ObservableAnalysisSerializer
+
 from .agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
 from .agent.memory import DjangoChatMessageHistory
 from .events import ChatErrorDetail
 from .health import chatbot_health
 from .models import ChatMessage, ChatSession
+from .pending_action import consume_pending_analysis
 from .rate_limit import _build_rate_limiter
+from .serializers.analyze_observable import ConfirmAnalysisResultSerializer, flatten_errors
 from .serializers.chat import (
     ChatMessageSerializer,
     ChatSessionSerializer,
@@ -170,3 +176,66 @@ class ChatHealthView(APIView):
 
     def get(self, request):
         return Response(ChatHealthSerializer(chatbot_health()).data)
+
+
+class ChatAnalysisConfirmView(APIView):
+    """Launch a previously previewed analysis. This is the ONLY path that starts an
+    analyze_observable run: the agent can only preview (mint a pending id); a real user action
+    (the Confirm button) posts that id here, so the model can never launch on its own (M-1)."""
+
+    permission_classes = [IsAuthenticated]
+
+    def post(self, request):
+        pending_id = request.data.get("pending_id")
+        record = consume_pending_analysis(request.user.id, pending_id) if pending_id else None
+        if record is None:
+            return Response(
+                {
+                    "errors": ["This confirmation has expired or is invalid. Ask for the analysis again."],
+                    "reused": False,
+                    "job": None,
+                },
+                status=status.HTTP_410_GONE,
+            )
+
+        # Re-apply the playbook visibility guard the preview tool uses: ObservableAnalysisSerializer
+        # resolves playbook_requested via PlaybookConfig.objects.all() (no visibility filter), so
+        # without this a playbook that became invisible to the user between preview and confirm could
+        # still be launched.
+        if (
+            record.get("playbook")
+            and not PlaybookConfig.objects.visible_for_user(request.user)
+            .filter(name=record["playbook"])
+            .exists()
+        ):
+            return Response(
+                {
+                    "errors": [f"Playbook '{record['playbook']}' is no longer visible to you."],
+                    "reused": False,
+                    "job": None,
+                },
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        data = {"observable_name": record["observable_name"], "tlp": record["tlp"]}
+        if record.get("playbook"):
+            data["playbook_requested"] = record["playbook"]
+        analyzers_list = [a.strip() for a in record.get("analyzers", "").split(",") if a.strip()]
+        if analyzers_list:
+            data["analyzers_requested"] = analyzers_list
+
+        # Re-validate the observable/analyzers at launch time; playbook visibility is re-checked above.
+        serializer = ObservableAnalysisSerializer(data=data, context={"request": request})
+        if not serializer.is_valid(raise_exception=False):
+            return Response(
+                {"errors": flatten_errors(serializer.errors), "reused": False, "job": None},
+                status=status.HTTP_400_BAD_REQUEST,
+            )
+
+        started = now()
+        job = serializer.save(send_task=True)
+        reused = job.received_request_time < started  # platform dedup returned a recent job
+        return Response(
+            ConfirmAnalysisResultSerializer({"errors": [], "reused": reused, "job": job}).data,
+            status=status.HTTP_200_OK,
+        )

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -28,3 +28,12 @@ CACHES["chatbot_rate_limit"] = {
     "BACKEND": "django.core.cache.backends.redis.RedisCache",
     "LOCATION": "redis://redis:6379/2",
 }
+
+# Pending analyze_observable confirmations (human-in-the-loop guardrail): a preview mints a
+# short-lived record; the confirm endpoint consumes it. Same Redis db as the rate limiter (2);
+# keys are namespaced by prefix so they never collide.
+CHATBOT_PENDING_ACTION_TTL = int(secrets.get_secret("CHATBOT_PENDING_ACTION_TTL", 600))
+CACHES["chatbot_pending_action"] = {
+    "BACKEND": "django.core.cache.backends.redis.RedisCache",
+    "LOCATION": "redis://redis:6379/2",
+}

--- a/tests/api_app/chatbot_manager/test_confirm_analysis.py
+++ b/tests/api_app/chatbot_manager/test_confirm_analysis.py
@@ -1,0 +1,105 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import patch
+
+from django.test import override_settings
+from rest_framework import status
+from rest_framework.test import APITestCase
+
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.chatbot_manager.pending_action import create_pending_analysis
+from api_app.models import Job
+from api_app.playbooks_manager.models import PlaybookConfig
+from certego_saas.apps.user.models import User
+
+_APPLY_ASYNC = "intel_owl.tasks.job_pipeline.apply_async"
+_URL = "/api/chatbot/analysis/confirm"
+
+
+@override_settings(CHATBOT_PENDING_ACTION_TTL=600)
+class ConfirmAnalysisViewTestCase(APITestCase):
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="confirm_user")
+        self.other, _ = User.objects.get_or_create(username="confirm_other")
+        self.analyzer = AnalyzerConfig.objects.get(name="Tranco")  # seeded, free, supports domain
+        # A playbook owned by another user and NOT shared -> invisible to self.user (TOCTOU guard test).
+        self.pb_private_other = PlaybookConfig.objects.create(
+            name="confirm_pb_private",
+            description="t",
+            type=["domain"],
+            owner=self.other,
+            for_organization=False,
+            starting=True,
+        )
+        self.pb_private_other.analyzers.set([self.analyzer])
+        self.client.force_authenticate(self.user)
+        self.payload = {
+            "observable_name": "example.com",
+            "tlp": "CLEAR",
+            "playbook": "",
+            "analyzers": "Tranco",
+        }
+
+    def tearDown(self):
+        Job.objects.filter(user__in=[self.user, self.other]).delete()
+        PlaybookConfig.objects.filter(owner=self.other).delete()
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_launches_valid_pending(self, mock_apply):
+        pending_id = create_pending_analysis(self.user.id, self.payload)
+        resp = self.client.post(_URL, {"pending_id": pending_id}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_200_OK)
+        self.assertEqual(resp.json()["errors"], [])
+        self.assertIsNotNone(resp.json()["job"])
+        mock_apply.assert_called_once()
+
+    @patch(_APPLY_ASYNC)
+    def test_launched_job_owned_by_requesting_user(self, mock_apply):
+        pending_id = create_pending_analysis(self.user.id, self.payload)
+        job_id = self.client.post(_URL, {"pending_id": pending_id}, format="json").json()["job"]["id"]
+        self.assertEqual(Job.objects.get(pk=job_id).user, self.user)
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_is_one_shot(self, mock_apply):
+        pending_id = create_pending_analysis(self.user.id, self.payload)
+        self.client.post(_URL, {"pending_id": pending_id}, format="json")
+        resp = self.client.post(_URL, {"pending_id": pending_id}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_410_GONE)
+        mock_apply.assert_called_once()
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_rejects_other_users_pending(self, mock_apply):
+        pending_id = create_pending_analysis(self.other.id, self.payload)
+        resp = self.client.post(_URL, {"pending_id": pending_id}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_410_GONE)
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_unknown_id(self, mock_apply):
+        resp = self.client.post(_URL, {"pending_id": "deadbeef"}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_410_GONE)
+        mock_apply.assert_not_called()
+
+    @patch(_APPLY_ASYNC)
+    def test_confirm_rejects_playbook_no_longer_visible(self, mock_apply):
+        # TOCTOU guard: a pending whose playbook is not visible to the user at confirm time is
+        # refused (the confirm view re-applies the same visible_for_user guard as the preview tool).
+        pending_id = create_pending_analysis(
+            self.user.id,
+            {
+                "observable_name": "example.com",
+                "tlp": "CLEAR",
+                "playbook": self.pb_private_other.name,
+                "analyzers": "",
+            },
+        )
+        resp = self.client.post(_URL, {"pending_id": pending_id}, format="json")
+        self.assertEqual(resp.status_code, status.HTTP_400_BAD_REQUEST)
+        self.assertTrue(resp.json()["errors"])
+        mock_apply.assert_not_called()
+
+    def test_confirm_requires_auth(self):
+        self.client.force_authenticate(None)
+        resp = self.client.post(_URL, {"pending_id": "x"}, format="json")
+        self.assertIn(resp.status_code, (status.HTTP_401_UNAUTHORIZED, status.HTTP_403_FORBIDDEN))

--- a/tests/api_app/chatbot_manager/test_pending_action.py
+++ b/tests/api_app/chatbot_manager/test_pending_action.py
@@ -1,0 +1,38 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.test import SimpleTestCase, override_settings
+
+from api_app.chatbot_manager.pending_action import (
+    consume_pending_analysis,
+    create_pending_analysis,
+)
+
+TEST_CACHES = {
+    "default": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
+    "chatbot_pending_action": {
+        "BACKEND": "django.core.cache.backends.locmem.LocMemCache",
+        "LOCATION": "pending-test",
+    },
+}
+PAYLOAD = {"observable_name": "example.com", "tlp": "CLEAR", "playbook": "", "analyzers": "Tranco"}
+
+
+@override_settings(CACHES=TEST_CACHES, CHATBOT_PENDING_ACTION_TTL=600)
+class PendingActionTestCase(SimpleTestCase):
+    def test_create_then_consume_returns_payload(self):
+        pending_id = create_pending_analysis(7, PAYLOAD)
+        self.assertTrue(pending_id)
+        self.assertEqual(consume_pending_analysis(7, pending_id), PAYLOAD)
+
+    def test_consume_is_one_shot(self):
+        pending_id = create_pending_analysis(7, PAYLOAD)
+        consume_pending_analysis(7, pending_id)
+        self.assertIsNone(consume_pending_analysis(7, pending_id))
+
+    def test_consume_rejects_other_user(self):
+        pending_id = create_pending_analysis(7, PAYLOAD)
+        self.assertIsNone(consume_pending_analysis(99, pending_id))
+
+    def test_consume_unknown_id_returns_none(self):
+        self.assertIsNone(consume_pending_analysis(7, "deadbeef"))

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -1,7 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-from unittest.mock import AsyncMock, MagicMock
+from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import SimpleTestCase
 
@@ -88,3 +88,24 @@ class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
         real_action.tool = "search_jobs"
         handler.on_agent_action(real_action)
         layer.group_send.assert_called_once()
+
+    def test_tool_output_with_pending_id_emits_action_required(self):
+        import json as _json
+
+        handler = ChatStreamingCallbackHandler(user_id=1, session_id=42)
+        with patch.object(handler, "_emit") as mock_emit:
+            handler.on_tool_end(
+                _json.dumps({"errors": [], "plan": {"observable_name": "x"}, "pending_id": "abc"}),
+                run_id="fake-run-id",
+            )
+        mock_emit.assert_called_once()
+        event = mock_emit.call_args.args[0]
+        self.assertEqual(event.pending_id, "abc")
+
+    def test_plain_tool_output_emits_nothing(self):
+        import json as _json
+
+        handler = ChatStreamingCallbackHandler(user_id=1, session_id=42)
+        with patch.object(handler, "_emit") as mock_emit:
+            handler.on_tool_end(_json.dumps({"errors": [], "jobs": []}), run_id="fake-run-id")
+        mock_emit.assert_not_called()

--- a/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
+++ b/tests/api_app/chatbot_manager/tools/test_analyze_observable.py
@@ -4,7 +4,7 @@
 import json
 from unittest.mock import patch
 
-from django.test import TestCase
+from django.test import TestCase, override_settings
 
 from api_app.analyzers_manager.models import AnalyzerConfig
 from api_app.chatbot_manager.agent.tools import build_tools
@@ -20,6 +20,7 @@ from certego_saas.apps.user.models import User
 _APPLY_ASYNC = "intel_owl.tasks.job_pipeline.apply_async"
 
 
+@override_settings(CHATBOT_PENDING_ACTION_TTL=600)
 class AnalyzeObservableToolTestCase(TestCase):
     def setUp(self):
         self.user, _ = User.objects.get_or_create(username="analyze_obs_user")
@@ -59,106 +60,68 @@ class AnalyzeObservableToolTestCase(TestCase):
         self.org.delete()
 
     @patch(_APPLY_ASYNC)
-    def test_preview_does_not_trigger(self, mock_apply):
-        # confirm defaults to False -> preview only: a plan is returned and NOTHING is launched.
-        # This is the core safety guarantee of the action tool.
+    def test_preview_returns_plan_and_pending_id_without_launching(self, mock_apply):
         data = json.loads(
             self.analyze_observable.invoke({"observable_name": "example.com", "analyzers": "Tranco"})
         )
         self.assertEqual(data["errors"], [])
-        self.assertTrue(data["confirmation_required"])
         self.assertIsNotNone(data["plan"])
-        self.assertIsNone(data["job"])
         self.assertEqual(data["plan"]["classification"], "domain")
         self.assertIn("Tranco", data["plan"]["analyzers"])
+        self.assertTrue(data["pending_id"])
+        mock_apply.assert_not_called()  # the tool NEVER launches
+
+    @patch(_APPLY_ASYNC)
+    def test_preview_mints_a_consumable_pending_record(self, mock_apply):
+        from api_app.chatbot_manager.pending_action import consume_pending_analysis
+
+        data = json.loads(
+            self.analyze_observable.invoke({"observable_name": "example.com", "analyzers": "Tranco"})
+        )
+        payload = consume_pending_analysis(self.user.id, data["pending_id"])
+        self.assertEqual(payload["observable_name"], "example.com")
+        self.assertEqual(payload["analyzers"], "Tranco")
         mock_apply.assert_not_called()
 
     @patch(_APPLY_ASYNC)
-    def test_confirm_triggers_once(self, mock_apply):
+    def test_private_ip_refused_at_preview(self, mock_apply):
         data = json.loads(
-            self.analyze_observable.invoke(
-                {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
-            )
+            self.analyze_observable.invoke({"observable_name": "10.0.0.1", "analyzers": "Classic_DNS"})
         )
-        self.assertEqual(data["errors"], [])
-        self.assertFalse(data["confirmation_required"])
+        self.assertTrue(data["errors"])
         self.assertIsNone(data["plan"])
-        self.assertIsNotNone(data["job"])
-        self.assertEqual(data["job"]["observable_name"], "example.com")
-        self.assertFalse(data["reused"])  # fresh observable -> a new job, not a reused one
-        mock_apply.assert_called_once()
-
-    @patch(_APPLY_ASYNC)
-    def test_created_job_owned_by_requesting_user(self, mock_apply):
-        # Multi-tenancy: the launched Job is created under the closured user, never widened.
-        data = json.loads(
-            self.analyze_observable.invoke(
-                {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
-            )
-        )
-        job = Job.objects.get(pk=data["job"]["id"])
-        self.assertEqual(job.user, self.user)
-
-    @patch(_APPLY_ASYNC)
-    def test_dedup_reuses_recent_job_on_second_confirm(self, mock_apply):
-        # Default scan_mode (CHECK_PREVIOUS_ANALYSIS): a second confirmed call for the same observable
-        # reuses the recent job instead of launching a duplicate -> apply_async fires only once and the
-        # second result is flagged `reused` with the same job id.
-        args = {"observable_name": "example.com", "analyzers": "Tranco", "confirm": True}
-        first = json.loads(self.analyze_observable.invoke(args))
-        second = json.loads(self.analyze_observable.invoke(args))
-        self.assertFalse(first["reused"])
-        self.assertTrue(second["reused"])
-        self.assertEqual(first["job"]["id"], second["job"]["id"])
-        mock_apply.assert_called_once()
-
-    @patch(_APPLY_ASYNC)
-    def test_private_ip_refused(self, mock_apply):
-        # The serializer's IP guardrail rejects a private IP during validation -> even with
-        # confirm=True the request never reaches the trigger.
-        data = json.loads(
-            self.analyze_observable.invoke(
-                {"observable_name": "10.0.0.1", "analyzers": "Classic_DNS", "confirm": True}
-            )
-        )
-        self.assertTrue(data["errors"])
-        self.assertIsNone(data["job"])
+        self.assertIsNone(data["pending_id"])
         mock_apply.assert_not_called()
 
     @patch(_APPLY_ASYNC)
-    def test_unknown_analyzer_refused(self, mock_apply):
-        # An analyzer name the serializer can't resolve -> validation error, nothing triggered.
+    def test_unknown_analyzer_refused_at_preview(self, mock_apply):
         data = json.loads(
             self.analyze_observable.invoke(
-                {"observable_name": "example.com", "analyzers": "NotARealAnalyzer", "confirm": True}
+                {"observable_name": "example.com", "analyzers": "NotARealAnalyzer"}
             )
         )
         self.assertTrue(data["errors"])
-        self.assertIsNone(data["job"])
+        self.assertIsNone(data["pending_id"])
         mock_apply.assert_not_called()
 
     @patch(_APPLY_ASYNC)
     def test_playbook_not_visible_refused(self, mock_apply):
-        # Isolation must-fix: another member's PRIVATE playbook must never resolve. The reused
-        # serializer would look it up via PlaybookConfig.objects.all(); the tool's visible_for_user
-        # guard rejects it first, so its existence/composition is never leaked into a plan.
         data = json.loads(
             self.analyze_observable.invoke(
-                {"observable_name": "example.com", "playbook": self.pb_private_other.name, "confirm": True}
+                {"observable_name": "example.com", "playbook": self.pb_private_other.name}
             )
         )
         self.assertTrue(any("not found or not visible" in e for e in data["errors"]))
         self.assertIsNone(data["plan"])
-        self.assertIsNone(data["job"])
+        self.assertIsNone(data["pending_id"])
         mock_apply.assert_not_called()
 
     @patch(_APPLY_ASYNC)
     def test_visible_playbook_preview(self, mock_apply):
-        # A playbook owned by the user passes the guard and previews with its name in the plan.
         data = json.loads(
             self.analyze_observable.invoke({"observable_name": "example.com", "playbook": self.pb_owned.name})
         )
         self.assertEqual(data["errors"], [])
-        self.assertTrue(data["confirmation_required"])
         self.assertEqual(data["plan"]["playbook"], self.pb_owned.name)
+        self.assertTrue(data["pending_id"])
         mock_apply.assert_not_called()


### PR DESCRIPTION
# Description

Backend half of the **M-1 confirmation guardrail** from the W10 security review. Mentor-approved precautionary solution (Matteo): the chatbot agent can only *preview* an analysis; the actual launch happens only on an explicit user action. The React Confirm button is **PR 2**.

`Refs #3784`

What changes:
- `analyze_observable` is now **preview-only**: it validates and returns a `plan` + a one-time `pending_id`, and never launches (the `confirm` argument and the `save(send_task=True)` path are gone from the tool).
- New short-lived **pending-action store** (Redis cache, TTL 600s) holding the previewed inputs — user-scoped and one-shot.
- New endpoint **`POST /api/chatbot/analysis/confirm {pending_id}`** — the only launch path: consumes the pending (user-scoped, one-shot), re-applies the playbook visibility guard, re-validates, and launches as the requesting user.
- New WS event **`action_required {session_id, pending_id, plan}`** (emitted by the streaming callback) so the frontend can render the Confirm button (PR 2).
- System prompt updated: `analyze_observable` previews only; the model must not claim it launched anything.

Security: the agent no longer has any launch path — a misbehaving/jailbroken model cannot start an analysis (and therefore cannot egress an observable to external analyzers) without an explicit user click. Reviewed with the data-isolation reviewer: no leaks; pending strictly user-scoped + one-shot; the launched job is owned by the requester; the `visible_for_user` playbook guard is enforced at **both** preview and confirm.

Contract for PR 2 (frontend): WS `action_required {session_id, pending_id, plan}`; `POST /api/chatbot/analysis/confirm {pending_id}` → `200 {errors:[], reused, job}` | `410/400 {errors:[...], reused:false, job:null}`.

Interim state: until PR 2 ships, the chatbot can **preview** an analysis but not launch one from chat (strictly safer; launching via the normal IntelOwl UI is unaffected).

## Type of change
- [x] New feature (non-breaking change which adds functionality).
- [x] Bug fix (security hardening: removes the model-controlled launch path).

## Checklist
- [x] I have read and understood the rules about how to Contribute to this project.
- [ ] The pull request is for the branch `develop` — N/A: targets the GSoC umbrella `gsoc-2026/llm-chatbot`.
- [ ] A new plugin was added or changed — N/A.
- [x] Copyright banner present on the new file (`pending_action.py`).
- [x] Avoid adding new libraries — none (Redis cache backend is built into Django; redis-py is already a transitive dep).
- [ ] Restrictive-license libraries — N/A.
- [x] Linters (Ruff) gave 0 errors.
- [x] Tests added; full chatbot suite is 136 tests OK on the rebuilt image (preview-only tool, pending store one-shot/user-scoped, confirm endpoint launch/reject/TOCTOU-guard, action_required streaming).
- [ ] GUI modified — N/A (frontend is PR 2).
- [ ] Will resolve any DeepSource/Django Doctors/CI alerts raised after submission.
- [ ] I have addressed raised Copilot issues.
- [x] I have reviewed and verified the LLM-generated code in this PR. Disclosure: implemented from a reviewed plan with Claude Code; verified locally — ruff clean, 136 chatbot tests pass, and the data-isolation reviewer confirmed no leaks (agent has no launch path, pending user-scoped + one-shot, playbook guard at preview and confirm).
