### PR TITLE
[GSoC 2026] chatbot: recover from invalid tool arguments

### DIFF
--- a/api_app/chatbot_manager/agent/system_prompt.txt
+++ b/api_app/chatbot_manager/agent/system_prompt.txt
@@ -17,6 +17,7 @@ Answer with short, data-driven summaries. Always cite the tools you used at the 
 [Rules]
 - Only access data belonging to the current user. Never reveal other users' data.
 - Call the right tool instead of guessing. Say so when a tool returns no data.
+- When a tool needs a value from a previous tool's result (an id, an md5), pass that actual value — never a placeholder like <job_id>.
 - analyze_observable only previews; never tell the user an analysis has started — they approve it themselves via the Confirm button.
 
 [Response style]

--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from ._common import on_invalid_tool_args
 from .analyze_observable import make_analyze_observable_tool
 from .get_data_model import make_get_data_model_tool
 from .get_investigation_tree import make_get_investigation_tree_tool
@@ -27,8 +28,12 @@ def build_tools(user) -> list:
     unless `confirm=True`) and creates jobs owned by `user`. Every tool returns a string
     (LangChain feeds it back to the model as the tool-call observation); see each tool
     for its shape.
+
+    Every tool also gets `handle_validation_error` set so that a schema-invalid argument the model
+    emits (e.g. the literal placeholder `<job_id>`) becomes a recoverable observation instead of an
+    exception that kills the turn (see `on_invalid_tool_args`).
     """
-    return [
+    tools = [
         make_search_jobs_tool(user),
         make_get_job_details_tool(user),
         make_summarize_job_tool(user),
@@ -40,3 +45,11 @@ def build_tools(user) -> list:
         make_recommend_playbook_tool(user),
         make_analyze_observable_tool(user),
     ]
+    # A schema-invalid tool argument (e.g. the model passing the literal "<job_id>" instead of a
+    # real id) raises a pydantic ValidationError inside BaseTool.run, before the tool body -- and is
+    # NOT covered by the executor's handle_parsing_errors (model output only). Returning it as an
+    # observation makes a bad argument recoverable (the agent retries with the real value) instead
+    # of killing the turn. Set centrally so every tool shares the behavior.
+    for chatbot_tool in tools:
+        chatbot_tool.handle_validation_error = on_invalid_tool_args
+    return tools

--- a/api_app/chatbot_manager/agent/tools/_common.py
+++ b/api_app/chatbot_manager/agent/tools/_common.py
@@ -23,3 +23,22 @@ def clamp_limit(limit, errors: list) -> int:
             f"returning at most {MAX_RESULTS} results."
         )
     return max(1, min(requested_limit, MAX_RESULTS))
+
+
+def on_invalid_tool_args(error: Exception) -> str:
+    """Observation returned when an LLM tool call fails the tool's argument schema.
+
+    Set as ``handle_validation_error`` on every built tool (see ``build_tools``). The pydantic
+    ``ValidationError`` is raised in ``BaseTool._parse_input`` *before* the tool body runs, so it is
+    not covered by ``AgentExecutor(handle_parsing_errors=...)`` (which only feeds back the model's
+    unparseable *output*). Returning the error as an observation -- instead of letting it propagate
+    and kill the whole turn as ``UNAVAILABLE`` -- lets the agent retry with the real value; if it
+    keeps emitting a bad value the run force-stops at ``max_iterations`` rather than crashing. The
+    message surfaces the failure and steers the model to substitute the actual value from a previous
+    tool result, not a placeholder.
+    """
+    return (
+        f"Invalid tool arguments: {error}. "
+        "Use the actual value from a previous tool result (for example a numeric id), "
+        "not a placeholder such as '<job_id>'. Then call the tool again."
+    )

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -98,7 +98,9 @@ def _scripted_llm(responses):
     """Fake ChatOllama whose bound runnable replays `responses`, one AIMessage per agent round."""
     replies = iter(responses)
     llm = MagicMock()
-    llm.bind_tools.return_value = RunnableLambda(lambda _: next(replies))
+    # next() takes a default so an exhausted script can't raise StopIteration (DeepSource PTC-W0063):
+    # returning a plain-text AIMessage ends the agent loop benignly instead of crashing the test.
+    llm.bind_tools.return_value = RunnableLambda(lambda _: next(replies, AIMessage(content="")))
     return llm
 
 

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -11,9 +11,11 @@ from langchain_core.runnables import RunnableLambda
 from api_app.chatbot_manager.agent.agent import (
     _MAX_AGENT_ITERATIONS,
     _NUM_CTX,
+    _SYSTEM_PROMPT,
     AGENT_STOPPED_OUTPUT,
     build_agent_executor,
 )
+from api_app.chatbot_manager.agent.tools._common import on_invalid_tool_args
 from certego_saas.apps.user.models import User
 
 # The full tool registry the agent must expose (one factory per module in agent/tools/).
@@ -80,3 +82,65 @@ class BuildAgentExecutorTestCase(TestCase):
         result = executor.invoke({"input": "loop forever", "chat_history": [], "page_context": ""})
 
         self.assertEqual(result["output"], AGENT_STOPPED_OUTPUT)
+
+
+class OnInvalidToolArgsTestCase(TestCase):
+    """The observation returned on a bad tool argument names the error and steers a retry."""
+
+    def test_message_surfaces_error_and_forbids_placeholders(self):
+        msg = on_invalid_tool_args(ValueError("job_id: not an integer"))
+        self.assertIsInstance(msg, str)
+        self.assertIn("job_id: not an integer", msg)  # the underlying error reaches the model
+        self.assertIn("placeholder", msg.lower())  # tell it not to pass a placeholder
+
+
+def _scripted_llm(responses):
+    """Fake ChatOllama whose bound runnable replays `responses`, one AIMessage per agent round."""
+    replies = iter(responses)
+    llm = MagicMock()
+    llm.bind_tools.return_value = RunnableLambda(lambda _: next(replies))
+    return llm
+
+
+class ToolArgRecoveryTestCase(TestCase):
+    """A schema-invalid tool argument is recoverable, never a turn-killing exception."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_arg_recovery_user")
+
+    def test_all_tools_handle_validation_errors(self):
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama"):
+            executor = build_agent_executor(user=self.user)
+        for tool in executor.tools:
+            self.assertEqual(tool.handle_validation_error, on_invalid_tool_args)
+
+    def test_invalid_tool_arg_is_recoverable_not_fatal(self):
+        # round 1: model passes the literal placeholder -> ValidationError on job_id (an int).
+        # round 2: model answers in plain text. The turn must complete, not raise.
+        bad = AIMessage(
+            content="", tool_calls=[{"name": "summarize_job", "args": {"job_id": "<job_id>"}, "id": "c1"}]
+        )
+        answer = AIMessage(content="Here is the summary.")
+        llm = _scripted_llm([bad, answer])
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
+            executor = build_agent_executor(user=self.user)
+        result = executor.invoke({"input": "summarize my latest job", "chat_history": [], "page_context": ""})
+        self.assertEqual(result["output"], "Here is the summary.")
+
+    def test_persistent_invalid_arg_degrades_to_forced_stop(self):
+        # The model emits the bad placeholder on every round: instead of crashing it must
+        # force-stop at max_iterations (the sentinel the caller maps to ITERATION_LIMIT).
+        bad = AIMessage(
+            content="", tool_calls=[{"name": "summarize_job", "args": {"job_id": "<job_id>"}, "id": "c1"}]
+        )
+        llm = MagicMock()
+        llm.bind_tools.return_value = RunnableLambda(lambda _: bad)
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
+            executor = build_agent_executor(user=self.user)
+        result = executor.invoke({"input": "summarize my latest job", "chat_history": [], "page_context": ""})
+        self.assertEqual(result["output"], AGENT_STOPPED_OUTPUT)
+
+    def test_system_prompt_warns_against_placeholder_args(self):
+        # guard the specific rule, not just the word: the <job_id> token appears only in it
+        self.assertIn("<job_id>", _SYSTEM_PROMPT)
+        self.assertIn("placeholder", _SYSTEM_PROMPT.lower())


### PR DESCRIPTION
# Description

Makes the chatbot agent **recover from schema-invalid tool arguments** instead of dropping the whole
turn as `UNAVAILABLE`.

When the model passes an argument that fails a tool's schema — e.g. `summarize_job(job_id='<job_id>')`,
the literal placeholder instead of the real id — langchain raises a pydantic `ValidationError` in
`BaseTool._parse_input`, **before** the tool body. `AgentExecutor(handle_parsing_errors=True)` covers
only the model's unparseable *output*, not tool *arguments*, so the error propagated and the worker
emitted `UNAVAILABLE`, dropping the turn.

Discovered by the W10 end-to-end latency benchmark (live Ollama): "find my most recent job and
summarize it" on `qwen2.5:3b` failed 9/9 warm vs 6/6 cold (`temperature=0` KV-cache argmax flip). The
failure is general to any tool with a typed argument.

## Changes

- NEW `on_invalid_tool_args(error) -> str` in `agent/tools/_common.py`: the observation returned when
  a tool call fails argument validation.
- `build_tools()` sets `handle_validation_error = on_invalid_tool_args` on every built tool (one
  central chokepoint, no per-tool-file edits).
- One `[Rules]` line in `agent/system_prompt.txt` discouraging placeholder arguments.
- 5 new tests in `tests/api_app/chatbot_manager/test_agent.py` (LLM mocked, no Ollama): helper
  message, structural wiring across all tools, recoverable→turn-completes, persistent-bad→graceful
  force-stop, prompt rule.

After this change a bad argument yields a retry with the real value, or a graceful `ITERATION_LIMIT`,
never an `UNAVAILABLE` crash. No change to `agent.py`, models, migrations or dependencies;
multi-tenancy is unchanged (`build_tools` still closes over `user`).

Refs #N

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/llm-chatbot` (GSoC umbrella branch, not `develop` — per the agreed GSoC workflow)
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed — **N/A** (no plugin added/changed)
- [x] I have inserted the copyright banner at the start of the file (existing files; the touched files already carry it)
- [x] Please avoid adding new libraries as requirements whenever it is possible — **no new dependency added**
- [ ] If external libraries/packages with restrictive licenses were added — **N/A**
- [x] Linters (`Ruff`) gave 0 errors (enforced by the pre-commit format-on-edit hook on every change)
- [x] I have added tests for the bug I solved (`tests/api_app/chatbot_manager/test_agent.py`); all tests (159 in `tests.api_app.chatbot_manager`) pass with 0 errors
- [ ] If the GUI has been modified — **N/A** (backend only)
- [x] After submitting the PR, I will resolve any `DeepSource`/`Django Doctors`/third-party alerts from CI
- [x] I have addressed raised Copilot issues (will address any on the PR)
- [x] I have reviewed and verified the LLM-generated code in this PR. **LLMs were used** (Claude Code) to draft the fix and tests; I reviewed and verified all of it.
