### PR TITLE
[GSoC 2026] fix: make '--ollama' start option work in test/dev mode. Closes 
  #3829

### DIFF
--- a/docker/test.ollama.override.yml
+++ b/docker/test.ollama.override.yml
@@ -1,0 +1,7 @@
+services:
+  celery_worker_chatbot:
+    image: intelowlproject/intelowl:test
+    volumes:
+      - ../:/opt/deploy/intel_owl
+    environment:
+      - DEBUG=True

--- a/start
+++ b/start
@@ -9,7 +9,7 @@ declare -A env_arguments=(["prod"]=1 ["test"]=1 ["ci"]=1)
 declare -A test_mode=(["test"]=1 ["ci"]=1)
 declare -A cmd_arguments=(["build"]=1 ["up"]=1 ["start"]=1 ["restart"]=1 ["down"]=1 ["stop"]=1 ["kill"]=1 ["logs"]=1 ["ps"]=1)
 
-declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml" ["ollama"]="docker/ollama.override.yml")
+declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml" ["ollama"]="docker/ollama.override.yml" ["test_ollama"]="docker/test.ollama.override.yml")
 print_synopsis () {
   echo "SYNOPSIS"
   echo -e "    start <env> <command> [OPTIONS]"
@@ -328,7 +328,7 @@ done
 
 # add all the test files
 if [[ $env_argument == "test" ]]; then
-  test_values=("multi_queue" "flower")
+  test_values=("multi_queue" "flower" "ollama")
   for value in "${test_values[@]}"; do
     if [ "${params["$value"]}" ]; then
       compose_files+=("${path_mapping["test_$value"]}")


### PR DESCRIPTION
# Description
  Fixes the `--ollama` start option crashing `celery_worker_chatbot` with `celery_chatbot.sh: no 
  such file or directory` in test/dev mode. Root cause in #3829.

  `celery_worker_chatbot` was the only worker not repointed to the locally built `:test` image / 
  source mount in test mode, so it ran the pulled release image which lacks the new entrypoint. Added 
  `docker/test.ollama.override.yml` (mirrors `test.multi-queue.override.yml`) and wired it into 
  `start`.

  ## Type of change
  - [x] Bug fix (non-breaking change which fixes an issue).
  
  # Checklist
  - [x] The pull request is for the branch `gsoc-2026/llm-chatbot` (umbrella; reaches `develop` 
  via the umbrella release PR).
  - [x] Linters (`Ruff` / pre-commit) gave 0 errors.
  - [x] I have reviewed and verified any LLM-generated code in this PR. **LLM usage: yes** (root-cause
  diagnosis + drafting the override).

  Closes #3829