### PR TITLE
[Connectors] Fix failing connector tests caused due to removal of monkeypatches

### DIFF
--- a/tests/api_app/connectors_manager/test_classes.py
+++ b/tests/api_app/connectors_manager/test_classes.py
@@ -42,13 +42,16 @@ class ConnectorTestCase(CustomTestCase):
             parameter=Parameter.objects.get(name="url_key_name", python_module=pm),
             connector_config=cc,
         )
-        with patch("requests.head"):
+
+        with patch("requests.head") as mock_head:
+            mock_head.return_value.status_code = 200
             result = MockUpConnector(cc).health_check(self.user)
-        self.assertTrue(result)
-        cc.disabled = False
-        cc.save()
-        result = MockUpConnector(cc).health_check(self.user)
-        self.assertTrue(result)
+            self.assertTrue(result)
+            cc.disabled = False
+            cc.save()
+            result = MockUpConnector(cc).health_check(self.user)
+            self.assertTrue(result)
+
         cc.delete()
         pc.delete()
 
@@ -131,7 +134,10 @@ class ConnectorTestCase(CustomTestCase):
                 )
                 signal.alarm(timeout_seconds)
                 try:
-                    sub.start(job.pk, {}, uuid())
+                    with patch(
+                        "api_app.connectors_manager.models.ConnectorConfig._get_params", return_value={}
+                    ):
+                        sub.start(job.pk, {}, uuid())
                 except Exception as e:
                     self.fail(f"Connector {subclass.__name__} with config {config.name} failed {e}")
                 finally:

--- a/tests/api_app/connectors_manager/test_views.py
+++ b/tests/api_app/connectors_manager/test_views.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 from typing import Type
+from unittest.mock import patch
 
 from api_app.analyzables_manager.models import Analyzable
 from api_app.choices import Classification
@@ -34,12 +35,15 @@ class ConnectorConfigViewSetTestCase(AbstractConfigViewSetTestCaseMixin, CustomV
             owner=None,
             connector_config=connector,
         )
-        response = self.client.get(f"{self.URL}/{connector.name}/health_check")
-        self.assertEqual(response.status_code, 200)
 
-        self.client.force_authenticate(self.superuser)
-        response = self.client.get(f"{self.URL}/{connector.name}/health_check")
-        self.assertEqual(response.status_code, 200)
+        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=True):
+            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
+            self.assertEqual(response.status_code, 200)
+
+            self.client.force_authenticate(self.superuser)
+            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
+            self.assertEqual(response.status_code, 200)
+
         result = response.json()
         self.assertIn("status", result)
         self.assertTrue(result["status"])


### PR DESCRIPTION

# Description

- added patches in connector tests (test_views and test_classes) as we removed the legacy monkeypatches from the source

## Type of change

- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`
