### PR TITLE
Add CVE_Exploitability analyzer (CISA KEV + FIRST EPSS) for CVE observables

### DIFF
--- a/api_app/analyzers_manager/migrations/0193_analyzer_config_cve_exploitability.py
+++ b/api_app/analyzers_manager/migrations/0193_analyzer_config_cve_exploitability.py
@@ -1,0 +1,128 @@
+from django.db import migrations
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ManyToManyDescriptor,
+    ReverseManyToOneDescriptor,
+    ReverseOneToOneDescriptor,
+)
+
+plugin = {
+    "python_module": {
+        "health_check_schedule": None,
+        "update_schedule": None,
+        "module": "cve_exploitability.CVEExploitability",
+        "base_path": "api_app.analyzers_manager.observable_analyzers",
+    },
+    "name": "CVE_Exploitability",
+    "description": "Enriches a CVE with real-world exploitation signals: membership in the "
+    "[CISA Known Exploited Vulnerabilities (KEV)](https://www.cisa.gov/known-exploited-vulnerabilities-catalog) "
+    "catalog (including the date added and known ransomware campaign use) and the "
+    "[FIRST.org EPSS](https://www.first.org/epss/) score and percentile (the probability the CVE will be "
+    "exploited in the wild in the next 30 days). Both data sources are free and require no API key.",
+    "disabled": False,
+    "soft_time_limit": 60,
+    "routing_key": "default",
+    "health_check_status": True,
+    "type": "observable",
+    "docker_based": False,
+    "maximum_tlp": "AMBER",
+    "observable_supported": ["generic"],
+    "supported_filetypes": [],
+    "run_hash": False,
+    "run_hash_type": "",
+    "not_supported_filetypes": [],
+    "model": "analyzers_manager.AnalyzerConfig",
+}
+
+params = []
+
+values = []
+
+
+def _get_real_obj(Model, field, value):
+    def _get_obj(Model, other_model, value):
+        if isinstance(value, dict):
+            real_vals = {}
+            for key, real_val in value.items():
+                real_vals[key] = _get_real_obj(other_model, key, real_val)
+            value = other_model.objects.get_or_create(**real_vals)[0]
+        # it is just the primary key serialized
+        else:
+            if isinstance(value, int):
+                if Model.__name__ == "PluginConfig":
+                    value = other_model.objects.get(name=plugin["name"])
+                else:
+                    value = other_model.objects.get(pk=value)
+            else:
+                value = other_model.objects.get(name=value)
+        return value
+
+    if (
+        type(getattr(Model, field))
+        in [
+            ForwardManyToOneDescriptor,
+            ReverseManyToOneDescriptor,
+            ReverseOneToOneDescriptor,
+            ForwardOneToOneDescriptor,
+        ]
+        and value
+    ):
+        other_model = getattr(Model, field).get_queryset().model
+        value = _get_obj(Model, other_model, value)
+    elif type(getattr(Model, field)) in [ManyToManyDescriptor] and value:
+        other_model = getattr(Model, field).rel.model
+        value = [_get_obj(Model, other_model, val) for val in value]
+    return value
+
+
+def _create_object(Model, data):
+    mtm, no_mtm = {}, {}
+    for field, value in data.items():
+        value = _get_real_obj(Model, field, value)
+        if type(getattr(Model, field)) is ManyToManyDescriptor:
+            mtm[field] = value
+        else:
+            no_mtm[field] = value
+    try:
+        o = Model.objects.get(**no_mtm)
+    except Model.DoesNotExist:
+        o = Model(**no_mtm)
+        o.full_clean()
+        o.save()
+        for field, value in mtm.items():
+            attribute = getattr(o, field)
+            if value is not None:
+                attribute.set(value)
+        return False
+    return True
+
+
+def migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    if not Model.objects.filter(name=plugin["name"]).exists():
+        exists = _create_object(Model, plugin)
+        if not exists:
+            for param in params:
+                _create_object(Parameter, param)
+            for value in values:
+                _create_object(PluginConfig, value)
+
+
+def reverse_migrate(apps, schema_editor):
+    python_path = plugin.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+    Model.objects.get(name=plugin["name"]).delete()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+    dependencies = [
+        ("api_app", "0073_alter_updatecheckstatus_last_checked_at_and_more"),
+        ("analyzers_manager", "0192_analyzer_config_ipqs_url_file_scanner"),
+    ]
+
+    operations = [migrations.RunPython(migrate, reverse_migrate)]

--- a/api_app/analyzers_manager/observable_analyzers/cve_exploitability.py
+++ b/api_app/analyzers_manager/observable_analyzers/cve_exploitability.py
@@ -1,0 +1,86 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import re
+
+import requests
+
+from api_app.analyzers_manager.classes import AnalyzerRunException, ObservableAnalyzer
+
+
+class CVEExploitability(ObservableAnalyzer):
+    """
+    Enrich a CVE observable with real-world exploitation signals instead of
+    relying on CVSS severity alone:
+
+    - CISA Known Exploited Vulnerabilities (KEV) catalog membership, the date
+      the CVE was added, and whether it is linked to known ransomware campaigns.
+    - FIRST.org EPSS (Exploit Prediction Scoring System) score and percentile,
+      i.e. the probability that the CVE will be exploited in the wild in the
+      next 30 days.
+
+    Both data sources are free and require no API key.
+    """
+
+    # `url` is used by IntelOwl health checks (HEAD HTTP request).
+    url: str = "https://api.first.org/data/v1/epss"
+    kev_url: str = "https://www.cisa.gov/sites/default/files/feeds/known_exploited_vulnerabilities.json"
+    cve_pattern: str = r"^CVE-\d{4}-\d{4,7}$"
+    http_timeout: int = 30
+
+    @classmethod
+    def update(cls) -> bool:
+        pass
+
+    def _query_kev(self, cve_id: str) -> dict:
+        response = requests.get(self.kev_url, timeout=self.http_timeout)
+        response.raise_for_status()
+        catalog = response.json()
+        for vuln in catalog.get("vulnerabilities", []):
+            if vuln.get("cveID", "").upper() == cve_id:
+                return {
+                    "in_kev": True,
+                    "kev_date": vuln.get("dateAdded"),
+                    "ransomware_use": vuln.get("knownRansomwareCampaignUse"),
+                    "kev_vendor_project": vuln.get("vendorProject"),
+                    "kev_product": vuln.get("product"),
+                    "kev_vulnerability_name": vuln.get("vulnerabilityName"),
+                    "kev_required_action": vuln.get("requiredAction"),
+                    "kev_due_date": vuln.get("dueDate"),
+                }
+        return {
+            "in_kev": False,
+            "kev_date": None,
+            "ransomware_use": None,
+        }
+
+    def _query_epss(self, cve_id: str) -> dict:
+        response = requests.get(self.url, params={"cve": cve_id}, timeout=self.http_timeout)
+        response.raise_for_status()
+        data = response.json().get("data", [])
+        if not data:
+            return {"epss_score": None, "epss_percentile": None, "epss_date": None}
+        entry = data[0]
+        epss = entry.get("epss")
+        percentile = entry.get("percentile")
+        return {
+            "epss_score": float(epss) if epss is not None else None,
+            "epss_percentile": float(percentile) if percentile is not None else None,
+            "epss_date": entry.get("date"),
+        }
+
+    def run(self):
+        # Validate the CVE format (e.g. CVE-2021-44228 or cve-2021-44228)
+        # before issuing any network request.
+        if not re.match(self.cve_pattern, self.observable_name, flags=re.IGNORECASE):
+            raise AnalyzerRunException(f"Invalid CVE format: {self.observable_name}")
+
+        cve_id = self.observable_name.upper()
+        result = {"cve": cve_id}
+        try:
+            result.update(self._query_kev(cve_id))
+            result.update(self._query_epss(cve_id))
+        except requests.RequestException as e:
+            raise AnalyzerRunException(e)
+
+        return result

--- a/api_app/playbooks_manager/migrations/0067_add_cve_exploitability_to_free_to_use.py
+++ b/api_app/playbooks_manager/migrations/0067_add_cve_exploitability_to_free_to_use.py
@@ -1,0 +1,41 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+
+from django.db import migrations
+
+ANALYZER_NAME = "CVE_Exploitability"
+
+
+def migrate(apps, schema_editor):
+    playbook_config = apps.get_model("playbooks_manager", "PlaybookConfig")
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+
+    pc = playbook_config.objects.get(name="FREE_TO_USE_ANALYZERS")
+    pc.analyzers.add(AnalyzerConfig.objects.get(name=ANALYZER_NAME).id)
+    pc.full_clean()
+    pc.save()
+
+
+def reverse_migrate(apps, schema_editor):
+    playbook_config = apps.get_model("playbooks_manager", "PlaybookConfig")
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+
+    pc = playbook_config.objects.get(name="FREE_TO_USE_ANALYZERS")
+    pc.analyzers.remove(AnalyzerConfig.objects.get(name=ANALYZER_NAME).id)
+    pc.full_clean()
+    pc.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        (
+            "playbooks_manager",
+            "0066_link_crawl_visualizer_to_playbook",
+        ),
+        ("analyzers_manager", "0193_analyzer_config_cve_exploitability"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate, reverse_migrate),
+    ]

--- a/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_cve_exploitability.py
+++ b/tests/api_app/analyzers_manager/unit_tests/observable_analyzers/test_cve_exploitability.py
@@ -1,0 +1,121 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import patch
+
+from api_app.analyzers_manager.exceptions import AnalyzerRunException
+from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.analyzers_manager.observable_analyzers.cve_exploitability import (
+    CVEExploitability,
+)
+from tests.api_app.analyzers_manager.unit_tests.observable_analyzers.base_test_class import (
+    BaseAnalyzerTest,
+)
+from tests.mock_utils import MockUpResponse
+
+# Trimmed CISA KEV catalog containing Log4Shell (CVE-2021-44228).
+KEV_CATALOG = {
+    "title": "CISA Catalog of Known Exploited Vulnerabilities",
+    "catalogVersion": "2024.11.01",
+    "count": 1,
+    "vulnerabilities": [
+        {
+            "cveID": "CVE-2021-44228",
+            "vendorProject": "Apache",
+            "product": "Log4j2",
+            "vulnerabilityName": "Apache Log4j2 Remote Code Execution Vulnerability",
+            "dateAdded": "2021-12-10",
+            "shortDescription": "Apache Log4j2 contains a vulnerability where JNDI "
+            "features do not protect against attacker-controlled LDAP.",
+            "requiredAction": "Apply updates per vendor instructions.",
+            "dueDate": "2021-12-24",
+            "knownRansomwareCampaignUse": "Known",
+            "notes": "https://nvd.nist.gov/vuln/detail/CVE-2021-44228",
+        }
+    ],
+}
+
+# FIRST.org EPSS API response for Log4Shell.
+EPSS_RESPONSE = {
+    "status": "OK",
+    "status-code": 200,
+    "version": "1.0",
+    "total": 1,
+    "data": [
+        {
+            "cve": "CVE-2021-44228",
+            "epss": "0.944260000",
+            "percentile": "0.999990000",
+            "date": "2024-11-01",
+        }
+    ],
+}
+
+# EPSS API response shape when a CVE has no published score.
+EPSS_EMPTY_RESPONSE = {
+    "status": "OK",
+    "status-code": 200,
+    "version": "1.0",
+    "total": 0,
+    "data": [],
+}
+
+
+def _dispatch(kev_payload, epss_payload):
+    """Return a requests.get side_effect that routes on the called URL."""
+
+    def side_effect(url, *args, **kwargs):
+        if "known_exploited_vulnerabilities" in url:
+            return MockUpResponse(kev_payload, 200)
+        return MockUpResponse(epss_payload, 200)
+
+    return side_effect
+
+
+class CVEExploitabilityTestCase(BaseAnalyzerTest):
+    analyzer_class = CVEExploitability
+    config = AnalyzerConfig.objects.get(python_module=analyzer_class.python_module)
+
+    @staticmethod
+    def get_mocked_response():
+        return patch(
+            "requests.get",
+            side_effect=_dispatch(KEV_CATALOG, EPSS_RESPONSE),
+        )
+
+    def test_cve_in_kev_with_epss(self):
+        """A KEV-listed CVE returns in_kev=True plus EPSS score and percentile."""
+        with self.get_mocked_response():
+            analyzer = self.analyzer_class(self.config)
+            analyzer.observable_name = "cve-2021-44228"
+            result = analyzer.run()
+
+        self.assertEqual(result["cve"], "CVE-2021-44228")
+        self.assertTrue(result["in_kev"])
+        self.assertEqual(result["kev_date"], "2021-12-10")
+        self.assertEqual(result["ransomware_use"], "Known")
+        self.assertAlmostEqual(result["epss_score"], 0.94426)
+        self.assertAlmostEqual(result["epss_percentile"], 0.99999)
+
+    def test_cve_not_in_kev(self):
+        """A CVE absent from the KEV catalog and from EPSS returns null signals."""
+        with patch(
+            "requests.get",
+            side_effect=_dispatch({"vulnerabilities": []}, EPSS_EMPTY_RESPONSE),
+        ):
+            analyzer = self.analyzer_class(self.config)
+            analyzer.observable_name = "CVE-2000-9999"
+            result = analyzer.run()
+
+        self.assertFalse(result["in_kev"])
+        self.assertIsNone(result["kev_date"])
+        self.assertIsNone(result["ransomware_use"])
+        self.assertIsNone(result["epss_score"])
+        self.assertIsNone(result["epss_percentile"])
+
+    def test_invalid_cve_format(self):
+        """An observable that is not a CVE id raises before any network call."""
+        analyzer = self.analyzer_class(self.config)
+        analyzer.observable_name = "2021-44228"
+        with self.assertRaises(AnalyzerRunException):
+            analyzer.run()


### PR DESCRIPTION
# Description

This PR adds a new free, key-less observable analyzer, **CVE_Exploitability**, that enriches a CVE observable with real-world exploitation signals rather than CVSS severity alone. For a given CVE it returns CISA KEV catalog membership and FIRST.org EPSS scoring, so analysts and playbooks can triage on *likelihood of exploitation* instead of theoretical severity.

It pairs cleanly with the existing `NVD_CVE` and `Vulners` analyzers (same `generic`/CVE-regex observable shape) and is added to the `FREE_TO_USE_ANALYZERS` playbook since it needs no API key.

## Summary

A new `ObservableAnalyzer` that, for a CVE observable, queries the CISA Known Exploited Vulnerabilities (KEV) catalog and the FIRST.org EPSS API and returns `{in_kev, kev_date, ransomware_use, epss_score, epss_percentile}` (plus KEV context fields), enabling exploitation-aware CVE prioritization with no API key.

## Problem / motivation

IntelOwl can already resolve CVE metadata (`NVD_CVE`) and search vendor advisories (`Vulners`), but it exposes no signal for *whether a CVE is actually being exploited in the wild*. CVSS base score is a poor prioritization signal on its own: the large majority of published CVEs are never exploited, while a small subset under active, often ransomware-linked, exploitation is what actually drives incidents. Two authoritative, free data sources fill this gap and are widely used by detection and response teams:

- **CISA KEV** — the U.S. authoritative list of vulnerabilities with confirmed in-the-wild exploitation, including whether the CVE is tied to known ransomware campaigns and the federal remediation due date.
- **FIRST EPSS** — a daily-updated probability (0–1) that a CVE will be exploited in the next 30 days, plus its percentile rank across all scored CVEs.

## Change

- New analyzer `api_app/analyzers_manager/observable_analyzers/cve_exploitability.py` (`CVEExploitability`), modeled on the existing `nvd_cve.py`:
  - Validates the observable against the same CVE regex (`^CVE-\d{4}-\d{4,7}$`, case-insensitive) **before** any network call.
  - `_query_kev()` fetches the free CISA KEV JSON catalog and returns membership, `dateAdded`, `knownRansomwareCampaignUse`, and KEV context (vendor/product/name/required action/due date).
  - `_query_epss()` fetches the FIRST EPSS API for the CVE and returns `epss_score` and `epss_percentile` as floats (with `epss_date`).
  - Exposes `url` (the EPSS endpoint) for IntelOwl HEAD health checks, uses request timeouts, and wraps network failures in `AnalyzerRunException`.
- Data migration `analyzers_manager/0193_analyzer_config_cve_exploitability.py` registers the `AnalyzerConfig` (type `observable`, `observable_supported: ["generic"]`, `maximum_tlp: AMBER`), mirroring the `NVD_CVE` registration migration. No parameters/secrets are required.
- Data migration `playbooks_manager/0067_add_cve_exploitability_to_free_to_use.py` adds the analyzer to the `FREE_TO_USE_ANALYZERS` playbook (it requires no API key).
- Unit test `tests/.../observable_analyzers/test_cve_exploitability.py` with all external calls mocked: a KEV+EPSS positive case (Log4Shell, `CVE-2021-44228`), a not-in-KEV / no-EPSS negative case, and an invalid-format case that must raise before any network call.

## Security rationale

This is exploitation-intelligence enrichment framed for prioritization and response:

- **CISA KEV** is the authoritative catalog of CVEs with confirmed active exploitation and underpins CISA BOD 22-01 remediation timelines; surfacing `knownRansomwareCampaignUse` maps directly to ransomware-driven risk.
- **FIRST EPSS** provides a calibrated, empirically-derived exploitation probability, the recommended complement to **CVSS** (severity) for risk-based vulnerability management.
- Combining KEV membership (binary, authoritative) with EPSS (probabilistic, continuous) lets responders separate the exploited / likely-to-be-exploited tail from the long list of low-probability CVEs — reducing alert fatigue and focusing remediation where in-the-wild exploitation is real.
- Input is strictly validated against the CVE regex before egress, and both endpoints are key-less GETs over TLS with explicit timeouts, so the analyzer adds no credential handling or new dependency surface.

## Testing / validation

Validated against a live IntelOwl stack (Postgres + the project's `develop` code) — not just static checks:

- `python manage.py makemigrations --check --dry-run` reports **no** missing migrations for `analyzers_manager` / `playbooks_manager`.
- `python manage.py migrate` applies cleanly end-to-end, including `analyzers_manager.0193_analyzer_config_cve_exploitability` and `playbooks_manager.0067_add_cve_exploitability_to_free_to_use` (the `AnalyzerConfig` is registered and linked to `FREE_TO_USE_ANALYZERS`).
- `python manage.py test tests.api_app.analyzers_manager.unit_tests.observable_analyzers.test_cve_exploitability` → **all tests pass** (including the inherited `test_analyzer_on_supported_observables`, which resolves the new `AnalyzerConfig` at class load):
  - positive: `in_kev=True`, `kev_date`, `ransomware_use="Known"`, `epss_score≈0.94426`, `epss_percentile≈0.99999`;
  - negative: all signals null when the CVE is absent from KEV and EPSS;
  - invalid format raises `AnalyzerRunException` **without** issuing any network request.
- `ruff check` and `ruff format --check` (ruff 0.14.10, the repo's pinned version) pass on the analyzer and test — **0 errors**.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project.
- [x] The pull request is for the branch `develop`.
- [x] A new plugin (analyzer) was added:
    - [x] I followed the "How to create a Plugin" documentation.
    - [ ] The `docs` repo (usage.md) update will be submitted as a linked follow-up PR.
    - [x] The plugin requires no additional optional configuration (no parameters/secrets).
    - [x] The analyzer configuration is added as a data migration mirroring `NVD_CVE`, produced to match the `dumpplugin` output format.
    - [x] The analyzer is free (no API key) and has been added to the `FREE_TO_USE_ANALYZERS` playbook.
    - [x] If the plugin interacts with an external service, I created a `url` attribute (EPSS endpoint) for Health Checks.
    - [x] I created a unittest for it and mocked all external calls — no real calls are made while testing.
    - [x] I added a representative raw JSON sample (KEV + EPSS) to the unittest mock responses.
    - [ ] No `DataModel` mapping was added, consistent with the existing `NVD_CVE`/`Vulners` analyzers; happy to add one if maintainers prefer.
- [x] I inserted the copyright banner at the start of the new files.
- [x] No new libraries were added (uses the existing `requests` dependency only).
- [x] `Ruff` lint and format give 0 errors on the touched files.
- [x] I have added tests for the feature. They mock all external calls.
- [x] I have reviewed and verified the LLM-assisted portions of this PR. Disclosure: an LLM was used to draft boilerplate and tests; all code was reviewed, validated, and lint/format-checked by me, and the full migrate + targeted test run was executed against a live Postgres-backed IntelOwl stack.
