### PR TITLE
[GSoC 2026] Run --ollama in CI and gate the slow build to develop→master

### DIFF
--- a/.github/workflows/pull_request_automation.yml
+++ b/.github/workflows/pull_request_automation.yml
@@ -87,10 +87,13 @@ jobs:
           password: ${{ secrets.GITHUB_TOKEN }}
 
       - name: Startup script launch (Slow)
-        if: contains(github.base_ref, 'master')
+        # Only the develop -> master release PR runs the full build: extra analyzers plus the
+        # chatbot stack (--ollama), which smoke-tests the ollama + celery_worker_chatbot topology
+        # on the :ci image. Kept off every other PR because the model pull is heavy.
+        if: github.base_ref == 'master' && github.head_ref == 'develop'
         run: |
           cp docker/env_file_integrations_template docker/env_file_integrations
-          ./start ci up --malware_tools_analyzers --phishing_analyzers -- --build -d
+          ./start ci up --malware_tools_analyzers --phishing_analyzers --ollama -- --build -d
         env:
           DOCKER_BUILDKIT: 1
           BUILDKIT_PROGRESS: "plain"
@@ -98,7 +101,9 @@ jobs:
           REPO_DOWNLOADER_ENABLED: false
 
       - name: Startup script launch (Fast)
-        if: "!contains(github.base_ref, 'master')"
+        # Exact complement of the Slow step so every other PR (incl. a non-develop head into
+        # master) still gets a container up for the test steps below.
+        if: ${{ !(github.base_ref == 'master' && github.head_ref == 'develop') }}
         run: |
           ./start ci up -- --build -d
         env:

--- a/docker/ci.ollama.override.yml
+++ b/docker/ci.ollama.override.yml
@@ -1,0 +1,9 @@
+services:
+  # In CI the chatbot worker must run the freshly built :ci image (like every other service in
+  # ci.override.yml), not the pulled release image pinned in ollama.override.yml. Without this the
+  # worker would run stale released code and, before a release ships the chatbot, would crash on
+  # the missing celery_chatbot.sh entrypoint. No source mount: CI bakes the source into the image.
+  celery_worker_chatbot:
+    image: intelowlproject/intelowl:ci
+    env_file:
+      - env_file_app_ci

--- a/start
+++ b/start
@@ -9,7 +9,7 @@ declare -A env_arguments=(["prod"]=1 ["test"]=1 ["ci"]=1)
 declare -A test_mode=(["test"]=1 ["ci"]=1)
 declare -A cmd_arguments=(["build"]=1 ["up"]=1 ["start"]=1 ["restart"]=1 ["down"]=1 ["stop"]=1 ["kill"]=1 ["logs"]=1 ["ps"]=1)
 
-declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml" ["ollama"]="docker/ollama.override.yml" ["test_ollama"]="docker/test.ollama.override.yml")
+declare -A path_mapping=(["default"]="docker/default.yml" ["postgres"]="docker/postgres.override.yml" ["rabbitmq"]="docker/rabbitmq.override.yml" ["test"]="docker/test.override.yml" ["ci"]="docker/ci.override.yml" ["custom"]="docker/custom.override.yml" ["traefik"]="docker/traefik.yml" ["traefik_prod"]="docker/traefik_prod.yml" ["traefik_local"]="docker/traefik_local.yml" ["multi_queue"]="docker/multi-queue.override.yml" ["test_multi_queue"]="docker/test.multi-queue.override.yml" ["flower"]="docker/flower.override.yml" ["test_flower"]="docker/test.flower.override.yml" ["elastic"]="docker/elasticsearch.override.yml" ["https"]="docker/https.override.yml" ["nfs"]="docker/nfs.override.yml" ["redis"]="docker/redis.override.yml" ["nginx_default"]="docker/nginx.override.yml" ["ollama"]="docker/ollama.override.yml" ["test_ollama"]="docker/test.ollama.override.yml" ["ci_ollama"]="docker/ci.ollama.override.yml")
 print_synopsis () {
   echo "SYNOPSIS"
   echo -e "    start <env> <command> [OPTIONS]"
@@ -334,6 +334,12 @@ if [[ $env_argument == "test" ]]; then
       compose_files+=("${path_mapping["test_$value"]}")
     fi
   done
+elif [[ $env_argument == "ci" ]]; then
+  # In ci mode --ollama pulls in ollama.override.yml (via the params loop above), whose chatbot
+  # worker is pinned to the pulled release image; repoint it to the built :ci image.
+  if [ "${params["ollama"]}" ]; then
+    compose_files+=("${path_mapping["ci_ollama"]}")
+  fi
 fi
 
 # add and parse analyzers


### PR DESCRIPTION
Closes #3834.

Adds `docker/ci.ollama.override.yml` (repoints celery_worker_chatbot to the built :ci image, mirroring ci.override.yml) and wires --ollama into ci mode in `start`. The Slow backend-tests step now runs only on the develop->master release PR and includes --ollama, smoke-testing the ollama + chatbot-worker topology; the Fast step becomes its exact complement.

Same class of bug as #3829/#3830 but for ci mode: without the override the chatbot worker would run the pulled release image instead of the PR's code.

Validated on a fork first: a develop->master PR ran the Slow step with --ollama (ollama + celery_worker_chatbot came up on :ci, no crash); other PRs ran the Fast step, no ollama.