### PR TITLE
[GSoC 2026] test(chatbot): E2E chat pipeline + guardrail + ChatPanel full-turn

### DIFF
--- a/frontend/tests/components/chat/ChatPanel.e2e.test.jsx
+++ b/frontend/tests/components/chat/ChatPanel.e2e.test.jsx
@@ -1,0 +1,158 @@
+import React from "react";
+import axios from "axios";
+import "@testing-library/jest-dom";
+import {
+  render,
+  screen,
+  act,
+  fireEvent,
+  waitFor,
+  within,
+} from "@testing-library/react";
+
+import { ChatPanel } from "../../../src/components/chat/ChatPanel";
+import {
+  useChatStore,
+  ConnectionState,
+} from "../../../src/stores/useChatStore";
+
+jest.mock("axios");
+
+// Controllable WebSocket: opens on the next tick (CONNECTING -> CONNECTED) and exposes the live
+// instance so the test can push server frames (emit) and assert what the client sent.
+let liveSocket = null;
+class ControllableWebSocket {
+  constructor() {
+    this.readyState = ControllableWebSocket.OPEN;
+    this.sent = [];
+    liveSocket = this;
+    setTimeout(() => {
+      if (this.onopen) this.onopen({});
+    }, 0);
+  }
+
+  send(data) {
+    this.sent.push(JSON.parse(data));
+  }
+
+  // eslint-disable-next-line class-methods-use-this
+  close() {}
+
+  emit(frame) {
+    if (this.onmessage) this.onmessage({ data: JSON.stringify(frame) });
+  }
+}
+ControllableWebSocket.OPEN = 1;
+
+// Reset the store data fields between tests WITHOUT replacing the action reducers (merge, no `true`).
+const baseState = {
+  isOpen: true,
+  sessionId: null,
+  messages: [],
+  streamingText: "",
+  currentTool: null,
+  isStreaming: false,
+  connectionState: ConnectionState.IDLE,
+  error: null,
+  sessions: [],
+  sessionsLoading: false,
+  sessionsError: null,
+  historyLoading: false,
+  navEpoch: 0,
+  assistantUnavailable: false,
+  pendingAction: null,
+};
+
+const SESSION_ID = 11;
+const PENDING_ID = "pending-abc";
+const PLAN = {
+  observable_name: "example.com",
+  classification: "domain",
+  tlp: "CLEAR",
+  playbook: null,
+  analyzers: ["Tranco"],
+  connectors: [],
+  skipped: [],
+};
+
+describe("ChatPanel E2E (full turn -> confirm)", () => {
+  beforeAll(() => {
+    window.HTMLElement.prototype.scrollIntoView = jest.fn();
+  });
+
+  beforeEach(() => {
+    liveSocket = null;
+    global.WebSocket = ControllableWebSocket;
+    useChatStore.setState(baseState);
+    axios.get.mockImplementation((url) =>
+      url.includes("/health")
+        ? Promise.resolve({ data: { available: true, detail: "" } })
+        : Promise.resolve({ data: { total_pages: 1, results: [] } }),
+    );
+    // confirmAnalysis() POSTs to the confirm endpoint
+    axios.post.mockResolvedValue({
+      data: { errors: [], reused: false, job: { id: 99, status: "pending" } },
+    });
+  });
+
+  test("streams a tool-call turn to the confirm card and launches the analysis", async () => {
+    render(<ChatPanel />);
+    expect(await screen.findByText("Connected")).toBeInTheDocument();
+
+    // user sends a message through the composer (Enter sends)
+    const input = screen.getByPlaceholderText(/Ask about/i);
+    fireEvent.change(input, { target: { value: "analyze example.com" } });
+    fireEvent.keyDown(input, { key: "Enter", code: "Enter" });
+
+    // the client framed and sent the message (session_id null -> server will create one)
+    await waitFor(() => expect(liveSocket.sent.length).toBeGreaterThan(0));
+    expect(liveSocket.sent[0]).toEqual({
+      message: "analyze example.com",
+      session_id: null,
+    });
+
+    // server turn: ack binds the session, then the streamed frames (all tagged with the session id
+    // so the hook's real demux accepts them)
+    act(() => {
+      liveSocket.emit({ type: "ack", session_id: SESSION_ID });
+      liveSocket.emit({ type: "start", session_id: SESSION_ID });
+      liveSocket.emit({
+        type: "status",
+        session_id: SESSION_ID,
+        tool: "analyze_observable",
+      });
+      liveSocket.emit({
+        type: "action_required",
+        session_id: SESSION_ID,
+        pending_id: PENDING_ID,
+        plan: PLAN,
+      });
+      liveSocket.emit({
+        type: "token",
+        session_id: SESSION_ID,
+        content: "Prepared the plan.",
+      });
+      liveSocket.emit({
+        type: "end",
+        session_id: SESSION_ID,
+        message_id: 1,
+        content: "Prepared an analysis plan. Click Confirm.",
+      });
+    });
+
+    // the M-1 confirm card is shown (persists past `end`); scope the observable lookup to the card
+    // because "example.com" also appears in the echoed user message.
+    expect(await screen.findByText("Start this analysis?")).toBeInTheDocument();
+    const card = document.getElementById("chat-action-confirm");
+    expect(within(card).getByText(/example\.com/)).toBeInTheDocument();
+
+    // user confirms -> confirmAnalysis POST -> success message appended, card gone
+    fireEvent.click(screen.getByRole("button", { name: "Confirm" }));
+
+    expect(
+      await screen.findByText(/Started analysis .* job #99 \(pending\)\./),
+    ).toBeInTheDocument();
+    expect(screen.queryByText("Start this analysis?")).not.toBeInTheDocument();
+    expect(axios.post).toHaveBeenCalledTimes(1);
+  });
+});

--- a/tests/api_app/chatbot_manager/test_e2e.py
+++ b/tests/api_app/chatbot_manager/test_e2e.py
@@ -1,0 +1,244 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""End-to-end tests of the chatbot chat pipeline.
+
+These wire the *real* components together — ChatConsumer, the process_chat_message Celery task,
+ChatStreamingCallbackHandler, the analyze_observable tool, the pending-action store and the
+confirm endpoint — and mock only the external boundaries: the LLM (via build_agent_executor) and
+the job pipeline (apply_async). Ollama and the network are never touched.
+
+Transport: the consumer leg does NOT use WebsocketCommunicator. A synchronous JsonWebsocketConsumer
+keeps a channel-layer receive listener bound to its event loop, and a real InMemoryChannelLayer
+round-trip reads an asyncio.Queue bound to the producer's (separate) async_to_sync loop — both are
+the loop-binding hang documented in test_consumers.py. Instead _CapturingChannelLayer records the
+plain-dict group_send payloads (loop-safe), which are then fed to the consumer's real chat.<type>
+relay handlers, exercising every real component bar the framework's queue plumbing.
+"""
+
+from types import SimpleNamespace
+from unittest.mock import MagicMock, patch
+
+from django.core.cache import caches
+from django.test import TestCase, override_settings
+from rest_framework import status
+from rest_framework.test import APIClient
+
+from api_app.chatbot_manager import events
+from api_app.chatbot_manager.agent.tools import build_tools
+from api_app.chatbot_manager.consumers import ChatConsumer
+from api_app.chatbot_manager.models import ChatMessage, ChatSession
+from api_app.chatbot_manager.tasks import process_chat_message
+from api_app.models import Job
+from certego_saas.apps.user.models import User
+
+_ASSISTANT_OUTPUT = "Prepared an analysis plan for example.com. Click Confirm to run it."
+_APPLY_ASYNC = "intel_owl.tasks.job_pipeline.apply_async"
+_CONFIRM_URL = "/api/chatbot/analysis/confirm"
+
+_LOCMEM = "django.core.cache.backends.locmem.LocMemCache"
+# Distinct LOCATIONs so the rate-limit and pending-action stores don't share one dict; locmem is
+# process-global, so each test clears these in setUp to stop entries bleeding across tests.
+LOCMEM_CACHES = {
+    "default": {"BACKEND": _LOCMEM, "LOCATION": "e2e-default"},
+    "chatbot_rate_limit": {"BACKEND": _LOCMEM, "LOCATION": "e2e-rl"},
+    "chatbot_pending_action": {"BACKEND": _LOCMEM, "LOCATION": "e2e-pa"},
+}
+
+
+class _CapturingChannelLayer:
+    """Records group_send payloads instead of queueing them (see module docstring for why)."""
+
+    def __init__(self):
+        self.sent = []  # ordered list of (group, channel_message)
+
+    async def group_send(self, group, message):
+        self.sent.append((group, message))
+
+    async def group_add(self, group, channel):
+        pass
+
+    async def group_discard(self, group, channel):
+        pass
+
+
+def _fake_tool_calling_executor(user):
+    """A stand-in AgentExecutor whose .invoke() drives the REAL streaming callbacks exactly as a
+    tool-calling turn would: a tool action (chat.status), the real analyze_observable tool output
+    (chat.action_required, carrying a real one-time pending_id), a streamed answer token
+    (chat.token), then the final output. Keeps the handler, the tool and the pending-action store
+    real while Ollama is never reached."""
+    real_tools = build_tools(user=user)
+    analyze_tool = next(tool for tool in real_tools if tool.name == "analyze_observable")
+
+    class _FakeExecutor:
+        # The task derives handler.tool_names from this real registry, so the chat.status filter
+        # (which suppresses the _Exception pseudo-tool) is exercised against real tool names.
+        tools = real_tools
+
+        @staticmethod
+        def invoke(payload, config=None):
+            handler = config["callbacks"][0]
+            # SimpleNamespace mirrors a langchain AgentAction's .tool attribute.
+            handler.on_agent_action(SimpleNamespace(tool="analyze_observable", tool_input={}, log=""))
+            # Real tool run: validates the observable and mints a real pending_id in the cache.
+            tool_output = analyze_tool.invoke({"observable_name": "example.com", "analyzers": "Tranco"})
+            handler.on_tool_end(tool_output)
+            handler.on_llm_new_token("Prepared the analysis plan. ")
+            return {"output": _ASSISTANT_OUTPUT}
+
+    return _FakeExecutor()
+
+
+def _connected_consumer(user, channel_layer):
+    """A ChatConsumer wired for direct calls with the capturing layer; real connect() sets up the
+    per-user group name. accept/send_json are mocked so the relayed client frames can be captured."""
+    consumer = ChatConsumer()
+    consumer.scope = {"user": user, "query_string": b"", "url_route": {"kwargs": {}}}
+    consumer.channel_name = "test.chat"
+    consumer.channel_layer = channel_layer
+    consumer.accept = MagicMock()
+    consumer.send_json = MagicMock()
+    consumer.connect()  # sets group_name = chat-<user_id>; group_add is a no-op on the capturing layer
+    return consumer
+
+
+@override_settings(
+    CACHES=LOCMEM_CACHES,
+    CHATBOT_PENDING_ACTION_TTL=600,
+    CHATBOT_RATE_LIMIT=1000,
+    CHATBOT_RATE_LIMIT_WINDOW=60,
+)
+class ChatPipelineE2ETestCase(TestCase):
+    """The full WebSocket turn: consumer -> task -> agent -> streaming callback -> relayed frames."""
+
+    def setUp(self):
+        for alias in ("default", "chatbot_rate_limit", "chatbot_pending_action"):
+            caches[alias].clear()
+        self.user, _ = User.objects.get_or_create(username="e2e_chat_user")
+
+    def tearDown(self):
+        Job.objects.filter(user=self.user).delete()
+
+    def _run_turn(self, *, message="analyze example.com", session_id=None):
+        """Run one turn end-to-end and return (consumer, layer, ack_frames, relay_frames).
+
+        ack_frames are what receive_json sent back synchronously (the ack). relay_frames are the
+        client payloads produced by replaying each captured group_send through the consumer's real
+        chat.<type> handler — i.e. exactly what the browser would receive.
+        """
+        layer = _CapturingChannelLayer()
+        consumer = _connected_consumer(self.user, layer)
+        with (
+            patch(
+                "api_app.chatbot_manager.agent.agent.build_agent_executor",
+                return_value=_fake_tool_calling_executor(self.user),
+            ),
+            patch("api_app.chatbot_manager.tasks.get_channel_layer", return_value=layer),
+            patch("api_app.chatbot_manager.agent.streaming.get_channel_layer", return_value=layer),
+            patch("api_app.chatbot_manager.consumers.process_chat_message") as consumer_task,
+        ):
+            # The consumer enqueues via .delay; forward to the real task body so the hand-off
+            # contract (exact args) is exercised and the turn runs synchronously in-test.
+            consumer_task.delay.side_effect = lambda *args: process_chat_message(*args)
+            content = {"message": message}
+            if session_id is not None:
+                content["session_id"] = session_id
+            consumer.receive_json(content)
+
+        ack_frames = [call.args[0] for call in consumer.send_json.call_args_list]
+        consumer.send_json.reset_mock()
+        # Replay each captured group message through the framework's type->method mapping.
+        for _group, channel_message in layer.sent:
+            getattr(consumer, channel_message["type"].replace(".", "_"))(channel_message)
+        relay_frames = [call.args[0] for call in consumer.send_json.call_args_list]
+        return consumer, layer, ack_frames, relay_frames
+
+    def test_full_turn_streams_tool_call_and_guardrail(self):
+        consumer, layer, ack_frames, relay_frames = self._run_turn()
+        session = ChatSession.objects.get(user=self.user)
+
+        # ack first, carrying the resolved (newly created) session id
+        self.assertEqual(ack_frames, [events.AckEvent(session.id).to_client()])
+
+        # every producer send targeted this user's group (the consumer's own subscription)
+        self.assertTrue(layer.sent)
+        self.assertTrue(all(group == consumer.group_name for group, _ in layer.sent))
+
+        # ordered client frames for a tool-calling turn with an M-1 preview
+        self.assertEqual(
+            [frame["type"] for frame in relay_frames],
+            [
+                events.ChatEventType.START.value,
+                events.ChatEventType.STATUS.value,
+                events.ChatEventType.ACTION_REQUIRED.value,
+                events.ChatEventType.TOKEN.value,
+                events.ChatEventType.END.value,
+            ],
+        )
+
+        # every frame is stamped with the session id (the client's demux key)
+        self.assertTrue(all(frame["session_id"] == session.id for frame in relay_frames))
+
+        # status names the real tool; action_required carries a pending id + a plan
+        self.assertEqual(relay_frames[1]["tool"], "analyze_observable")
+        action = relay_frames[2]
+        self.assertTrue(action["pending_id"])
+        self.assertEqual(action["plan"]["observable_name"], "example.com")
+        self.assertEqual(action["plan"]["classification"], "domain")
+
+        # end carries the persisted assistant message + its id
+        assistant = ChatMessage.objects.get(session=session, role=ChatMessage.Role.ASSISTANT)
+        self.assertEqual(relay_frames[-1]["message_id"], assistant.id)
+        self.assertEqual(relay_frames[-1]["content"], _ASSISTANT_OUTPUT)
+
+        # the exchange is persisted user-then-assistant
+        self.assertEqual(
+            list(
+                ChatMessage.objects.filter(session=session)
+                .order_by("timestamp")
+                .values_list("role", "content")
+            ),
+            [(ChatMessage.Role.USER, "analyze example.com"), (ChatMessage.Role.ASSISTANT, _ASSISTANT_OUTPUT)],
+        )
+
+    def test_action_required_pending_id_confirms_and_launches_once(self):
+        # The pending_id surfaced to the browser in action_required is the only thing needed to
+        # launch: a real user POST of it to the confirm endpoint starts the job (M-1 — the model
+        # itself never launches).
+        _consumer, _layer, _ack, relay_frames = self._run_turn()
+        action = next(
+            frame for frame in relay_frames if frame["type"] == events.ChatEventType.ACTION_REQUIRED.value
+        )
+        pending_id = action["pending_id"]
+
+        client = APIClient()
+        client.force_authenticate(self.user)
+        with patch(_APPLY_ASYNC) as mock_apply:
+            first = client.post(_CONFIRM_URL, {"pending_id": pending_id}, format="json")
+            self.assertEqual(first.status_code, status.HTTP_200_OK)
+            self.assertEqual(first.json()["errors"], [])
+            job_id = first.json()["job"]["id"]
+            # multi-tenancy: the launched job is owned by the confirming user
+            self.assertEqual(Job.objects.get(pk=job_id).user, self.user)
+
+            # one-shot: the consumed pending id cannot launch a second job
+            second = client.post(_CONFIRM_URL, {"pending_id": pending_id}, format="json")
+            self.assertEqual(second.status_code, status.HTTP_410_GONE)
+            mock_apply.assert_called_once()
+
+    def test_frames_are_tagged_per_session_for_multi_tab_demux(self):
+        # Frames fan out to every tab of a user (one per-user group); a tab demultiplexes by the
+        # session_id each frame carries. Two sessions of the same user must produce disjoint tags so
+        # a tab pinned to one session drops the other's frames.
+        session_a = ChatSession.objects.create(user=self.user)
+        session_b = ChatSession.objects.create(user=self.user)
+
+        _ca, _la, _acka, frames_a = self._run_turn(session_id=session_a.id)
+        _cb, _lb, _ackb, frames_b = self._run_turn(session_id=session_b.id)
+
+        self.assertNotEqual(session_a.id, session_b.id)
+        self.assertTrue(frames_a and all(frame["session_id"] == session_a.id for frame in frames_a))
+        self.assertTrue(frames_b and all(frame["session_id"] == session_b.id for frame in frames_b))
+        # session A's stream contains nothing a tab on session B would accept
+        self.assertFalse(any(frame["session_id"] == session_b.id for frame in frames_a))

--- a/tests/api_app/chatbot_manager/test_e2e.py
+++ b/tests/api_app/chatbot_manager/test_e2e.py
@@ -69,7 +69,8 @@ def _fake_tool_calling_executor(user):
     (chat.token), then the final output. Keeps the handler, the tool and the pending-action store
     real while Ollama is never reached."""
     real_tools = build_tools(user=user)
-    analyze_tool = next(tool for tool in real_tools if tool.name == "analyze_observable")
+    # dict lookup (not next()) so a missing tool fails loudly with a KeyError naming it
+    analyze_tool = {tool.name: tool for tool in real_tools}["analyze_observable"]
 
     class _FakeExecutor:
         # The task derives handler.tool_names from this real registry, so the chat.status filter
@@ -139,8 +140,9 @@ class ChatPipelineE2ETestCase(TestCase):
             patch("api_app.chatbot_manager.consumers.process_chat_message") as consumer_task,
         ):
             # The consumer enqueues via .delay; forward to the real task body so the hand-off
-            # contract (exact args) is exercised and the turn runs synchronously in-test.
-            consumer_task.delay.side_effect = lambda *args: process_chat_message(*args)
+            # contract (exact args) is exercised and the turn runs synchronously in-test. The task
+            # object is itself callable, so it is the side_effect directly (no wrapping lambda).
+            consumer_task.delay.side_effect = process_chat_message
             content = {"message": message}
             if session_id is not None:
                 content["session_id"] = session_id
@@ -207,10 +209,13 @@ class ChatPipelineE2ETestCase(TestCase):
         # launch: a real user POST of it to the confirm endpoint starts the job (M-1 — the model
         # itself never launches).
         _consumer, _layer, _ack, relay_frames = self._run_turn()
-        action = next(
+        # exactly one action_required frame is expected; index it (not next()) so an empty/oversized
+        # match fails loudly here rather than with a bare StopIteration
+        action_frames = [
             frame for frame in relay_frames if frame["type"] == events.ChatEventType.ACTION_REQUIRED.value
-        )
-        pending_id = action["pending_id"]
+        ]
+        self.assertEqual(len(action_frames), 1)
+        pending_id = action_frames[0]["pending_id"]
 
         client = APIClient()
         client.force_authenticate(self.user)


### PR DESCRIPTION
Refs #3793.

  E2E integration tests of the full chat path (no production code).

  **Backend** `tests/api_app/chatbot_manager/test_e2e.py` — wires the real ChatConsumer → process_chat_message → ChatStreamingCallbackHandler → relay, mocking only the LLM (build_agent_executor) and the job pipeline (apply_async):
  - full WS turn with a tool-call: ack/start/status/action_required/token/end + persistence;
  - M-1 bridge: action_required {session_id, pending_id, plan} → POST /api/chatbot/analysis/confirm launches the job (one-shot, owned by the user);
  - multi-tab session_id demux.
  Transport uses a loop-safe capturing channel layer rather than WebsocketCommunicator (avoids the documented sync-consumer event-loop hang).

  **Frontend** `frontend/tests/components/chat/ChatPanel.e2e.test.jsx` — real ChatPanel + hook + store driven through a full turn via a mock socket to the Confirm card and the 'Started analysis — job #N' message.

  Local: backend 144/144 OK (rebuilt test image), frontend 12 suites / 101 tests, ruff + eslint clean.