### PR TITLE
[GSoC 2026] M-1 guardrail frontend: analyze Confirm/Cancel card (Refs #3791)

### DIFF
--- a/api_app/chatbot_manager/urls.py
+++ b/api_app/chatbot_manager/urls.py
@@ -6,6 +6,11 @@ from rest_framework.routers import DefaultRouter
 
 from .views import ChatAnalysisConfirmView, ChatHealthView, ChatSessionViewSet
 
+# These route suffixes are mirrored by the frontend in frontend/src/constants/apiURLs.js
+# (CHATBOT_SESSIONS_URI / CHATBOT_HEALTH_URI / CHATBOT_ANALYSIS_CONFIRM_URI). They can't be imported
+# across the JS/Python boundary, so a frontend coupling test
+# (frontend/tests/components/chat/chatbotRouteCoupling.test.js) reads this file and breaks if a route
+# is renamed here without updating the constant there. Keep both in sync.
 router = DefaultRouter(trailing_slash=False)
 router.register(r"sessions", ChatSessionViewSet, basename="chat-sessions")
 

--- a/frontend/src/components/chat/ChatActionConfirm.jsx
+++ b/frontend/src/components/chat/ChatActionConfirm.jsx
@@ -1,0 +1,79 @@
+import React from "react";
+import { Card, CardBody, Button } from "reactstrap";
+
+import { useChatStore } from "../../stores/useChatStore";
+
+/**
+ * Confirmation card for an analyze_observable preview. The agent can only propose an analysis
+ * (it returns a plan + pending_id); the actual launch happens here, on an explicit user click,
+ * via the backend confirm endpoint — so the model can never start an analysis on its own.
+ * Renders nothing unless the store holds a pending action.
+ */
+export function ChatActionConfirm() {
+  const pendingAction = useChatStore((state) => state.pendingAction);
+  const confirmPendingAction = useChatStore(
+    (state) => state.confirmPendingAction,
+  );
+  const cancelPendingAction = useChatStore(
+    (state) => state.cancelPendingAction,
+  );
+  const isStreaming = useChatStore((state) => state.isStreaming);
+  const [submitting, setSubmitting] = React.useState(false);
+
+  if (!pendingAction) return null;
+  const { plan } = pendingAction;
+  // The backend `action_required` plan always carries these lists (AnalysisPlanSerializer), but
+  // default to [] so a malformed/partial frame degrades to an empty row instead of crashing render.
+  const analyzers = plan.analyzers ?? [];
+  const connectors = plan.connectors ?? [];
+  const skipped = plan.skipped ?? [];
+
+  const onConfirm = async () => {
+    setSubmitting(true);
+    try {
+      await confirmPendingAction();
+    } finally {
+      setSubmitting(false);
+    }
+  };
+
+  return (
+    <Card className="m-2 border-warning" id="chat-action-confirm">
+      <CardBody className="p-2 small">
+        <div className="fw-bold mb-1">Start this analysis?</div>
+        <div>
+          Observable: {plan.observable_name} ({plan.classification})
+        </div>
+        <div>TLP: {plan.tlp}</div>
+        {plan.playbook && <div>Playbook: {plan.playbook}</div>}
+        <div>Analyzers: {analyzers.join(", ") || "default"}</div>
+        {connectors.length > 0 && (
+          <div>Connectors: {connectors.join(", ")}</div>
+        )}
+        {skipped.length > 0 && (
+          <div className="text-muted">Skipped: {skipped.join(", ")}</div>
+        )}
+        <div className="d-flex gap-2 mt-2">
+          {/* Confirm is also gated on isStreaming (can't launch mid-turn); Cancel deliberately is
+              NOT — dismissing a stale card must always work, even while a reply streams. */}
+          <Button
+            color="primary"
+            size="sm"
+            disabled={submitting || isStreaming}
+            onClick={onConfirm}
+          >
+            Confirm
+          </Button>
+          <Button
+            color="outline-secondary"
+            size="sm"
+            disabled={submitting}
+            onClick={cancelPendingAction}
+          >
+            Cancel
+          </Button>
+        </div>
+      </CardBody>
+    </Card>
+  );
+}

--- a/frontend/src/components/chat/ChatPanel.jsx
+++ b/frontend/src/components/chat/ChatPanel.jsx
@@ -17,6 +17,7 @@ import { ChatMessageList } from "./ChatMessageList";
 import { ChatComposer } from "./ChatComposer";
 import { ChatSessionList } from "./ChatSessionList";
 import { QuickActions } from "./QuickActions";
+import { ChatActionConfirm } from "./ChatActionConfirm";
 
 // Connection-state badge shown in the drawer header.
 const CONNECTION_BADGE = {
@@ -136,6 +137,7 @@ export function ChatPanel() {
         ) : (
           <>
             <ChatMessageList />
+            <ChatActionConfirm />
             <QuickActions onSend={sendMessage} disabled={inputDisabled} />
             <ChatComposer onSend={sendMessage} />
           </>

--- a/frontend/src/components/chat/chatApi.js
+++ b/frontend/src/components/chat/chatApi.js
@@ -1,0 +1,15 @@
+import axios from "axios";
+
+import { CHATBOT_ANALYSIS_CONFIRM_URI } from "../../constants/apiURLs";
+
+/**
+ * Launch a previously previewed analysis. The chatbot agent can only *preview* (it mints a
+ * pending_id); this confirms it as an explicit user action — the model can never launch itself.
+ * Resolves to { errors, reused, job }; throws on a non-2xx response (caller surfaces the error).
+ */
+export async function confirmAnalysis(pendingId) {
+  const response = await axios.post(CHATBOT_ANALYSIS_CONFIRM_URI, {
+    pending_id: pendingId,
+  });
+  return response.data;
+}

--- a/frontend/src/components/chat/useChatWebSocket.js
+++ b/frontend/src/components/chat/useChatWebSocket.js
@@ -11,6 +11,7 @@ const ChatEventType = Object.freeze({
   TOKEN: "token",
   END: "end",
   ERROR: "error",
+  ACTION_REQUIRED: "action_required",
 });
 
 // Normal WebSocket close code: a clean close must NOT trigger a reconnect.
@@ -135,6 +136,13 @@ export function useChatWebSocket() {
           if (event.session_id !== activeSession) return;
           clearTurnTimers();
           store.applyEnd(event);
+          break;
+        case ChatEventType.ACTION_REQUIRED:
+          // A tool previewed an analysis the user must confirm. Demuxed like the streaming frames so
+          // another tab's preview never raises this tab's card; it does NOT end the turn (prose still
+          // streams), so the turn watchdogs are left untouched.
+          if (event.session_id !== activeSession) return;
+          store.applyActionRequired(event);
           break;
         case ChatEventType.ERROR:
           // Looser guard than the streaming frames: the consumer's *direct* errors arrive only on

--- a/frontend/src/constants/apiURLs.js
+++ b/frontend/src/constants/apiURLs.js
@@ -51,10 +51,15 @@ export const NOTIFICATION_BASE_URI = `${API_BASE_URI}/notification`;
 export const AUTH_BASE_URI = `${API_BASE_URI}/auth`;
 export const APIACCESS_BASE_URI = `${AUTH_BASE_URI}/apiaccess`;
 
-// chatbot (router uses trailing_slash=False, so these paths carry no trailing slash)
+// chatbot (router uses trailing_slash=False, so these paths carry no trailing slash).
+// These path suffixes mirror the canonical Django routes in
+// api_app/chatbot_manager/urls.py; they can't be imported across the JS/Python boundary, so a
+// coupling test (tests/components/chat/chatbotRouteCoupling.test.js) reads that file and fails
+// loudly if a route is renamed on either side. Keep both in sync.
 export const CHATBOT_BASE_URI = `${API_BASE_URI}/chatbot`;
 export const CHATBOT_SESSIONS_URI = `${CHATBOT_BASE_URI}/sessions`;
 export const CHATBOT_HEALTH_URI = `${CHATBOT_BASE_URI}/health`;
+export const CHATBOT_ANALYSIS_CONFIRM_URI = `${CHATBOT_BASE_URI}/analysis/confirm`;
 
 // WEBSOCKETS
 const WEBSOCKET_BASE_URI = "ws";

--- a/frontend/src/stores/useChatStore.jsx
+++ b/frontend/src/stores/useChatStore.jsx
@@ -3,6 +3,7 @@ import axios from "axios";
 import { format } from "date-fns-tz";
 
 import { CHATBOT_HEALTH_URI, CHATBOT_SESSIONS_URI } from "../constants/apiURLs";
+import { confirmAnalysis } from "../components/chat/chatApi";
 
 /**
  * Connection states for the chat WebSocket, surfaced in the UI as a status badge.
@@ -31,6 +32,8 @@ const HISTORY_LOAD_ERROR =
   "Could not load this conversation. Please try again.";
 const SESSION_DELETE_ERROR =
   "Could not delete this conversation. Please try again.";
+const CONFIRM_ERROR =
+  "Could not start the analysis. The confirmation may have expired — ask again.";
 
 // Fetch every page of a session's messages. The backend orders by timestamp asc and returns pages
 // in order, so concatenation preserves chronological (oldest-first) order. Mirrors the paginated
@@ -87,6 +90,10 @@ export const useChatStore = create((set, get) => ({
   // is still up, so this — not connectionState — is what tells the badge the assistant itself can't
   // serve a turn right now. Cleared on the next `start` (the worker proving it is alive again).
   assistantUnavailable: false,
+  // A single previewed analysis awaiting the user's explicit Confirm/Cancel (HITL guardrail M-1).
+  // Deliberately NOT part of initialTurnState: the `action_required` frame arrives before `end`, so
+  // it must survive applyEnd and persist until the user acts or a new turn supersedes it.
+  pendingAction: null,
 
   // --- session list (serializable; the WS hook is untouched — these only change
   // sessionId/messages, which the hook reads live for demux and send) ---
@@ -114,6 +121,8 @@ export const useChatStore = create((set, get) => ({
       ...initialTurnState,
       isStreaming: true,
       error: null,
+      // a new user turn supersedes any stale confirmation card
+      pendingAction: null,
     })),
 
   // --- inbound frame reducers (called by the hook; demux/filtering happens upstream there) ---
@@ -148,6 +157,43 @@ export const useChatStore = create((set, get) => ({
   // produced nothing, so the assistant is unavailable — flag the badge in addition to the banner.
   applyUnavailable: (detail) =>
     set({ ...initialTurnState, error: detail, assistantUnavailable: true }),
+
+  // --- pending action (analyze confirm; HITL guardrail M-1) ---
+  // Set when a tool (analyze_observable) previews an action the user must confirm out-of-band.
+  // Persists past `end` (the action_required frame arrives before it) until the user acts or a
+  // new turn supersedes it.
+  applyActionRequired: (event) =>
+    set({ pendingAction: { pendingId: event.pending_id, plan: event.plan } }),
+
+  // Launch the previewed analysis as an explicit user action (the only path that starts it).
+  confirmPendingAction: async () => {
+    const pending = get().pendingAction;
+    if (!pending) return;
+    try {
+      const { errors, reused, job } = await confirmAnalysis(pending.pendingId);
+      // The envelope always carries `errors`; a 2xx with no job (or surfaced errors) shouldn't throw
+      // on job.id — clear the card and show the message instead.
+      if (!job) {
+        set({ pendingAction: null, error: errors?.[0] || CONFIRM_ERROR });
+        return;
+      }
+      const verb = reused ? "Reused recent analysis" : "Started analysis";
+      set((state) => ({
+        pendingAction: null,
+        messages: [
+          ...state.messages,
+          {
+            role: MessageRole.ASSISTANT,
+            content: `${verb} — job #${job.id} (${job.status}).`,
+          },
+        ],
+      }));
+    } catch (error) {
+      set({ pendingAction: null, error: CONFIRM_ERROR });
+    }
+  },
+
+  cancelPendingAction: () => set({ pendingAction: null }),
 
   // --- session management (REST) ---
   // Load the user's sessions (every page) for the list view; the queryset is user-scoped server-side.
@@ -185,6 +231,7 @@ export const useChatStore = create((set, get) => ({
       messages: [],
       ...initialTurnState,
       error: null,
+      pendingAction: null,
       historyLoading: true,
       navEpoch: state.navEpoch + 1,
     });
@@ -207,6 +254,7 @@ export const useChatStore = create((set, get) => ({
       messages: [],
       ...initialTurnState,
       error: null,
+      pendingAction: null,
       navEpoch: state.navEpoch + 1,
     })),
 
@@ -234,6 +282,7 @@ export const useChatStore = create((set, get) => ({
               messages: [],
               ...initialTurnState,
               error: null,
+              pendingAction: null,
               navEpoch: current.navEpoch + 1,
             }
           : {}),

--- a/frontend/tests/components/chat/ChatActionConfirm.test.jsx
+++ b/frontend/tests/components/chat/ChatActionConfirm.test.jsx
@@ -1,0 +1,70 @@
+import React from "react";
+import { render, screen } from "@testing-library/react";
+import userEvent from "@testing-library/user-event";
+import "@testing-library/jest-dom";
+
+import { ChatActionConfirm } from "../../../src/components/chat/ChatActionConfirm";
+import { useChatStore } from "../../../src/stores/useChatStore";
+
+const PLAN = {
+  observable_name: "example.com",
+  classification: "domain",
+  tlp: "CLEAR",
+  playbook: null,
+  analyzers: ["Tranco"],
+  connectors: [],
+  skipped: [],
+};
+
+describe("ChatActionConfirm", () => {
+  afterEach(() => useChatStore.setState({ pendingAction: null }));
+
+  it("renders nothing when there is no pending action", () => {
+    useChatStore.setState({ pendingAction: null });
+    const { container } = render(<ChatActionConfirm />);
+    expect(container).toBeEmptyDOMElement();
+  });
+
+  it("shows the plan and triggers confirm on click", async () => {
+    const confirmPendingAction = jest.fn();
+    useChatStore.setState({
+      pendingAction: { pendingId: "abc", plan: PLAN },
+      confirmPendingAction,
+      isStreaming: false,
+    });
+    render(<ChatActionConfirm />);
+    expect(screen.getByText(/example\.com/)).toBeInTheDocument();
+    expect(screen.getByText(/Tranco/)).toBeInTheDocument();
+    await userEvent.click(screen.getByRole("button", { name: /confirm/i }));
+    expect(confirmPendingAction).toHaveBeenCalled();
+  });
+
+  it("renders without crashing when the plan omits the optional arrays", () => {
+    useChatStore.setState({
+      pendingAction: {
+        pendingId: "abc",
+        plan: {
+          observable_name: "1.1.1.1",
+          classification: "ip",
+          tlp: "CLEAR",
+        },
+      },
+    });
+    render(<ChatActionConfirm />);
+    // arrays absent -> analyzers falls back to "default", no Connectors/Skipped rows
+    expect(screen.getByText(/Analyzers: default/)).toBeInTheDocument();
+    expect(screen.queryByText(/Connectors:/)).not.toBeInTheDocument();
+    expect(screen.queryByText(/Skipped:/)).not.toBeInTheDocument();
+  });
+
+  it("cancels on click", async () => {
+    const cancelPendingAction = jest.fn();
+    useChatStore.setState({
+      pendingAction: { pendingId: "abc", plan: PLAN },
+      cancelPendingAction,
+    });
+    render(<ChatActionConfirm />);
+    await userEvent.click(screen.getByRole("button", { name: /cancel/i }));
+    expect(cancelPendingAction).toHaveBeenCalled();
+  });
+});

--- a/frontend/tests/components/chat/chatApi.test.js
+++ b/frontend/tests/components/chat/chatApi.test.js
@@ -1,0 +1,19 @@
+import axios from "axios";
+
+import { confirmAnalysis } from "../../../src/components/chat/chatApi";
+import { CHATBOT_ANALYSIS_CONFIRM_URI } from "../../../src/constants/apiURLs";
+
+jest.mock("axios");
+
+describe("chatApi.confirmAnalysis", () => {
+  test("POSTs the pending_id and returns the data", async () => {
+    axios.post.mockResolvedValue({
+      data: { errors: [], reused: false, job: { id: 7 } },
+    });
+    const data = await confirmAnalysis("abc");
+    expect(axios.post).toHaveBeenCalledWith(CHATBOT_ANALYSIS_CONFIRM_URI, {
+      pending_id: "abc",
+    });
+    expect(data.job.id).toBe(7);
+  });
+});

--- a/frontend/tests/components/chat/chatbotRouteCoupling.test.js
+++ b/frontend/tests/components/chat/chatbotRouteCoupling.test.js
@@ -1,0 +1,40 @@
+import { readFileSync } from "fs";
+import { resolve } from "path";
+
+import {
+  CHATBOT_SESSIONS_URI,
+  CHATBOT_HEALTH_URI,
+  CHATBOT_ANALYSIS_CONFIRM_URI,
+} from "../../../src/constants/apiURLs";
+
+// Coupling guard (mentor convention #19). The chatbot frontend URIs mirror Django routes that live
+// in another language/layer, so they cannot be imported. This test reads the canonical route
+// definitions and fails loudly if a route is renamed on either side without updating the other —
+// turning a silent 404 into a red test. Cross-referenced from comments in both files.
+const BACKEND_URLS = resolve(
+  __dirname,
+  "../../../../api_app/chatbot_manager/urls.py",
+);
+
+describe("chatbot frontend URIs stay coupled to the backend routes", () => {
+  const source = readFileSync(BACKEND_URLS, "utf8");
+
+  // [human label, frontend constant, backend route literal as it appears in urls.py]
+  test.each([
+    ["sessions", CHATBOT_SESSIONS_URI, 'r"sessions"'],
+    ["health", CHATBOT_HEALTH_URI, 'path("health"'],
+    [
+      "analysis/confirm",
+      CHATBOT_ANALYSIS_CONFIRM_URI,
+      'path("analysis/confirm"',
+    ],
+  ])(
+    "…/%s is defined in urls.py and matches the frontend constant",
+    (suffix, uri, backendLiteral) => {
+      // backend side: the route must still exist with this exact path
+      expect(source).toContain(backendLiteral);
+      // frontend side: the constant must resolve to /chatbot/<suffix>
+      expect(uri.endsWith(`/chatbot/${suffix}`)).toBe(true);
+    },
+  );
+});

--- a/frontend/tests/components/chat/useChatWebSocket.test.jsx
+++ b/frontend/tests/components/chat/useChatWebSocket.test.jsx
@@ -69,6 +69,7 @@ const initialState = {
   error: null,
   navEpoch: 0,
   assistantUnavailable: false,
+  pendingAction: null,
 };
 
 describe("useChatWebSocket", () => {
@@ -177,6 +178,33 @@ describe("useChatWebSocket", () => {
       });
     });
     expect(useChatStore.getState().streamingText).toBe("");
+  });
+
+  test("dispatches action_required to the store, demuxed by session", () => {
+    connectAndOpen();
+    act(() => {
+      useChatStore.setState({ sessionId: 5 });
+    });
+    // a frame for another tab's session must not raise this tab's confirmation card
+    act(() => {
+      lastSocket().mockMessage({
+        type: "action_required",
+        session_id: 999,
+        pending_id: "other",
+        plan: { observable_name: "y" },
+      });
+    });
+    expect(useChatStore.getState().pendingAction).toBeNull();
+    // the active session's frame is stored as the pending action
+    act(() => {
+      lastSocket().mockMessage({
+        type: "action_required",
+        session_id: 5,
+        pending_id: "abc",
+        plan: { observable_name: "x" },
+      });
+    });
+    expect(useChatStore.getState().pendingAction.pendingId).toBe("abc");
   });
 
   test("surfaces a null-session error but ignores another session's error", () => {

--- a/frontend/tests/stores/useChatStore.test.jsx
+++ b/frontend/tests/stores/useChatStore.test.jsx
@@ -7,8 +7,10 @@ import {
   deriveSessionLabel,
 } from "../../src/stores/useChatStore";
 import { CHATBOT_SESSIONS_URI } from "../../src/constants/apiURLs";
+import { confirmAnalysis } from "../../src/components/chat/chatApi";
 
 jest.mock("axios");
+jest.mock("../../src/components/chat/chatApi");
 
 const initialState = {
   isOpen: false,
@@ -25,6 +27,7 @@ const initialState = {
   historyLoading: false,
   navEpoch: 0,
   assistantUnavailable: false,
+  pendingAction: null,
 };
 
 describe("useChatStore reducers", () => {
@@ -362,5 +365,70 @@ describe("useChatStore checkHealth", () => {
     const state = useChatStore.getState();
     expect(state.assistantUnavailable).toBe(false);
     expect(state.error).toBeNull();
+  });
+});
+
+describe("pending action (analyze confirm)", () => {
+  beforeEach(() => {
+    useChatStore.setState({ pendingAction: null, messages: [], error: null });
+    confirmAnalysis.mockReset();
+  });
+
+  test("applyActionRequired stores the pending plan", () => {
+    useChatStore.getState().applyActionRequired({
+      pending_id: "abc",
+      plan: { observable_name: "x" },
+    });
+    expect(useChatStore.getState().pendingAction).toEqual({
+      pendingId: "abc",
+      plan: { observable_name: "x" },
+    });
+  });
+
+  test("confirmPendingAction posts, clears, and appends a result message", async () => {
+    useChatStore.setState({ pendingAction: { pendingId: "abc", plan: {} } });
+    confirmAnalysis.mockResolvedValue({
+      errors: [],
+      reused: false,
+      job: { id: 7, status: "running" },
+    });
+    await useChatStore.getState().confirmPendingAction();
+    expect(confirmAnalysis).toHaveBeenCalledWith("abc");
+    expect(useChatStore.getState().pendingAction).toBeNull();
+    const last = useChatStore.getState().messages.at(-1);
+    expect(last.content).toContain("#7");
+  });
+
+  test("confirmPendingAction clears the card and surfaces errors when no job is returned", async () => {
+    useChatStore.setState({ pendingAction: { pendingId: "abc", plan: {} } });
+    confirmAnalysis.mockResolvedValue({
+      errors: ["could not launch"],
+      reused: false,
+      job: null,
+    });
+    await useChatStore.getState().confirmPendingAction();
+    expect(useChatStore.getState().pendingAction).toBeNull();
+    expect(useChatStore.getState().error).toBe("could not launch");
+    expect(useChatStore.getState().messages).toEqual([]);
+  });
+
+  test("confirmPendingAction surfaces an error and clears the card on failure", async () => {
+    useChatStore.setState({ pendingAction: { pendingId: "abc", plan: {} } });
+    confirmAnalysis.mockRejectedValue(new Error("gone"));
+    await useChatStore.getState().confirmPendingAction();
+    expect(useChatStore.getState().pendingAction).toBeNull();
+    expect(useChatStore.getState().error).toBeTruthy();
+  });
+
+  test("cancelPendingAction clears it", () => {
+    useChatStore.setState({ pendingAction: { pendingId: "abc", plan: {} } });
+    useChatStore.getState().cancelPendingAction();
+    expect(useChatStore.getState().pendingAction).toBeNull();
+  });
+
+  test("sending a new message supersedes a pending action", () => {
+    useChatStore.setState({ pendingAction: { pendingId: "abc", plan: {} } });
+    useChatStore.getState().enqueueUserMessage("hi");
+    expect(useChatStore.getState().pendingAction).toBeNull();
   });
 });


### PR DESCRIPTION
Refs #3791

  # Description
  Frontend half of the M-1 guardrail (backend PR #3787, merged into the umbrella). On an `action_required` WS frame the chat panel renders a **Confirm / Cancel card** summarising the previewed analysis (observable, classification, 
  TLP, playbook, analyzers, connectors, skipped). **Confirm** is the only launch path — it POSTs the opaque `pending_id` to `/api/chatbot/analysis/confirm` (a real user action); the model can never launch on its own. Confirm is 
  disabled while streaming; a 2xx-without-job / expired pending surfaces a retry message. Pending state survives `end` and is superseded by a new turn / session switch. A coupling test pins the three chatbot frontend URIs to their 
  Django routes.
  
  ## Type of change
  - [x] New feature (non-breaking change which adds functionality).

  # Checklist
  - [x] If the GUI has been modified: screenshot provided + frontend tests added/updated.
  - [x] I have added tests for the feature. All tests pass (`TZ=UTC jest tests/components/chat tests/stores` → 100 passed; eslint 0 errors; pre-commit prettier/ruff green).
  - [x] Copyright banner present where applicable.
  - [x] I have reviewed and verified the LLM-assisted code in this PR, and I explicitly disclose that I used an LLM (Claude Code) while developing it.

<img width="1280" height="720" alt="m1-confirm-card" src="https://github.com/user-attachments/assets/863798c7-f4c3-4686-8d99-75a462650fba" />

**DEMO:**

https://github.com/user-attachments/assets/c992b676-0d21-459f-b53c-601d6ac44d55

