### PR TITLE
[GSoC 2026] fix(chatbot): round up rate limiter retry_after

### DIFF
--- a/api_app/chatbot_manager/rate_limit.py
+++ b/api_app/chatbot_manager/rate_limit.py
@@ -8,6 +8,7 @@ shared between the REST view and the WebSocket consumer so a user who sends via
 both paths hits the same bucket.
 """
 
+import math
 import time
 
 from django.core.cache import caches
@@ -39,9 +40,11 @@ class RateLimiter:
         current = self._cache.get(self._cache_key(key), 0)
         if current < self.limit:
             return True, 0
-        # Estimate how long until the window rolls over.
+        # Estimate how long until the window rolls over. Round up: truncating with int()
+        # can return 0 in the final second of the window (telling the client to retry
+        # immediately while it is still limited), and always under-estimates the wait.
         elapsed = time.time() % self.window_seconds
-        retry_after = int(self.window_seconds - elapsed)
+        retry_after = math.ceil(self.window_seconds - elapsed)
         return False, retry_after
 
     def increment(self, key: str) -> int:

--- a/tests/api_app/chatbot_manager/test_rate_limit.py
+++ b/tests/api_app/chatbot_manager/test_rate_limit.py
@@ -68,6 +68,22 @@ class RateLimiterAllowTests(SimpleTestCase):
         self.assertGreater(retry_after, 0, "retry_after should be positive")
 
     @override_settings(CACHES=TEST_CACHES)
+    def test_retry_after_positive_at_end_of_window(self):
+        """In the final fraction of a window retry_after must still be >= 1: int()
+        truncation would return 0 here (regression guard for the flaky failure)."""
+        limiter = _make_limiter()
+        user = _fresh_key()
+        # 1742345580 is exactly on a 60s boundary; +59.7 puts us 0.3s before the next
+        # rollover, so window_seconds - elapsed = 0.3 (int() -> 0, ceil() -> 1).
+        end_of_window = 1742345580.0 + 59.7
+        with patch("api_app.chatbot_manager.rate_limit.time.time", return_value=end_of_window):
+            for _ in range(_limit):
+                limiter.increment(user)
+            allowed, retry_after = limiter.allow(user)
+        self.assertFalse(allowed)
+        self.assertGreaterEqual(retry_after, 1)
+
+    @override_settings(CACHES=TEST_CACHES)
     def test_retry_after_decreases_as_time_passes(self):
         """retry_after is recalculated from the current time, so it shrinks as the
         window progresses."""


### PR DESCRIPTION
Closes #3835. allow() could return retry_after=0 in the last second of the window (int() truncation), causing a flaky test. Fixed with math.ceil + regression test. Found while validating #3834 on a fork.