### PR TITLE
[Connectors] Implement health check for connectors

### DIFF
--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -162,6 +162,10 @@ class MISP(Connector):
                 timeout=5,
             )
 
+            # PyMISP has a property misp_instance_version
+            # that makes a GET request to servers/getVersion
+            # using valid API key and returns the version of
+            # the MISP instance if the connection is successful
             misp.misp_instance_version
             return True
 

--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import logging
 from typing import List
 
 import pymisp
@@ -10,6 +11,8 @@ from api_app import helpers
 from api_app.choices import Classification
 from api_app.connectors_manager.classes import Connector
 from api_app.connectors_manager.exceptions import ConnectorRunException
+
+logger = logging.getLogger(__name__)
 
 INTELOWL_MISP_TYPE_MAP = {
     Classification.IP: "ip-src",
@@ -112,6 +115,59 @@ class MISP(Connector):
             )
         else:
             raise ConnectorRunException(f"{errors}{debug_info}")
+
+    def health_check(self, user=None) -> bool:
+        if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
+            return True
+
+        params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
+            self._config, user
+        )
+
+        url = None
+        key = None
+
+        ssl_check = True
+        self_signed_certificate = False
+
+        for param in params:
+            if param.name == "url_key_name":
+                url = param.value
+            elif param.name == "api_key_name":
+                key = param.value
+            elif param.name == "ssl_check":
+                ssl_check = param.value
+            elif param.name == "self_signed_certificate":
+                self_signed_certificate = param.value
+
+        if not url:
+            logger.info("Healthcheck failed: Missing config url")
+            return False
+        if not key:
+            logger.info("Healthcheck failed: Missing config api key")
+            return False
+
+        ssl_param = (
+            f"{settings.PROJECT_LOCATION}/configuration/misp_ssl.crt"
+            if ssl_check and self_signed_certificate
+            else ssl_check
+        )
+
+        try:
+            misp = pymisp.PyMISP(
+                url=url,
+                key=key,
+                ssl=ssl_param,
+                debug=False,
+                timeout=5,
+            )
+
+            misp.misp_instance_version
+            return True
+
+        except Exception as e:
+            logger.info(f"MISP health check failed: {e}")
+            return False
 
     def run(self):
         ssl_param = (

--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -166,6 +166,7 @@ class MISP(Connector):
             # that makes a GET request to servers/getVersion
             # using valid API key and returns the version of
             # the MISP instance if the connection is successful
+            # Refs: https://pymisp.readthedocs.io/en/latest/modules.html?#pymisp.PyMISP.misp_instance_version
             misp.misp_instance_version
             return True
 

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -219,6 +219,7 @@ class OpenCTI(classes.Connector):
             # pycti has a built-in method (health_check) that
             # returns boolean True/False based on validity of
             # API key and reachability of the OpenCTI instance
+            # Ref: https://opencti-python-client.readthedocs.io/en/latest/pycti/pycti.api.opencti_api_client.html#pycti.api.opencti_api_client.OpenCTIApiClient.health_check
             resp = client.health_check()
             return resp
         except Exception as e:

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -215,6 +215,10 @@ class OpenCTI(classes.Connector):
 
         try:
             client = pycti.OpenCTIApiClient(url, token, ssl_verify=ssl_verify, proxies=proxies)
+
+            # pycti has a built-in method (health_check) that
+            # returns boolean True/False based on validity of
+            # API key and reachability of the OpenCTI instance
             resp = client.health_check()
             return resp
         except Exception as e:

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import logging
 from typing import Dict
 
 import pycti
@@ -10,6 +11,8 @@ from pycti.api.opencti_api_client import File
 from api_app import helpers
 from api_app.choices import Classification
 from api_app.connectors_manager import classes
+
+logger = logging.getLogger(__name__)
 
 INTELOWL_OPENCTI_TYPE_MAP = {
     Classification.IP: {
@@ -179,6 +182,38 @@ class OpenCTI(classes.Connector):
             pycti.Report(self.opencti_instance).add_stix_object_or_stix_relationship(
                 id=report_id, stixObjectOrStixRelationshipId=observable_id
             )
+
+    def health_check(self, user=None) -> bool:
+        if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
+            return True
+
+        params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
+            self._config, user
+        )
+
+        url = None
+        token = None
+
+        for param in params:
+            if param.name == "url_key_name":
+                url = param.value
+            elif param.name == "api_key_name":
+                token = param.value
+
+        if not url:
+            logger.info("Healthcheck failed: Missing config url")
+            return False
+        if not token:
+            logger.info("Healthcheck failed: Missing config api key")
+            return False
+
+        try:
+            client = pycti.OpenCTIApiClient(url, token)
+            resp = client.health_check()
+            return resp
+        except Exception as e:
+            logger.info(f"OpenCTI health check failed: {e}")
+            return False
 
     def run(self):
         # Initialize OpenCTI client for this run.

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -193,12 +193,18 @@ class OpenCTI(classes.Connector):
 
         url = None
         token = None
+        ssl_verify = False
+        proxies = None
 
         for param in params:
             if param.name == "url_key_name":
                 url = param.value
             elif param.name == "api_key_name":
                 token = param.value
+            elif param.name == "ssl_verify":
+                ssl_verify = str(param.value).lower() == "true"
+            elif param.name == "proxies":
+                proxies = param.value
 
         if not url:
             logger.info("Healthcheck failed: Missing config url")
@@ -208,7 +214,7 @@ class OpenCTI(classes.Connector):
             return False
 
         try:
-            client = pycti.OpenCTIApiClient(url, token)
+            client = pycti.OpenCTIApiClient(url, token, ssl_verify=ssl_verify, proxies=proxies)
             resp = client.health_check()
             return resp
         except Exception as e:

--- a/api_app/connectors_manager/connectors/slack.py
+++ b/api_app/connectors_manager/connectors/slack.py
@@ -62,6 +62,7 @@ class Slack(Connector):
             # test the authentication and connectivity to Slack
             # (auth_test returns identity information of the
             # authenticated user if the token is valid)
+            # Ref: https://docs.slack.dev/tools/python-slack-sdk/reference/#slack_sdk.WebClient.auth_test
             client.auth_test()
             return True
         except Exception as e:

--- a/api_app/connectors_manager/connectors/slack.py
+++ b/api_app/connectors_manager/connectors/slack.py
@@ -57,6 +57,11 @@ class Slack(Connector):
 
         try:
             client = slack_sdk.WebClient(token=token)
+
+            # slack sdk has a built-in method (auth_test) to
+            # test the authentication and connectivity to Slack
+            # (auth_test returns identity information of the
+            # authenticated user if the token is valid)
             client.auth_test()
             return True
         except Exception as e:

--- a/api_app/connectors_manager/connectors/slack.py
+++ b/api_app/connectors_manager/connectors/slack.py
@@ -1,9 +1,16 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import logging
 from typing import Dict
 
 import slack_sdk
+from django.conf import settings
 from slack_sdk.errors import SlackApiError
 
 from api_app.connectors_manager.classes import Connector
+
+logger = logging.getLogger(__name__)
 
 
 class Slack(Connector):
@@ -30,6 +37,31 @@ class Slack(Connector):
             f"{f'by <@{self.slack_username}> ' if self.slack_username else ''}"
             f"for <{self._job.url}/raw|{self._job.analyzable.name}>"
         )
+
+    def health_check(self, user=None) -> bool:
+        if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
+            return True
+
+        params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
+            self._config, user
+        )
+        token = None
+        for param in params:
+            if param.name == "token":
+                token = param.value
+                break
+
+        if not token:
+            logger.info("Slack health check failed: Missing token configuration.")
+            return False
+
+        try:
+            client = slack_sdk.WebClient(token=token)
+            client.auth_test()
+            return True
+        except Exception as e:
+            logger.info(f"Slack health check failed: {e}")
+            return False
 
     def run(self) -> dict:
         self.client.chat_postMessage(text=f"{self.title}\n{self.body}", channel=self._channel, mrkdwn=True)

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -52,6 +52,7 @@ class YETI(classes.Connector):
             # Posting the API key to YETI's authentication endpoint returns an
             # access token on success (YETI API v2). A valid access token confirms
             # that the API key is valid and the YETI instance is reachable.
+            # Ref: https://yeti-platform.io/docs/api/#authentication
             auth_resp = requests.post(
                 url=auth_url,
                 headers=auth_headers,

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -49,6 +49,9 @@ class YETI(classes.Connector):
         try:
             verify_ssl = getattr(self, "verify_ssl", False)
 
+            # Posting the API key to YETI's authentication endpoint returns an
+            # access token on success (YETI API v2). A valid access token confirms
+            # that the API key is valid and the YETI instance is reachable.
             auth_resp = requests.post(
                 url=auth_url,
                 headers=auth_headers,

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -2,6 +2,7 @@
 # See the file 'LICENSE' for copying permission.
 
 import ipaddress
+import logging
 
 import requests
 from django.conf import settings
@@ -9,11 +10,66 @@ from django.conf import settings
 from api_app.connectors_manager import classes
 from api_app.connectors_manager.exceptions import ConnectorRunException
 
+logger = logging.getLogger(__name__)
+
 
 class YETI(classes.Connector):
     verify_ssl: bool
     _url_key_name: str
     _api_key_name: str
+
+    def health_check(self, user=None) -> bool:
+        params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
+            self._config, user
+        )
+        url = None
+        api_key = None
+
+        for param in params:
+            if param.name == "url_key_name":
+                url = param.value
+            elif param.name == "api_key_name":
+                api_key = param.value
+
+        if not url:
+            logger.info("Healthcheck failed: Missing config url")
+            return False
+        if not api_key:
+            logger.info("Healthcheck failed: Missing config api key")
+            return False
+
+        if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
+            return True
+
+        base_url = url.rstrip("/")
+        auth_url = f"{base_url}/api/v2/auth/api-token"
+
+        auth_headers = {"x-yeti-apikey": api_key, "User-Agent": "IntelOwl"}
+
+        try:
+            verify_ssl = getattr(self, "verify_ssl", False)
+
+            auth_resp = requests.post(
+                url=auth_url,
+                headers=auth_headers,
+                verify=verify_ssl,
+                timeout=10,
+            )
+            auth_resp.raise_for_status()
+            access_token = auth_resp.json().get("access_token")
+
+            if access_token:
+                return True
+            else:
+                logger.info(f"Healthcheck failed for {self}: No access token in response.")
+                return False
+
+        except requests.RequestException as e:
+            logger.info(f"Healthcheck failed: YETI Auth Request failed for {self}. Error: {e}")
+            return False
+        except Exception as e:
+            logger.exception(f"Unexpected error in YETI health_check: {e}")
+            return False
 
     def run(self):
         # get observable value and type

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
@@ -3,6 +3,8 @@
 
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from api_app.connectors_manager.connectors.misp import MISP
 from api_app.connectors_manager.exceptions import ConnectorRunException
 from tests.api_app.connectors_manager.unit_tests.base_test_class import BaseConnectorTest
@@ -143,3 +145,68 @@ class MISPConnectorTestCase(BaseConnectorTest):
                 connector.run()
 
             self.assertIn("plain HTTP request to an HTTPS port", str(context.exception))
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_misp_health_check_success(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://misp.test/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        mock_ssl_param = MagicMock()
+        mock_ssl_param.name = "ssl_check"
+        mock_ssl_param.value = "false"
+
+        mock_cert_param = MagicMock()
+        mock_cert_param.name = "self_signed_certificate"
+        mock_cert_param.value = ""
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+            mock_ssl_param,
+            mock_cert_param,
+        ]
+
+        with patch("api_app.connectors_manager.connectors.misp.pymisp.PyMISP") as mock_client_cls:
+            mock_instance = mock_client_cls.return_value
+            mock_instance.health_check.return_value = True
+
+            self.assertTrue(connector.health_check())
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_misp_health_check_failures(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://misp.test/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+        ]
+
+        with (
+            self.subTest("MISP Connection Exception"),
+            patch(
+                "api_app.connectors_manager.connectors.misp.pymisp.PyMISP",
+                side_effect=Exception("Connection refused"),
+            ),
+        ):
+            self.assertFalse(connector.health_check())
+
+        with self.subTest("Missing Configuration"):
+            connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
+            self.assertFalse(connector.health_check())

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
@@ -4,6 +4,8 @@
 from contextlib import ExitStack
 from unittest.mock import MagicMock, patch
 
+from django.test import override_settings
+
 from api_app.connectors_manager.connectors.opencti import OpenCTI
 from tests.api_app.connectors_manager.unit_tests.base_test_class import BaseConnectorTest
 
@@ -275,3 +277,65 @@ class OpenCTIConnectorTestCase(BaseConnectorTest):
             self.assertIn("id", result["observable"])
             self.assertIn("report", result)
             self.assertIn("id", result["report"])
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_opencti_health_check_success(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://opencti.test/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+        ]
+
+        with patch("api_app.connectors_manager.connectors.opencti.pycti.OpenCTIApiClient") as mock_client_cls:
+            mock_instance = mock_client_cls.return_value
+            mock_instance.health_check.return_value = True
+
+            self.assertTrue(connector.health_check())
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_opencti_health_check_failures(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://opencti.test/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+        ]
+
+        with (
+            self.subTest("OpenCTI Connection Exception"),
+            patch("api_app.connectors_manager.connectors.opencti.pycti.OpenCTIApiClient") as mock_client_cls,
+        ):
+            mock_instance = mock_client_cls.return_value
+            mock_instance.health_check.side_effect = Exception("Connection refused")
+            self.assertFalse(connector.health_check())
+
+        with (
+            self.subTest("OpenCTI Reports Unhealthy"),
+            patch("api_app.connectors_manager.connectors.opencti.pycti.OpenCTIApiClient") as mock_client_cls,
+        ):
+            mock_instance = mock_client_cls.return_value
+            mock_instance.health_check.return_value = False
+            self.assertFalse(connector.health_check())
+
+        with self.subTest("Missing Configuration"):
+            connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
+            self.assertFalse(connector.health_check())

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
@@ -290,10 +290,20 @@ class OpenCTIConnectorTestCase(BaseConnectorTest):
         mock_api_param.name = "api_key_name"
         mock_api_param.value = "dummy_api_key"
 
+        mock_ssl_param = MagicMock()
+        mock_ssl_param.name = "ssl_verify"
+        mock_ssl_param.value = "false"
+
+        mock_proxies_param = MagicMock()
+        mock_proxies_param.name = "proxies"
+        mock_proxies_param.value = None
+
         connector._config = MagicMock()
         connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
             mock_url_param,
             mock_api_param,
+            mock_ssl_param,
+            mock_proxies_param,
         ]
 
         with patch("api_app.connectors_manager.connectors.opencti.pycti.OpenCTIApiClient") as mock_client_cls:

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_slack.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_slack.py
@@ -1,0 +1,72 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from django.test import override_settings
+
+from api_app.connectors_manager.connectors.slack import Slack
+from tests.api_app.connectors_manager.unit_tests.base_test_class import BaseConnectorTest
+
+
+class SlackTestCase(BaseConnectorTest):
+    connector_class = Slack
+
+    @classmethod
+    def get_extra_config(cls) -> dict:
+        return {
+            "_channel": "ABCD",
+            "slack_username": "intelowl_bot",
+            "_token": "mock-token-123",
+        }
+
+    @staticmethod
+    def get_mocked_response():
+        return [patch("api_app.connectors_manager.connectors.slack.slack_sdk.WebClient")]
+
+    def test_connector_run_execution(self):
+        self.skipTest("Will implement later")
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_slack_health_check_success(self):
+        connector = self._setup_connector()
+
+        mock_token_param = MagicMock()
+        mock_token_param.name = "token"
+        mock_token_param.value = "mock-token-123"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_token_param
+        ]
+
+        with patch("api_app.connectors_manager.connectors.slack.slack_sdk.WebClient") as mock_webclient_cls:
+            mock_instance = mock_webclient_cls.return_value
+            mock_instance.auth_test.return_value = {"ok": True}
+
+            self.assertTrue(connector.health_check())
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_slack_health_check_failures(self):
+        connector = self._setup_connector()
+
+        mock_token_param = MagicMock()
+        mock_token_param.name = "token"
+        mock_token_param.value = "mock-token-123"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_token_param
+        ]
+
+        with (
+            self.subTest("Slack Connection/Token Exception"),
+            patch("api_app.connectors_manager.connectors.slack.slack_sdk.WebClient") as mock_webclient_cls,
+        ):
+            mock_instance = mock_webclient_cls.return_value
+            mock_instance.auth_test.side_effect = Exception("invalid_auth")
+            self.assertFalse(connector.health_check())
+
+        with self.subTest("Missing Token Configuration"):
+            connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
+            self.assertFalse(connector.health_check())

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
@@ -182,17 +182,21 @@ class YETITestCase(BaseConnectorTest):
             mock_api_param,
         ]
 
-        with self.subTest("Network Exception"):
-            with patch(
+        with (
+            self.subTest("Network Exception"),
+            patch(
                 "api_app.connectors_manager.connectors.yeti.requests.post",
                 side_effect=requests.exceptions.Timeout,
-            ):
-                self.assertFalse(connector.health_check())
+            ),
+        ):
+            self.assertFalse(connector.health_check())
 
-        with self.subTest("Authentication Failure"):
-            with patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post:
-                mock_post.return_value = MockResponse({"error": "Unauthorized"}, 401)
-                self.assertFalse(connector.health_check())
+        with (
+            self.subTest("Authentication Failure"),
+            patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post,
+        ):
+            mock_post.return_value = MockResponse({"error": "Unauthorized"}, 401)
+            self.assertFalse(connector.health_check())
 
         with self.subTest("Missing Configuration"):
             connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
@@ -3,6 +3,8 @@
 
 from unittest.mock import MagicMock, patch
 
+import requests
+from django.test import override_settings
 from requests.exceptions import HTTPError
 
 from api_app.connectors_manager.connectors.yeti import YETI
@@ -138,3 +140,60 @@ class YETITestCase(BaseConnectorTest):
 
             with self.assertRaisesRegex(ConnectorRunException, "Failed to obtain access token from YETI"):
                 connector.run()
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_yeti_health_check_success(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://yeti.local/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+        ]
+
+        with patch(
+            "api_app.connectors_manager.connectors.yeti.requests.post", side_effect=mock_yeti_api_flow
+        ):
+            self.assertTrue(connector.health_check())
+
+    @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
+    def test_yeti_health_check_failures(self):
+        connector = self._setup_connector()
+
+        mock_url_param = MagicMock()
+        mock_url_param.name = "url_key_name"
+        mock_url_param.value = "http://yeti.local/"
+
+        mock_api_param = MagicMock()
+        mock_api_param.name = "api_key_name"
+        mock_api_param.value = "dummy_api_key"
+
+        connector._config = MagicMock()
+        connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = [
+            mock_url_param,
+            mock_api_param,
+        ]
+
+        with self.subTest("Network Exception"):
+            with patch(
+                "api_app.connectors_manager.connectors.yeti.requests.post",
+                side_effect=requests.exceptions.Timeout,
+            ):
+                self.assertFalse(connector.health_check())
+
+        with self.subTest("Authentication Failure"):
+            with patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post:
+                mock_post.return_value = MockResponse({"error": "Unauthorized"}, 401)
+                self.assertFalse(connector.health_check())
+
+        with self.subTest("Missing Configuration"):
+            connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
+            self.assertFalse(connector.health_check())


### PR DESCRIPTION
Closes #928 

# Description

## Health Check methods implemented for connectors
- YETI - successful auth token means health check passes
- Slack - slack sdk has an auth_test(), calling it validates the token and also identity info
- OpenCTI - called native health_check() method of pycti
- MISP - calling the misp_instance_version which connects the server instance and returns the server instance version and related info
- Tests (8 tests - 2 per connector): One health check success and one health check failure (containing multiple cases as subtests) per connector 

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
