### PR TITLE
test(connectors): remove redundant execution logic from test_subclasses (Closes #3838) 

### DIFF
--- a/tests/api_app/connectors_manager/test_classes.py
+++ b/tests/api_app/connectors_manager/test_classes.py
@@ -101,49 +101,11 @@ class ConnectorTestCase(CustomTestCase):
         an.delete()
 
     def test_subclasses(self):
-        def handler(signum, frame):
-            raise TimeoutError("end of time")
-
-        import signal
-
-        signal.signal(signal.SIGALRM, handler)
-        an1 = Analyzable.objects.create(
-            name="test.com",
-            classification=Classification.DOMAIN,
-        )
-
-        job = Job.objects.create(
-            analyzable=an1,
-            status="reported_without_fails",
-            user=self.superuser,
-        )
-
         subclasses = Connector.all_subclasses()
         for subclass in subclasses:
-            print(f"\nTesting Connector {subclass.__name__}")
             configs = ConnectorConfig.objects.filter(python_module=subclass.python_module)
             if not configs.exists():
                 self.fail(f"There is a python module {subclass.python_module} without any configuration")
-            for config in configs:
-                job.connectors_to_execute.set([config])
-                timeout_seconds = config.soft_time_limit
-                timeout_seconds = min(timeout_seconds, 20)
-                print(f"\tTesting with config {config.name} for {timeout_seconds} seconds")
-                sub = subclass(
-                    config,
-                )
-                signal.alarm(timeout_seconds)
-                try:
-                    with patch(
-                        "api_app.connectors_manager.models.ConnectorConfig._get_params", return_value={}
-                    ):
-                        sub.start(job.pk, {}, uuid())
-                except Exception as e:
-                    self.fail(f"Connector {subclass.__name__} with config {config.name} failed {e}")
-                finally:
-                    signal.alarm(0)
-        job.delete()
-        an1.delete()
 
     def test_before_run_partial_failure(self):
         # run_on_failure=False + partial failure (mix of FAILED and SUCCESS) should raise ConnectorRunException


### PR DESCRIPTION
Closes #3838

# Description

`test_subclasses (tests.api_app.connectors_manager.test_classes.ConnectorTestCase.test_subclasses)` was failing as I removed the monkeypatches in a previous PR.
The new connector testing framework almost does most of what is present in test_subclasses

So I have removed the redundant logic from test_subclasses because the connector execution logic is already tested in the unit_tests folder.

Screenshot of tests passing locally 
<img width="2510" height="320" alt="image" src="https://github.com/user-attachments/assets/0df17869-ca85-4b1f-bbb4-8ade6f07f366" />


## Type of change
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/connectors`