### PR TITLE
[GSoC 2026] chatbot: LangChain 1.x migration (create_agent) — Refs #3833

### DIFF
--- a/.github/workflows/dependency_review.yml
+++ b/.github/workflows/dependency_review.yml
@@ -14,10 +14,3 @@ jobs:
         uses: actions/checkout@v6.0.2
       - name: 'Dependency Review'
         uses: actions/dependency-review-action@v4
-        with:
-          # GHSA-gr75-jv2w-4656: LangChain path traversal in file-search middleware/loaders.
-          # Patched only in langchain 1.3.9 (breaking major upgrade). The chatbot uses no
-          # document loaders, file-search middleware, or hub prompt pulls (only langchain.agents,
-          # langchain_core.*, langchain_ollama), so the vulnerable code paths are unreachable.
-          # Accepted until the planned langchain 1.x migration. Approved by @mlodic.
-          allow-ghsas: GHSA-gr75-jv2w-4656

--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -1,87 +1,99 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from dataclasses import dataclass
 from pathlib import Path
 
 from django.conf import settings
-from langchain.agents import AgentExecutor, create_tool_calling_agent
-from langchain_core.prompts import ChatPromptTemplate, MessagesPlaceholder
+from langchain.agents import create_agent
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.runnables import Runnable
 from langchain_ollama import ChatOllama
 
 from .tools import build_tools
 
-# The system prompt lives in its own text file so it is readable, testable, and
-# editable without touching Python code. {page_context} is appended separately by
-# the prompt template below so the file stays self-contained (no interpolation).
+# The system prompt lives in its own text file so it is readable, testable, and editable without
+# touching Python code. The page context (if any) is appended by build_agent at build time so the
+# file stays self-contained (no interpolation).
 _SYSTEM_PROMPT = Path(__file__).parent.joinpath("system_prompt.txt").read_text(encoding="utf-8").strip()
 
-# The agent uses Ollama's native tool-calling API (`llm.bind_tools`, wired by
-# `create_tool_calling_agent`), so the prompt carries no rendered tool list and no ReAct
-# Thought/Action/Final Answer text scaffolding: the model emits structured tool calls and the
-# executor loops tool call -> observation under the hood. `chat_history` and `agent_scratchpad`
-# are message lists (MessagesPlaceholder), not pre-rendered text.
-PROMPT = ChatPromptTemplate.from_messages(
-    [
-        ("system", _SYSTEM_PROMPT + "\n\n{page_context}"),
-        MessagesPlaceholder("chat_history"),
-        ("human", "{input}"),
-        MessagesPlaceholder("agent_scratchpad"),
-    ]
-)
-
-# One iteration = one round of tool calls + observation. Real questions resolve in 1-3 rounds
-# (analyze_observable's confirm flow spans two turns, not two iterations), so 6 leaves room for
+# One "round" = one model turn that calls a tool + its observation. Real questions resolve in 1-3
+# rounds (analyze_observable's confirm flow spans two turns, not two rounds), so 6 leaves room for
 # a retry after a failed call while force-stopping a looping model well before the Celery task's
 # 300s soft time limit would on CPU.
 _MAX_AGENT_ITERATIONS = 6
 
-# What AgentExecutor returns as "output" when max_iterations force-stops the run (the
-# multi-action agent's return_stopped_response, langchain 0.3.25). Callers compare against this
-# to turn a forced stop into a user-facing error instead of persisting the canned framework
-# string as an assistant message.
-AGENT_STOPPED_OUTPUT = "Agent stopped due to max iterations."
+# LangGraph bounds a run by supersteps (its recursion_limit), not by agent rounds, and the count is
+# not 1:1 with rounds: one tool round is model -> tools -> model (2 supersteps), the run then ends
+# with a terminal model reply (+1), and LangGraph raises when the *next* superstep would reach the
+# limit (a boundary +1). So N rounds needs 2*N + 2 (measured: a single tool round completes only at
+# recursion_limit >= 4). This preserves the old max_iterations=6 force-stop budget under the new
+# runtime; a run that keeps calling tools raises GraphRecursionError, which the callers map to
+# ChatErrorDetail.ITERATION_LIMIT (there is no canned "stopped" string to compare against anymore).
+RECURSION_LIMIT = 2 * _MAX_AGENT_ITERATIONS + 2
 
-# The rendered prompt (system prompt + the 10 bound tool schemas) is already ~2.2k tokens
-# before any history: Ollama's default 2048-token context window silently truncates it from
-# the start (observed live: "truncating input prompt" limit=2048 prompt=2174), dropping the
-# system prompt and most tool schemas and wrecking tool selection. 8192 fits prompt + history
-# + tool observations comfortably and keeps the prompt prefix stable across iterations, so
-# follow-up rounds hit Ollama's KV prefix cache instead of re-evaluating everything.
+# The rendered prompt (system prompt + the 10 bound tool schemas) is already ~2.2k tokens before any
+# history: Ollama's default 2048-token context window silently truncates it from the start (observed
+# live: "truncating input prompt" limit=2048 prompt=2174), dropping the system prompt and most tool
+# schemas and wrecking tool selection. 8192 fits prompt + history + tool observations comfortably and
+# keeps the prompt prefix stable across rounds, so follow-ups hit Ollama's KV prefix cache.
 _NUM_CTX = 8192
 
 
-def build_agent_executor(user, streaming: bool = False) -> AgentExecutor:
-    """Build a tool-calling agent executor scoped to `user`.
+@dataclass(frozen=True)
+class ChatAgent:
+    """A user-scoped chat agent: the compiled LangGraph runnable plus its tool-name registry.
 
-    `ChatOllama` is the local LLM; `create_tool_calling_agent` binds the tools to the model
-    through the native tool-calling API — there is no text format to parse, which is what made
-    the previous string-ReAct loop unreliable on small local models (they rarely emit a
-    parseable `Final Answer:` line). `AgentExecutor` runs the tool-call -> observation loop
-    until the model replies with plain text. `handle_parsing_errors=True` feeds an unparseable
-    model output back as an observation instead of raising (it does NOT cover schema-invalid
-    tool *arguments*, which raise from the tool itself and surface through the caller's generic
-    error handling); `max_iterations` bounds a looping model (`early_stopping_method` stays at
-    its default "force" — runnable agents support no other value in langchain 0.3, "generate"
-    raises ValueError).
+    ``tool_names`` is carried alongside the runnable so the streaming consumer can gate which tool
+    calls become a ``chat.status`` event without re-deriving the registry from the compiled graph.
+    """
 
-    `streaming=True` makes `ChatOllama` emit token-level callbacks so the WebSocket path can
-    stream the answer live. No callbacks are bound to the model here: the caller attaches them
-    per run (`executor.invoke(..., config={"callbacks": [...]})`) so they also receive the
-    agent's tool actions, which originate from the executor and not from the LLM.
+    runnable: Runnable
+    tool_names: frozenset[str]
+
+
+def build_agent(user, page_context: str = "") -> ChatAgent:
+    """Build a tool-calling agent scoped to ``user``.
+
+    ``ChatOllama`` is the local LLM; ``create_agent`` (the LangGraph agent runtime that replaced the
+    deprecated ``AgentExecutor`` + ``create_tool_calling_agent``) binds the tools to the model via
+    Ollama's native tool-calling API and runs the model -> tools -> model loop as a graph. The input
+    is a ``{"messages": [...]}`` list (prior turns + the new user message), not the old
+    ``{input, chat_history, agent_scratchpad}`` template dict.
+
+    The system prompt is a plain string, so ``page_context`` (the compact "user is viewing job #N"
+    hint) is appended here at build time rather than interpolated through a prompt template; when it
+    is empty the base prompt is used verbatim. Streaming is chosen at call time (``runnable.stream``
+    vs ``runnable.invoke``), so ``ChatOllama`` needs no ``streaming`` flag.
+
+    Each built tool keeps ``handle_validation_error = on_invalid_tool_args`` (set in ``build_tools``):
+    a schema-invalid argument the model emits becomes a recoverable observation instead of an
+    exception that kills the turn — ``create_agent``'s tool node honors it because ``BaseTool``
+    swallows the ``ValidationError`` before the node sees one.
     """
     llm = ChatOllama(
         model=settings.OLLAMA_MODEL,
         base_url=settings.OLLAMA_BASE_URL,
         temperature=0,
         num_ctx=_NUM_CTX,
-        streaming=streaming,
     )
     tools = build_tools(user=user)
-    agent = create_tool_calling_agent(llm, tools, PROMPT)
-    return AgentExecutor(
-        agent=agent,
-        tools=tools,
-        verbose=False,
-        handle_parsing_errors=True,
-        max_iterations=_MAX_AGENT_ITERATIONS,
-    )
+    system_prompt = _SYSTEM_PROMPT if not page_context else f"{_SYSTEM_PROMPT}\n\n{page_context}"
+    agent = create_agent(model=llm, tools=tools, system_prompt=system_prompt)
+    return ChatAgent(runnable=agent, tool_names=frozenset(tool.name for tool in tools))
+
+
+def final_answer(messages: list[BaseMessage]) -> str:
+    """Return the assistant's terminal reply text from a finished run's ``messages``.
+
+    ``create_agent`` ends when the model returns an ``AIMessage`` with no tool calls, so the final
+    answer is the text of the last message when it carries no tool calls (otherwise the run did not
+    reach a plain answer and there is nothing to persist). This is the source of truth the WebSocket
+    ``chat.end`` and the REST reply both use.
+    """
+    if not messages:
+        return ""
+    last = messages[-1]
+    if isinstance(last, AIMessage) and not last.tool_calls:
+        return last.text
+    return ""

--- a/api_app/chatbot_manager/agent/streaming.py
+++ b/api_app/chatbot_manager/agent/streaming.py
@@ -1,13 +1,20 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-"""LangChain callback that streams a chat turn to the WebSocket as it runs.
+"""Consumes a create_agent run and streams the chat turn to the WebSocket as it happens.
 
-Attached at run level (``executor.invoke(..., config={"callbacks": [handler]})``) so it sees
-both the LLM token stream and the agent's tool actions, then pushes them onto the per-user
-channel group via ``group_send``. Running inside the (synchronous) Celery worker means there is
-no event loop, so ``async_to_sync`` is the right bridge to the async channel layer — the same
-pattern ``JobConsumer.serialize_and_send_job`` already uses.
+LangChain 1.x exposes streaming through the LangGraph runtime, so instead of a callback handler we
+drive the run with ``runnable.stream(stream_mode=["messages", "values"])`` and translate it into the
+same wire events:
+
+- ``messages`` yields ``(message_chunk, metadata)``: ``AIMessageChunk`` text becomes ``chat.token``;
+  its ``tool_call_chunks`` become one ``chat.status`` per tool call; a ``ToolMessage`` carrying a
+  ``pending_id`` becomes ``chat.action_required`` (the M-1 guardrail preview).
+- ``values`` yields the full state after each step; the terminal message is the answer persisted and
+  sent in ``chat.end`` (the source of truth — the streamed tokens are a best-effort live preview).
+
+Running inside the (synchronous) Celery worker means there is no event loop, so ``async_to_sync`` is
+the right bridge to the async channel layer — the same pattern ``JobConsumer`` already uses.
 """
 
 import json
@@ -15,8 +22,9 @@ import logging
 
 from asgiref.sync import async_to_sync
 from channels.layers import get_channel_layer
-from langchain_core.callbacks.base import BaseCallbackHandler
+from langchain_core.messages import AIMessageChunk, ToolMessage
 
+from api_app.chatbot_manager.agent.agent import final_answer
 from api_app.chatbot_manager.events import (
     ActionRequiredEvent,
     ChatEvent,
@@ -28,58 +36,71 @@ from api_app.chatbot_manager.events import (
 logger = logging.getLogger(__name__)
 
 
-class ChatStreamingCallbackHandler(BaseCallbackHandler):
-    """Streams the answer text token-by-token, plus a status event per tool call.
+class ChatStreamConsumer:
+    """Streams a create_agent run to a user's channel group and returns the final answer.
 
-    With a tool-calling agent there is no ``Final Answer:`` marker to gate on: when the model
-    decides to call a tool, the streamed chunks carry structured tool-call deltas whose *text*
-    is empty (the call itself rides ``tool_call_chunks``), and when it answers it streams plain
-    text. Forwarding only non-empty text therefore streams the answer while keeping tool-call
-    payloads off the wire.
-
-    This is a best-effort live view: a model may emit a short text preamble before a tool call,
-    which streams and is then superseded by the actual answer. The worker persists
-    ``result["output"]`` and sends it in the ``chat.end`` event, which the client treats as the
-    source of truth, so the stored/displayed answer is always correct.
+    With a tool-calling agent there is no ``Final Answer:`` marker: the model streams plain text for
+    the answer and rides tool calls on ``tool_call_chunks`` (whose text is empty). Forwarding only
+    non-empty text therefore streams the answer while keeping tool-call payloads off the wire. A
+    model may emit a short text preamble before a tool call, which streams and is then superseded by
+    the real answer; ``chat.end`` carries the terminal message, which the client treats as truth, so
+    the stored/displayed answer is always correct.
     """
 
-    def __init__(self, user_id: int, session_id: int, tool_names: set[str] | None = None):
+    def __init__(self, user_id: int, session_id: int, tool_names: frozenset[str] | None = None):
         self._group = chat_group_for_user(user_id)
         self._session_id = session_id
-        # Only these tool names produce a chat.status; None means "emit any" (unit tests).
-        # Filtering by the real registry suppresses LangChain's internal "_Exception" pseudo-tool
-        # (and the raw error text) that handle_parsing_errors surfaces as agent actions.
+        # Only these tool names produce a chat.status; None means "emit any" (unit tests). Filtering
+        # by the real registry keeps any non-registered tool name off the wire as chat.status.
         self._tool_names = tool_names
         self._channel_layer = get_channel_layer()
+        # (message_id, tool_call_index) already announced, so a tool call whose name streams across
+        # several chunks yields exactly one chat.status while distinct rounds each get their own.
+        self._status_seen: set[tuple] = set()
 
     def _emit(self, event: ChatEvent) -> None:
         async_to_sync(self._channel_layer.group_send)(self._group, event.as_channel_message())
 
-    def on_llm_new_token(self, token: str, **kwargs) -> None:
-        # Tool-call deltas surface here with empty text; only real answer text is forwarded.
-        if token:
-            self._emit(TokenEvent(self._session_id, token))
+    def run(self, agent_runnable, inputs: dict, config: dict) -> str:
+        """Stream the run, emitting token/status/action events, and return the terminal answer."""
+        answer = ""
+        for mode, payload in agent_runnable.stream(inputs, stream_mode=["messages", "values"], config=config):
+            if mode == "messages":
+                self._handle_message(payload[0])
+            elif mode == "values":
+                terminal = final_answer(payload.get("messages") or [])
+                if terminal:
+                    answer = terminal
+        return answer
 
-    def on_agent_action(self, action, **kwargs) -> None:
-        # Fired when the agent picks a tool; action.tool is the clean tool name. Skip anything
-        # that isn't a registered tool (e.g. the "_Exception" parse-error pseudo-tool, whose
-        # "tool" is the raw malformed model output) so internals don't leak as chat.status.
-        tool_name = getattr(action, "tool", "") or ""
-        if not tool_name or (self._tool_names is not None and tool_name not in self._tool_names):
+    def _handle_message(self, message) -> None:
+        if isinstance(message, AIMessageChunk):
+            # Tool-call deltas surface here with empty text; only real answer text is forwarded.
+            if message.text:
+                self._emit(TokenEvent(self._session_id, message.text))
+            for chunk in message.tool_call_chunks or []:
+                self._maybe_status(message.id, chunk)
+        elif isinstance(message, ToolMessage):
+            self._maybe_action_required(message.content)
+
+    def _maybe_status(self, message_id, tool_call_chunk) -> None:
+        name = tool_call_chunk.get("name")
+        if not name:
             return
-        self._emit(StatusEvent(self._session_id, tool_name))
+        key = (message_id, tool_call_chunk.get("index"))
+        if key in self._status_seen or (self._tool_names is not None and name not in self._tool_names):
+            return
+        self._status_seen.add(key)
+        self._emit(StatusEvent(self._session_id, name))
 
-    def on_tool_end(self, output, **kwargs) -> None:
+    def _maybe_action_required(self, content) -> None:
         # analyze_observable returns an envelope carrying a one-time pending_id; surface it as a
         # structured action so the frontend can render a Confirm button. Other tools have no
         # pending_id, so this is a no-op for them.
-        text = getattr(output, "content", output)
         try:
-            data = json.loads(text)
+            data = json.loads(content)
         except (TypeError, ValueError):
-            logger.warning("on_tool_end: cannot parse tool output as JSON (%s)", type(output).__name__)
+            logger.warning("stream: cannot parse tool output as JSON")
             return
         if isinstance(data, dict) and data.get("pending_id"):
             self._emit(ActionRequiredEvent(self._session_id, data["pending_id"], data.get("plan") or {}))
-        else:
-            logger.debug("on_tool_end: no pending_id in tool output")

--- a/api_app/chatbot_manager/agent/tools/__init__.py
+++ b/api_app/chatbot_manager/agent/tools/__init__.py
@@ -46,10 +46,10 @@ def build_tools(user) -> list:
         make_analyze_observable_tool(user),
     ]
     # A schema-invalid tool argument (e.g. the model passing the literal "<job_id>" instead of a
-    # real id) raises a pydantic ValidationError inside BaseTool.run, before the tool body -- and is
-    # NOT covered by the executor's handle_parsing_errors (model output only). Returning it as an
-    # observation makes a bad argument recoverable (the agent retries with the real value) instead
-    # of killing the turn. Set centrally so every tool shares the behavior.
+    # real id) raises a pydantic ValidationError inside BaseTool.run, before the tool body. Setting
+    # handle_validation_error makes BaseTool swallow it and return the message as an observation
+    # (create_agent's tool node surfaces it), so a bad argument is recoverable (the agent retries
+    # with the real value) instead of killing the turn. Set centrally so every tool shares it.
     for chatbot_tool in tools:
         chatbot_tool.handle_validation_error = on_invalid_tool_args
     return tools

--- a/api_app/chatbot_manager/agent/tools/_common.py
+++ b/api_app/chatbot_manager/agent/tools/_common.py
@@ -29,13 +29,13 @@ def on_invalid_tool_args(error: Exception) -> str:
     """Observation returned when an LLM tool call fails the tool's argument schema.
 
     Set as ``handle_validation_error`` on every built tool (see ``build_tools``). The pydantic
-    ``ValidationError`` is raised in ``BaseTool._parse_input`` *before* the tool body runs, so it is
-    not covered by ``AgentExecutor(handle_parsing_errors=...)`` (which only feeds back the model's
-    unparseable *output*). Returning the error as an observation -- instead of letting it propagate
-    and kill the whole turn as ``UNAVAILABLE`` -- lets the agent retry with the real value; if it
-    keeps emitting a bad value the run force-stops at ``max_iterations`` rather than crashing. The
-    message surfaces the failure and steers the model to substitute the actual value from a previous
-    tool result, not a placeholder.
+    ``ValidationError`` is raised in ``BaseTool._parse_input`` *before* the tool body runs; setting
+    ``handle_validation_error`` makes ``BaseTool`` swallow it and return this message as the tool
+    observation (``create_agent``'s tool node surfaces it) instead of letting it propagate and kill
+    the whole turn as ``UNAVAILABLE``. That lets the agent retry with the real value; if it keeps
+    emitting a bad value the run force-stops at the recursion limit rather than crashing. The message
+    surfaces the failure and steers the model to substitute the actual value from a previous tool
+    result, not a placeholder.
     """
     return (
         f"Invalid tool arguments: {error}. "

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -36,22 +36,25 @@ logger = logging.getLogger(__name__)
 def process_chat_message(session_id: int, user_message: str, user_id: int, context_url: str = "") -> None:
     """Run one chat turn off-request and stream it to the user's WebSocket group.
 
-    Enqueued by ChatConsumer.receive_json. The agent runs synchronously here (so token and
-    tool callbacks can bridge to the async channel layer via async_to_sync) and pushes
+    Enqueued by ChatConsumer.receive_json. The agent runs synchronously here (so the stream can
+    bridge to the async channel layer via async_to_sync) and pushes
     chat.start -> chat.status/chat.token* -> chat.end onto the per-user group, which the
     consumer relays to the browser. On any failure a single chat.error is emitted instead and
     the turn is dropped (no assistant message persisted), mirroring the sync REST path.
 
-    Persistence is the source of truth: the streamed tokens are a live preview, while
-    result["output"] is what gets stored and sent in chat.end. History is snapshotted before
-    this turn is written so the current message is not double-counted.
+    Persistence is the source of truth: the streamed tokens are a live preview, while the run's
+    terminal message (returned by the stream consumer) is what gets stored and sent in chat.end.
+    History is snapshotted before this turn is written so the current message is not double-counted.
     """
     # The agent/LLM stack (langchain + ChatOllama) is imported lazily so the other Celery
     # workers that load this module never pay for that heavy import — only the chatbot worker,
     # which actually runs this task, does.
-    from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
+    from langchain_core.messages import HumanMessage
+    from langgraph.errors import GraphRecursionError
+
+    from api_app.chatbot_manager.agent.agent import RECURSION_LIMIT, build_agent
     from api_app.chatbot_manager.agent.memory import DjangoChatMessageHistory
-    from api_app.chatbot_manager.agent.streaming import ChatStreamingCallbackHandler
+    from api_app.chatbot_manager.agent.streaming import ChatStreamConsumer
     from api_app.chatbot_manager.models import ChatMessage, ChatSession
 
     channel_layer = get_channel_layer()
@@ -78,37 +81,30 @@ def process_chat_message(session_id: int, user_message: str, user_id: int, conte
 
     emit(StartEvent(session_id))
     try:
-        executor = build_agent_executor(user=user, streaming=True)
-        # Scope streamed tool-status events to the agent's real tools (drops the internal
-        # "_Exception" pseudo-tool that handle_parsing_errors raises on malformed model output).
-        handler = ChatStreamingCallbackHandler(
+        chat_agent = build_agent(user=user, page_context=derive_page_context(context_url))
+        # Stream the run to the WebSocket. tool_names scopes which tool calls become a chat.status.
+        consumer = ChatStreamConsumer(
             user_id=user_id,
             session_id=session_id,
-            tool_names={tool.name for tool in executor.tools},
+            tool_names=chat_agent.tool_names,
         )
-        result = executor.invoke(
-            {
-                "input": user_message,
-                "chat_history": chat_history,
-                "page_context": derive_page_context(context_url),
-            },
-            config={"callbacks": [handler]},
-        )
+        # History (snapshotted before this turn is persisted) + the new user message feed the agent
+        # as a messages list, the create_agent input shape.
+        inputs = {"messages": [*chat_history, HumanMessage(content=user_message)]}
+        response_text = consumer.run(chat_agent.runnable, inputs, {"recursion_limit": RECURSION_LIMIT})
     except SoftTimeLimitExceeded:
         logger.warning(f"process_chat_message: timed out for session {session_id}")
         emit(ErrorEvent(session_id, ChatErrorDetail.TIMEOUT.value))
         return
+    except GraphRecursionError:
+        # A looping model hit the recursion limit: surface a real error and drop the turn rather
+        # than persisting a partial/looping run as the assistant's answer.
+        logger.warning(f"process_chat_message: iteration cap hit for session {session_id}")
+        emit(ErrorEvent(session_id, ChatErrorDetail.ITERATION_LIMIT.value))
+        return
     except Exception as exc:  # noqa: BLE001 - any agent/Ollama failure must still reach the client
         logger.exception(f"process_chat_message: agent run failed for session {session_id}: {exc}")
         emit(ErrorEvent(session_id, ChatErrorDetail.UNAVAILABLE.value))
-        return
-
-    response_text = result.get("output", "")
-    if response_text == AGENT_STOPPED_OUTPUT:
-        # max_iterations force-stopped a looping model: surface a real error and drop the
-        # turn rather than persisting LangChain's canned string as the assistant's answer.
-        logger.warning(f"process_chat_message: iteration cap hit for session {session_id}")
-        emit(ErrorEvent(session_id, ChatErrorDetail.ITERATION_LIMIT.value))
         return
 
     history.add_user_message(user_message)

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -6,6 +6,8 @@ import logging
 from django.db.models import OuterRef, Subquery
 from django.db.models.functions import Substr
 from django.utils.timezone import now
+from langchain_core.messages import HumanMessage
+from langgraph.errors import GraphRecursionError
 from rest_framework import status
 from rest_framework.decorators import action
 from rest_framework.generics import get_object_or_404
@@ -17,7 +19,7 @@ from rest_framework.viewsets import ModelViewSet
 from api_app.playbooks_manager.models import PlaybookConfig
 from api_app.serializers.job import ObservableAnalysisSerializer
 
-from .agent.agent import AGENT_STOPPED_OUTPUT, build_agent_executor
+from .agent.agent import RECURSION_LIMIT, build_agent, final_answer
 from .agent.memory import DjangoChatMessageHistory
 from .events import ChatErrorDetail
 from .health import chatbot_health
@@ -109,10 +111,20 @@ class ChatSessionViewSet(ModelViewSet):
 
         history = DjangoChatMessageHistory(session=session)
 
-        executor = build_agent_executor(user=request.user)
+        chat_agent = build_agent(user=request.user)
+        # No page_context on the REST path (unchanged): the browser chat panel drives page context
+        # over the WebSocket. History + the new user message feed the agent as a messages list.
+        inputs = {"messages": [*history.messages, HumanMessage(content=user_message)]}
         try:
-            result = executor.invoke(
-                {"input": user_message, "chat_history": history.messages, "page_context": ""}
+            result = chat_agent.runnable.invoke(inputs, config={"recursion_limit": RECURSION_LIMIT})
+        except GraphRecursionError:
+            # A looping model hit the recursion limit; surface a clean 503 instead of persisting a
+            # partial run. session_id rides the error so a client that created the session here can
+            # keep using it.
+            logger.warning(f"chatbot message: iteration cap hit for session {session.pk}")
+            return Response(
+                {"detail": ChatErrorDetail.ITERATION_LIMIT.value, "session_id": session.pk},
+                status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         except Exception:  # noqa: BLE001 - any agent/Ollama failure must reach the client cleanly
             # Mirror the Celery path (tasks.py): a model/Ollama failure is surfaced as a clean
@@ -123,13 +135,7 @@ class ChatSessionViewSet(ModelViewSet):
                 {"detail": ChatErrorDetail.UNAVAILABLE.value, "session_id": session.pk},
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
-        response_text = result.get("output", "")
-        if response_text == AGENT_STOPPED_OUTPUT:
-            logger.warning(f"chatbot message: iteration cap hit for session {session.pk}")
-            return Response(
-                {"detail": ChatErrorDetail.ITERATION_LIMIT.value, "session_id": session.pk},
-                status=status.HTTP_503_SERVICE_UNAVAILABLE,
-            )
+        response_text = final_answer(result["messages"])
 
         history.add_user_message(user_message)
         history.add_ai_message(response_text)

--- a/requirements/project-requirements.txt
+++ b/requirements/project-requirements.txt
@@ -112,8 +112,8 @@ defusedxml==0.7.1
 pyzipper==0.3.6
 
 # LangChain / Ollama
-langchain==0.3.30
-langchain-ollama==0.3.3
+langchain==1.3.11
+langchain-ollama==1.1.0
 
 # others
 dateparser==1.2.0

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -1,19 +1,26 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-from unittest.mock import MagicMock, patch
+from typing import Any, Optional
+from unittest.mock import patch
 
 from django.conf import settings
 from django.test import TestCase
-from langchain_core.messages import AIMessage
-from langchain_core.runnables import RunnableLambda
+from langchain_core.callbacks import CallbackManagerForLLMRun
+from langchain_core.language_models.chat_models import BaseChatModel
+from langchain_core.messages import AIMessage, BaseMessage
+from langchain_core.outputs import ChatGeneration, ChatResult
+from langgraph.errors import GraphRecursionError
+from pydantic import PrivateAttr
 
 from api_app.chatbot_manager.agent.agent import (
     _MAX_AGENT_ITERATIONS,
     _NUM_CTX,
     _SYSTEM_PROMPT,
-    AGENT_STOPPED_OUTPUT,
-    build_agent_executor,
+    RECURSION_LIMIT,
+    ChatAgent,
+    build_agent,
+    final_answer,
 )
 from api_app.chatbot_manager.agent.tools._common import on_invalid_tool_args
 from certego_saas.apps.user.models import User
@@ -33,55 +40,218 @@ EXPECTED_TOOL_NAMES = {
 }
 
 
-class BuildAgentExecutorTestCase(TestCase):
-    """The executor wires the full user-scoped tool registry and bounds the agent loop."""
+class _ScriptedChatModel(BaseChatModel):
+    """Fake chat model that replays a scripted list of AIMessages, one per agent round.
+
+    Stands in for ChatOllama inside ``create_agent`` without Ollama: ``bind_tools`` is a no-op
+    (the responses are scripted, not derived from the bound tools) and each ``_generate`` returns
+    the next scripted message (the last one repeats once the script is exhausted). Distinct message
+    ids per round keep LangGraph's ``add_messages`` reducer appending rather than de-duplicating.
+    """
+
+    responses: list
+    _i: int = PrivateAttr(default=0)
+
+    @property
+    def _llm_type(self) -> str:
+        return "scripted-test"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        message = self.responses[min(self._i, len(self.responses) - 1)]
+        self._i += 1
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+class _LoopingChatModel(BaseChatModel):
+    """Fake chat model that NEVER stops: it re-calls one tool every round with a FRESH tool-call
+    id (like a real model), so the run is a genuine runaway that force-stops at ``recursion_limit``
+    rather than being collapsed by the id-deduping reducer.
+    """
+
+    tool_name: str
+    tool_args: dict
+    _i: int = PrivateAttr(default=0)
+
+    @property
+    def _llm_type(self) -> str:
+        return "looping-test"
+
+    def bind_tools(self, tools, **kwargs):
+        return self
+
+    def _generate(
+        self,
+        messages: list[BaseMessage],
+        stop: Optional[list[str]] = None,
+        run_manager: Optional[CallbackManagerForLLMRun] = None,
+        **kwargs: Any,
+    ) -> ChatResult:
+        self._i += 1
+        message = AIMessage(
+            content="",
+            tool_calls=[{"name": self.tool_name, "args": self.tool_args, "id": f"call_{self._i}"}],
+        )
+        return ChatResult(generations=[ChatGeneration(message=message)])
+
+
+class BuildAgentTestCase(TestCase):
+    """``build_agent`` wires the full user-scoped tool registry and configures the local LLM."""
 
     def setUp(self):
         self.user, _ = User.objects.get_or_create(username="chatbot_agent_user")
 
     def _build(self, **kwargs):
-        # ChatOllama is mocked so no Ollama/network is ever touched; create_tool_calling_agent
-        # only needs the mock's bind_tools() result to be composable into its runnable chain.
+        # ChatOllama is mocked so no Ollama/network is ever touched; create_agent only needs the
+        # mock's bind_tools() result to assemble the graph (it is not invoked here).
         with patch("api_app.chatbot_manager.agent.agent.ChatOllama") as mock_llm_cls:
-            executor = build_agent_executor(user=self.user, **kwargs)
-        return executor, mock_llm_cls
+            chat_agent = build_agent(user=self.user, **kwargs)
+        return chat_agent, mock_llm_cls
 
-    def test_executor_has_all_tools_and_a_bounded_loop(self):
-        executor, _ = self._build()
+    def test_agent_exposes_the_full_tool_registry(self):
+        chat_agent, _ = self._build()
+        self.assertIsInstance(chat_agent, ChatAgent)
+        self.assertEqual(set(chat_agent.tool_names), EXPECTED_TOOL_NAMES)
 
-        self.assertEqual({tool.name for tool in executor.tools}, EXPECTED_TOOL_NAMES)
-        # max_iterations is the only bound that force-stops a looping model
-        self.assertEqual(executor.max_iterations, _MAX_AGENT_ITERATIONS)
-        self.assertTrue(executor.handle_parsing_errors)
+    def test_llm_is_configured_for_local_ollama(self):
+        _, mock_llm_cls = self._build()
+        llm_kwargs = mock_llm_cls.call_args.kwargs
+        self.assertEqual(llm_kwargs["model"], settings.OLLAMA_MODEL)
+        self.assertEqual(llm_kwargs["base_url"], settings.OLLAMA_BASE_URL)
+        self.assertEqual(llm_kwargs["temperature"], 0)
+        # without an explicit context window Ollama truncates the multi-tool prompt
+        self.assertEqual(llm_kwargs["num_ctx"], _NUM_CTX)
 
-    def test_streaming_flag_reaches_the_llm(self):
-        for streaming in (False, True):
-            with self.subTest(streaming=streaming):
-                _, mock_llm_cls = self._build(streaming=streaming)
-                llm_kwargs = mock_llm_cls.call_args.kwargs
-                self.assertEqual(llm_kwargs["streaming"], streaming)
-                self.assertEqual(llm_kwargs["model"], settings.OLLAMA_MODEL)
-                self.assertEqual(llm_kwargs["base_url"], settings.OLLAMA_BASE_URL)
-                # without an explicit context window Ollama truncates the multi-tool prompt
-                self.assertEqual(llm_kwargs["num_ctx"], _NUM_CTX)
+    def test_recursion_limit_maps_from_agent_rounds(self):
+        # LangGraph counts supersteps, not agent rounds: one tool round is model->tools->model
+        # (2 supersteps) plus the terminal model reply, plus LangGraph's boundary off-by-one.
+        self.assertEqual(RECURSION_LIMIT, 2 * _MAX_AGENT_ITERATIONS + 2)
 
-    def test_forced_stop_output_matches_the_sentinel(self):
-        # Ties AGENT_STOPPED_OUTPUT to the real framework behavior: the executor is the real
-        # tool-calling pipeline, only the LLM is faked to request a tool on every round, so
-        # max_iterations force-stops it. A langchain bump that changes the canned stop message
-        # must fail here rather than silently persist it as an assistant answer.
-        tool_call_forever = AIMessage(
-            content="",
-            tool_calls=[{"name": "search_jobs", "args": {"query": ""}, "id": "call_1"}],
+    def test_page_context_is_baked_into_the_system_prompt(self):
+        with (
+            patch("api_app.chatbot_manager.agent.agent.ChatOllama"),
+            patch("api_app.chatbot_manager.agent.agent.create_agent") as mock_create,
+        ):
+            build_agent(user=self.user, page_context="The user is viewing job #42.")
+            with_ctx = mock_create.call_args.kwargs["system_prompt"]
+            build_agent(user=self.user)
+            without_ctx = mock_create.call_args.kwargs["system_prompt"]
+        self.assertIn(_SYSTEM_PROMPT, with_ctx)
+        self.assertIn("The user is viewing job #42.", with_ctx)
+        # no context -> exactly the base prompt (no dangling separator)
+        self.assertEqual(without_ctx, _SYSTEM_PROMPT)
+
+
+class AgentRunTestCase(TestCase):
+    """End-to-end runs of the real create_agent graph with a scripted (Ollama-free) model."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_run_user")
+
+    def _agent_with_model(self, fake_model):
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=fake_model):
+            return build_agent(user=self.user)
+
+    def _run(self, fake_model, message="hello"):
+        chat_agent = self._agent_with_model(fake_model)
+        return chat_agent.runnable.invoke(
+            {"messages": [{"role": "user", "content": message}]},
+            config={"recursion_limit": RECURSION_LIMIT},
         )
-        llm = MagicMock()
-        llm.bind_tools.return_value = RunnableLambda(lambda _: tool_call_forever)
-        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
-            executor = build_agent_executor(user=self.user)
 
-        result = executor.invoke({"input": "loop forever", "chat_history": [], "page_context": ""})
+    def test_legit_conversation_completes_under_the_limit(self):
+        # one tool round then a plain-text answer -> the run terminates well within RECURSION_LIMIT.
+        call = AIMessage(content="", tool_calls=[{"name": "search_jobs", "args": {"limit": 5}, "id": "c1"}])
+        answer = AIMessage(content="You have no recent jobs. (used: search_jobs)")
+        result = self._run(_ScriptedChatModel(responses=[call, answer]), message="show my recent jobs")
+        self.assertEqual(final_answer(result["messages"]), "You have no recent jobs. (used: search_jobs)")
 
-        self.assertEqual(result["output"], AGENT_STOPPED_OUTPUT)
+    def test_runaway_model_force_stops_at_recursion_limit(self):
+        # Authoritative bound for RECURSION_LIMIT: a model that keeps calling a tool must raise
+        # GraphRecursionError (the caller maps it to ITERATION_LIMIT) instead of looping forever.
+        looping = _LoopingChatModel(tool_name="search_jobs", tool_args={"limit": 5})
+        chat_agent = self._agent_with_model(looping)
+        with self.assertRaises(GraphRecursionError):
+            chat_agent.runnable.invoke(
+                {"messages": [{"role": "user", "content": "loop"}]},
+                config={"recursion_limit": RECURSION_LIMIT},
+            )
+
+
+class FinalAnswerTestCase(TestCase):
+    """`final_answer` returns the terminal assistant text, and only that."""
+
+    def test_returns_last_ai_message_text(self):
+        messages = [
+            AIMessage(content="", tool_calls=[{"name": "x", "args": {}, "id": "1"}]),
+            AIMessage(content="done"),
+        ]
+        self.assertEqual(final_answer(messages), "done")
+
+    def test_empty_when_terminal_message_still_has_tool_calls(self):
+        # defensive: a terminal message with tool calls is not a real answer.
+        messages = [AIMessage(content="partial", tool_calls=[{"name": "x", "args": {}, "id": "1"}])]
+        self.assertEqual(final_answer(messages), "")
+
+
+class ToolArgRecoveryTestCase(TestCase):
+    """A schema-invalid tool argument is recoverable, never a turn-killing exception."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_arg_recovery_user")
+
+    def test_all_tools_handle_validation_errors(self):
+        from api_app.chatbot_manager.agent.tools import build_tools
+
+        for tool in build_tools(user=self.user):
+            self.assertEqual(tool.handle_validation_error, on_invalid_tool_args)
+
+    def test_invalid_tool_arg_is_recoverable_not_fatal(self):
+        # round 1: model passes the literal placeholder -> ValidationError on job_id (an int),
+        # surfaced as an on_invalid_tool_args observation. round 2: model answers in plain text.
+        from langchain_core.messages import ToolMessage
+
+        bad = AIMessage(
+            content="", tool_calls=[{"name": "summarize_job", "args": {"job_id": "<job_id>"}, "id": "c1"}]
+        )
+        answer = AIMessage(content="Here is the summary.")
+        with patch(
+            "api_app.chatbot_manager.agent.agent.ChatOllama",
+            return_value=_ScriptedChatModel(responses=[bad, answer]),
+        ):
+            chat_agent = build_agent(user=self.user)
+        result = chat_agent.runnable.invoke(
+            {"messages": [{"role": "user", "content": "summarize my latest job"}]},
+            config={"recursion_limit": RECURSION_LIMIT},
+        )
+        self.assertEqual(final_answer(result["messages"]), "Here is the summary.")
+        observation = next(m for m in result["messages"] if isinstance(m, ToolMessage))
+        self.assertIn("Invalid tool arguments", observation.content)
+
+    def test_persistent_invalid_arg_degrades_to_forced_stop(self):
+        # The model emits the bad placeholder on every round: instead of crashing it must
+        # force-stop at recursion_limit (GraphRecursionError -> ITERATION_LIMIT for the caller).
+        looping = _LoopingChatModel(tool_name="summarize_job", tool_args={"job_id": "<job_id>"})
+        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=looping):
+            chat_agent = build_agent(user=self.user)
+        with self.assertRaises(GraphRecursionError):
+            chat_agent.runnable.invoke(
+                {"messages": [{"role": "user", "content": "summarize my latest job"}]},
+                config={"recursion_limit": RECURSION_LIMIT},
+            )
+
+    def test_system_prompt_warns_against_placeholder_args(self):
+        # guard the specific rule, not just the word: the <job_id> token appears only in it
+        self.assertIn("<job_id>", _SYSTEM_PROMPT)
+        self.assertIn("placeholder", _SYSTEM_PROMPT.lower())
 
 
 class OnInvalidToolArgsTestCase(TestCase):
@@ -92,57 +262,3 @@ class OnInvalidToolArgsTestCase(TestCase):
         self.assertIsInstance(msg, str)
         self.assertIn("job_id: not an integer", msg)  # the underlying error reaches the model
         self.assertIn("placeholder", msg.lower())  # tell it not to pass a placeholder
-
-
-def _scripted_llm(responses):
-    """Fake ChatOllama whose bound runnable replays `responses`, one AIMessage per agent round."""
-    replies = iter(responses)
-    llm = MagicMock()
-    # next() takes a default so an exhausted script can't raise StopIteration (DeepSource PTC-W0063):
-    # returning a plain-text AIMessage ends the agent loop benignly instead of crashing the test.
-    llm.bind_tools.return_value = RunnableLambda(lambda _: next(replies, AIMessage(content="")))
-    return llm
-
-
-class ToolArgRecoveryTestCase(TestCase):
-    """A schema-invalid tool argument is recoverable, never a turn-killing exception."""
-
-    def setUp(self):
-        self.user, _ = User.objects.get_or_create(username="chatbot_arg_recovery_user")
-
-    def test_all_tools_handle_validation_errors(self):
-        with patch("api_app.chatbot_manager.agent.agent.ChatOllama"):
-            executor = build_agent_executor(user=self.user)
-        for tool in executor.tools:
-            self.assertEqual(tool.handle_validation_error, on_invalid_tool_args)
-
-    def test_invalid_tool_arg_is_recoverable_not_fatal(self):
-        # round 1: model passes the literal placeholder -> ValidationError on job_id (an int).
-        # round 2: model answers in plain text. The turn must complete, not raise.
-        bad = AIMessage(
-            content="", tool_calls=[{"name": "summarize_job", "args": {"job_id": "<job_id>"}, "id": "c1"}]
-        )
-        answer = AIMessage(content="Here is the summary.")
-        llm = _scripted_llm([bad, answer])
-        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
-            executor = build_agent_executor(user=self.user)
-        result = executor.invoke({"input": "summarize my latest job", "chat_history": [], "page_context": ""})
-        self.assertEqual(result["output"], "Here is the summary.")
-
-    def test_persistent_invalid_arg_degrades_to_forced_stop(self):
-        # The model emits the bad placeholder on every round: instead of crashing it must
-        # force-stop at max_iterations (the sentinel the caller maps to ITERATION_LIMIT).
-        bad = AIMessage(
-            content="", tool_calls=[{"name": "summarize_job", "args": {"job_id": "<job_id>"}, "id": "c1"}]
-        )
-        llm = MagicMock()
-        llm.bind_tools.return_value = RunnableLambda(lambda _: bad)
-        with patch("api_app.chatbot_manager.agent.agent.ChatOllama", return_value=llm):
-            executor = build_agent_executor(user=self.user)
-        result = executor.invoke({"input": "summarize my latest job", "chat_history": [], "page_context": ""})
-        self.assertEqual(result["output"], AGENT_STOPPED_OUTPUT)
-
-    def test_system_prompt_warns_against_placeholder_args(self):
-        # guard the specific rule, not just the word: the <job_id> token appears only in it
-        self.assertIn("<job_id>", _SYSTEM_PROMPT)
-        self.assertIn("placeholder", _SYSTEM_PROMPT.lower())

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -233,8 +233,10 @@ class ToolArgRecoveryTestCase(TestCase):
             config={"recursion_limit": RECURSION_LIMIT},
         )
         self.assertEqual(final_answer(result["messages"]), "Here is the summary.")
-        observation = next(m for m in result["messages"] if isinstance(m, ToolMessage))
-        self.assertIn("Invalid tool arguments", observation.content)
+        # index (not next()) so a missing observation fails loudly here, not with a bare StopIteration
+        observations = [m for m in result["messages"] if isinstance(m, ToolMessage)]
+        self.assertTrue(observations)
+        self.assertIn("Invalid tool arguments", observations[0].content)
 
     def test_persistent_invalid_arg_degrades_to_forced_stop(self):
         # The model emits the bad placeholder on every round: instead of crashing it must

--- a/tests/api_app/chatbot_manager/test_e2e.py
+++ b/tests/api_app/chatbot_manager/test_e2e.py
@@ -4,8 +4,8 @@
 """End-to-end tests of the chatbot chat pipeline.
 
 These wire the *real* components together — ChatConsumer, the process_chat_message Celery task,
-ChatStreamingCallbackHandler, the analyze_observable tool, the pending-action store and the
-confirm endpoint — and mock only the external boundaries: the LLM (via build_agent_executor) and
+ChatStreamConsumer, the analyze_observable tool, the pending-action store and the
+confirm endpoint — and mock only the external boundaries: the LLM (via build_agent) and
 the job pipeline (apply_async). Ollama and the network are never touched.
 
 Transport: the consumer leg does NOT use WebsocketCommunicator. A synchronous JsonWebsocketConsumer
@@ -21,6 +21,7 @@ from unittest.mock import MagicMock, patch
 
 from django.core.cache import caches
 from django.test import TestCase, override_settings
+from langchain_core.messages import AIMessage, AIMessageChunk, HumanMessage, ToolMessage
 from rest_framework import status
 from rest_framework.test import APIClient
 
@@ -62,33 +63,61 @@ class _CapturingChannelLayer:
         pass
 
 
-def _fake_tool_calling_executor(user):
-    """A stand-in AgentExecutor whose .invoke() drives the REAL streaming callbacks exactly as a
-    tool-calling turn would: a tool action (chat.status), the real analyze_observable tool output
-    (chat.action_required, carrying a real one-time pending_id), a streamed answer token
-    (chat.token), then the final output. Keeps the handler, the tool and the pending-action store
-    real while Ollama is never reached."""
+def _fake_agent(user):
+    """A stand-in ChatAgent whose runnable.stream() drives the REAL stream consumer exactly as a
+    tool-calling turn would: a tool-call chunk (chat.status), the real analyze_observable tool output
+    as a ToolMessage (chat.action_required, carrying a real one-time pending_id), a streamed answer
+    token (chat.token), then the terminal state (persisted answer). Keeps the consumer, the tool and
+    the pending-action store real while Ollama is never reached."""
     real_tools = build_tools(user=user)
     # dict lookup (not next()) so a missing tool fails loudly with a KeyError naming it
     analyze_tool = {tool.name: tool for tool in real_tools}["analyze_observable"]
 
-    class _FakeExecutor:
-        # The task derives handler.tool_names from this real registry, so the chat.status filter
-        # (which suppresses the _Exception pseudo-tool) is exercised against real tool names.
-        tools = real_tools
-
+    class _FakeRunnable:
         @staticmethod
-        def invoke(payload, config=None):
-            handler = config["callbacks"][0]
-            # SimpleNamespace mirrors a langchain AgentAction's .tool attribute.
-            handler.on_agent_action(SimpleNamespace(tool="analyze_observable", tool_input={}, log=""))
+        def stream(inputs, stream_mode=None, config=None):
+            # tool decision -> chat.status (tool_call_chunks carry the name)
+            yield (
+                "messages",
+                (
+                    AIMessageChunk(
+                        content="",
+                        id="m1",
+                        tool_call_chunks=[
+                            {
+                                "name": "analyze_observable",
+                                "args": "",
+                                "id": "c1",
+                                "index": 0,
+                                "type": "tool_call_chunk",
+                            }
+                        ],
+                    ),
+                    {"langgraph_node": "model"},
+                ),
+            )
             # Real tool run: validates the observable and mints a real pending_id in the cache.
             tool_output = analyze_tool.invoke({"observable_name": "example.com", "analyzers": "Tranco"})
-            handler.on_tool_end(tool_output)
-            handler.on_llm_new_token("Prepared the analysis plan. ")
-            return {"output": _ASSISTANT_OUTPUT}
+            yield (
+                "messages",
+                (ToolMessage(content=tool_output, name="analyze_observable", tool_call_id="c1"), {}),
+            )
+            # streamed answer token -> chat.token
+            yield ("messages", (AIMessageChunk(content="Prepared the analysis plan. ", id="m2"), {}))
+            # terminal state -> the persisted answer sent in chat.end
+            yield (
+                "values",
+                {
+                    "messages": [
+                        HumanMessage(content="analyze example.com"),
+                        AIMessage(content=_ASSISTANT_OUTPUT),
+                    ]
+                },
+            )
 
-    return _FakeExecutor()
+    # The task derives the chat.status filter from this real registry, so it is exercised against
+    # real tool names.
+    return SimpleNamespace(runnable=_FakeRunnable(), tool_names=frozenset(tool.name for tool in real_tools))
 
 
 def _connected_consumer(user, channel_layer):
@@ -132,8 +161,8 @@ class ChatPipelineE2ETestCase(TestCase):
         consumer = _connected_consumer(self.user, layer)
         with (
             patch(
-                "api_app.chatbot_manager.agent.agent.build_agent_executor",
-                return_value=_fake_tool_calling_executor(self.user),
+                "api_app.chatbot_manager.agent.agent.build_agent",
+                return_value=_fake_agent(self.user),
             ),
             patch("api_app.chatbot_manager.tasks.get_channel_layer", return_value=layer),
             patch("api_app.chatbot_manager.agent.streaming.get_channel_layer", return_value=layer),

--- a/tests/api_app/chatbot_manager/test_prompt.py
+++ b/tests/api_app/chatbot_manager/test_prompt.py
@@ -8,10 +8,11 @@ and covers all registered tools — no LLM inference is performed.
 """
 
 from pathlib import Path
+from unittest.mock import patch
 
 from django.test import TestCase
 
-from api_app.chatbot_manager.agent.agent import _SYSTEM_PROMPT, PROMPT
+from api_app.chatbot_manager.agent.agent import _SYSTEM_PROMPT, build_agent
 from api_app.chatbot_manager.agent.tools import build_tools
 from certego_saas.apps.user.models import User
 
@@ -78,15 +79,17 @@ class SystemPromptTestCase(TestCase):
                 f"Tool '{name}' not found in system_prompt.txt — add it to the [Tools] section",
             )
 
-    def test_prompt_is_part_of_the_chat_template(self):
-        """The loaded prompt content is embedded in the ChatPromptTemplate's
-        system message, so the agent actually sees the file content at runtime.
+    def test_prompt_is_passed_to_the_agent(self):
+        """build_agent hands the file content to create_agent as the system prompt, so the agent
+        actually sees it at runtime (ChatOllama/create_agent are mocked — no Ollama is touched).
         """
-        # PROMPT.messages[0] is a SystemMessagePromptTemplate; its .prompt.template
-        # carries the system text (with {page_context} appended).
-        system_msg = PROMPT.messages[0]
-        template = system_msg.prompt.template
-        self.assertIn(_SYSTEM_PROMPT, template)
+        user, _ = User.objects.get_or_create(username="prompt_build_user")
+        with (
+            patch("api_app.chatbot_manager.agent.agent.ChatOllama"),
+            patch("api_app.chatbot_manager.agent.agent.create_agent") as mock_create,
+        ):
+            build_agent(user=user)
+        self.assertIn(_SYSTEM_PROMPT, mock_create.call_args.kwargs["system_prompt"])
 
     def test_prompt_sections_are_present(self):
         """Each planned section header appears so the structure is enforced."""

--- a/tests/api_app/chatbot_manager/test_query_counts.py
+++ b/tests/api_app/chatbot_manager/test_query_counts.py
@@ -14,6 +14,7 @@ validation (platform code resolving analyzers/playbooks/connectors), not the cha
 so a guard there would be a brittle measure of someone else's query plan.
 """
 
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 from uuid import uuid4
 
@@ -251,15 +252,21 @@ class ChatTaskQueryCountTestCase(TestCase):
         self.session = ChatSession.objects.create(user=self.user)
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_process_chat_message_query_count_is_constant_in_history(self, mock_build, mock_get_layer):
+        from langchain_core.messages import AIMessage
+
         layer = MagicMock()
         layer.group_send = AsyncMock()
         mock_get_layer.return_value = layer
-        executor = MagicMock()
-        executor.invoke.return_value = {"output": "ok"}
-        executor.tools = []  # handler.tool_names = set(); no real tools needed
-        mock_build.return_value = executor
+
+        class _FakeRunnable:
+            # streams only the terminal state (no real tools / DB work), so the query count
+            # reflects the task's own history load + persistence, not the agent internals.
+            def stream(self, inputs, stream_mode=None, config=None):
+                yield ("values", {"messages": [AIMessage(content="ok")]})
+
+        mock_build.return_value = SimpleNamespace(runnable=_FakeRunnable(), tool_names=frozenset())
 
         # Each call persists one user + one assistant message, so history grows naturally.
         process_chat_message(self.session.id, "hi", self.user.id)  # warm up

--- a/tests/api_app/chatbot_manager/test_query_counts.py
+++ b/tests/api_app/chatbot_manager/test_query_counts.py
@@ -263,7 +263,8 @@ class ChatTaskQueryCountTestCase(TestCase):
         class _FakeRunnable:
             # streams only the terminal state (no real tools / DB work), so the query count
             # reflects the task's own history load + persistence, not the agent internals.
-            def stream(self, inputs, stream_mode=None, config=None):
+            @staticmethod
+            def stream(inputs, stream_mode=None, config=None):
                 yield ("values", {"messages": [AIMessage(content="ok")]})
 
         mock_build.return_value = SimpleNamespace(runnable=_FakeRunnable(), tool_names=frozenset())

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -50,7 +50,8 @@ def _values_payload(final_text):
 class ChatStreamConsumerTestCase(SimpleTestCase):
     """The consumer streams answer text, one status per tool call, and the guardrail action."""
 
-    def _make_consumer(self, tool_names=None):
+    @staticmethod
+    def _make_consumer(tool_names=None):
         consumer = ChatStreamConsumer(user_id=USER_ID, session_id=SESSION_ID, tool_names=tool_names)
         layer = MagicMock()
         layer.group_send = AsyncMock()

--- a/tests/api_app/chatbot_manager/test_streaming.py
+++ b/tests/api_app/chatbot_manager/test_streaming.py
@@ -1,111 +1,189 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-from unittest.mock import AsyncMock, MagicMock, patch
+import json
+from unittest.mock import AsyncMock, MagicMock
 
 from django.test import SimpleTestCase
+from langchain_core.messages import AIMessage, AIMessageChunk, ToolMessage
 
 from api_app.chatbot_manager import events
-from api_app.chatbot_manager.agent.streaming import ChatStreamingCallbackHandler
+from api_app.chatbot_manager.agent.streaming import ChatStreamConsumer
 
 USER_ID = 7
 SESSION_ID = 3
 
 
-class ChatStreamingCallbackHandlerTestCase(SimpleTestCase):
-    """The callback streams answer text and a status per tool action."""
+def _ai_text(content, msg_id="m1"):
+    return AIMessageChunk(content=content, id=msg_id)
 
-    def _make_handler(self, tool_names=None):
-        handler = ChatStreamingCallbackHandler(user_id=USER_ID, session_id=SESSION_ID, tool_names=tool_names)
+
+def _ai_tool_call(name, msg_id="m1", index=0, args=""):
+    return AIMessageChunk(
+        content="",
+        id=msg_id,
+        tool_call_chunks=[
+            {"name": name, "args": args, "id": "c1", "index": index, "type": "tool_call_chunk"}
+        ],
+    )
+
+
+class _FakeRunnable:
+    """Replays a scripted list of (mode, payload) tuples as create_agent's dual-mode stream."""
+
+    def __init__(self, items):
+        self._items = items
+
+    def stream(self, inputs, stream_mode=None, config=None):
+        assert stream_mode == ["messages", "values"]
+        yield from self._items
+
+
+def _messages_payload(*chunks):
+    return [("messages", (chunk, {"langgraph_node": "model"})) for chunk in chunks]
+
+
+def _values_payload(final_text):
+    return ("values", {"messages": [AIMessage(content=final_text)]})
+
+
+class ChatStreamConsumerTestCase(SimpleTestCase):
+    """The consumer streams answer text, one status per tool call, and the guardrail action."""
+
+    def _make_consumer(self, tool_names=None):
+        consumer = ChatStreamConsumer(user_id=USER_ID, session_id=SESSION_ID, tool_names=tool_names)
         layer = MagicMock()
         layer.group_send = AsyncMock()
-        handler._channel_layer = layer
-        return handler, layer
+        consumer._channel_layer = layer
+        return consumer, layer
 
     @staticmethod
-    def _messages(layer):
-        # each group_send call is (group, channel_message)
+    def _sent(layer):
         return [call.args for call in layer.group_send.call_args_list]
 
     def test_text_tokens_stream_in_order(self):
-        handler, layer = self._make_handler()
-        for token in ["Hello", " world"]:
-            handler.on_llm_new_token(token)
+        consumer, layer = self._make_consumer()
+        consumer.run(_FakeRunnable(_messages_payload(_ai_text("Hello"), _ai_text(" world"))), {}, {})
 
         group = events.chat_group_for_user(USER_ID)
         self.assertEqual(
-            self._messages(layer),
+            self._sent(layer),
             [
                 (group, events.TokenEvent(SESSION_ID, "Hello").as_channel_message()),
                 (group, events.TokenEvent(SESSION_ID, " world").as_channel_message()),
             ],
         )
 
-    def test_empty_tokens_are_not_streamed(self):
-        # A tool-call delta reaches on_llm_new_token with empty text (the call itself rides
-        # tool_call_chunks); nothing may hit the wire for it.
-        handler, layer = self._make_handler()
-        for token in ["", "", ""]:
-            handler.on_llm_new_token(token)
-
+    def test_empty_text_chunks_are_not_streamed(self):
+        # A tool-call delta carries empty text (the call rides tool_call_chunks); nothing hits the
+        # wire for its text.
+        consumer, layer = self._make_consumer()
+        consumer.run(_FakeRunnable(_messages_payload(_ai_text(""), _ai_text(""))), {}, {})
         layer.group_send.assert_not_called()
 
     def test_mixed_stream_forwards_only_text(self):
-        # A turn that starts with tool-call deltas and ends with the streamed answer.
-        handler, layer = self._make_handler()
-        for token in ["", "", "The", " answer"]:
-            handler.on_llm_new_token(token)
-
-        contents = [m[1]["payload"]["content"] for m in self._messages(layer)]
+        consumer, layer = self._make_consumer()
+        consumer.run(
+            _FakeRunnable(_messages_payload(_ai_text(""), _ai_text("The"), _ai_text(" answer"))), {}, {}
+        )
+        contents = [m[1]["payload"]["content"] for m in self._sent(layer)]
         self.assertEqual(contents, ["The", " answer"])
 
-    def test_agent_action_emits_status_event_with_tool_name(self):
-        handler, layer = self._make_handler()
-        action = MagicMock()
-        action.tool = "search_jobs"
-
-        handler.on_agent_action(action)
-
+    def test_tool_call_emits_one_status_with_the_tool_name(self):
+        consumer, layer = self._make_consumer()
+        consumer.run(_FakeRunnable(_messages_payload(_ai_tool_call("search_jobs"))), {}, {})
         self.assertEqual(
-            self._messages(layer)[0],
+            self._sent(layer)[0],
             (
                 events.chat_group_for_user(USER_ID),
                 events.StatusEvent(SESSION_ID, "search_jobs").as_channel_message(),
             ),
         )
 
-    def test_agent_action_for_unregistered_tool_is_suppressed(self):
-        # With a real tool registry, LangChain's "_Exception" parse-error pseudo-tool (and any
-        # raw malformed model output as a "tool") must not leak to the client as chat.status.
-        handler, layer = self._make_handler(tool_names={"search_jobs"})
+    def test_status_is_deduped_per_tool_call(self):
+        # The same tool call streams across several chunks (same message id + index, name only in
+        # the first); exactly one chat.status must be emitted for it.
+        consumer, layer = self._make_consumer()
+        first = _ai_tool_call("search_jobs", msg_id="m1", index=0)
+        cont = AIMessageChunk(
+            content="",
+            id="m1",
+            tool_call_chunks=[
+                {"name": None, "args": '{"limit":5}', "id": "c1", "index": 0, "type": "tool_call_chunk"}
+            ],
+        )
+        consumer.run(_FakeRunnable(_messages_payload(first, cont)), {}, {})
+        statuses = [
+            m for m in self._sent(layer) if m[1]["payload"]["type"] == events.ChatEventType.STATUS.value
+        ]
+        self.assertEqual(len(statuses), 1)
 
-        exception_action = MagicMock()
-        exception_action.tool = "_Exception"
-        handler.on_agent_action(exception_action)
-        layer.group_send.assert_not_called()
+    def test_sequential_tool_rounds_each_emit_a_status(self):
+        # Two separate tool calls (distinct message ids) -> two statuses, not deduped together.
+        consumer, layer = self._make_consumer()
+        consumer.run(
+            _FakeRunnable(
+                _messages_payload(
+                    _ai_tool_call("search_jobs", msg_id="m1"), _ai_tool_call("summarize_job", msg_id="m2")
+                )
+            ),
+            {},
+            {},
+        )
+        tools = [
+            m[1]["payload"]["tool"]
+            for m in self._sent(layer)
+            if m[1]["payload"]["type"] == events.ChatEventType.STATUS.value
+        ]
+        self.assertEqual(tools, ["search_jobs", "summarize_job"])
 
-        real_action = MagicMock()
-        real_action.tool = "search_jobs"
-        handler.on_agent_action(real_action)
-        layer.group_send.assert_called_once()
+    def test_unregistered_tool_status_is_suppressed(self):
+        # With a real registry, only registered tool names may surface as chat.status.
+        consumer, layer = self._make_consumer(tool_names={"search_jobs"})
+        consumer.run(
+            _FakeRunnable(
+                _messages_payload(
+                    _ai_tool_call("_Exception", msg_id="m1"), _ai_tool_call("search_jobs", msg_id="m2")
+                )
+            ),
+            {},
+            {},
+        )
+        tools = [
+            m[1]["payload"]["tool"]
+            for m in self._sent(layer)
+            if m[1]["payload"]["type"] == events.ChatEventType.STATUS.value
+        ]
+        self.assertEqual(tools, ["search_jobs"])
 
     def test_tool_output_with_pending_id_emits_action_required(self):
-        import json as _json
-
-        handler = ChatStreamingCallbackHandler(user_id=1, session_id=42)
-        with patch.object(handler, "_emit") as mock_emit:
-            handler.on_tool_end(
-                _json.dumps({"errors": [], "plan": {"observable_name": "x"}, "pending_id": "abc"}),
-                run_id="fake-run-id",
-            )
-        mock_emit.assert_called_once()
-        event = mock_emit.call_args.args[0]
-        self.assertEqual(event.pending_id, "abc")
+        consumer, layer = self._make_consumer()
+        tool_msg = ToolMessage(
+            content=json.dumps({"errors": [], "plan": {"observable_name": "x"}, "pending_id": "abc"}),
+            name="analyze_observable",
+            tool_call_id="c1",
+        )
+        consumer.run(_FakeRunnable([("messages", (tool_msg, {}))]), {}, {})
+        actions = [
+            m
+            for m in self._sent(layer)
+            if m[1]["payload"]["type"] == events.ChatEventType.ACTION_REQUIRED.value
+        ]
+        self.assertEqual(len(actions), 1)
+        self.assertEqual(actions[0][1]["payload"]["pending_id"], "abc")
 
     def test_plain_tool_output_emits_nothing(self):
-        import json as _json
+        consumer, layer = self._make_consumer()
+        tool_msg = ToolMessage(
+            content=json.dumps({"errors": [], "jobs": []}), name="search_jobs", tool_call_id="c1"
+        )
+        consumer.run(_FakeRunnable([("messages", (tool_msg, {}))]), {}, {})
+        layer.group_send.assert_not_called()
 
-        handler = ChatStreamingCallbackHandler(user_id=1, session_id=42)
-        with patch.object(handler, "_emit") as mock_emit:
-            handler.on_tool_end(_json.dumps({"errors": [], "jobs": []}), run_id="fake-run-id")
-        mock_emit.assert_not_called()
+    def test_run_returns_the_terminal_answer_from_values(self):
+        consumer, _ = self._make_consumer()
+        items = _messages_payload(_ai_text("Prepared ")) + [
+            _values_payload("Prepared the plan. Click Confirm.")
+        ]
+        answer = consumer.run(_FakeRunnable(items), {}, {})
+        self.assertEqual(answer, "Prepared the plan. Click Confirm.")

--- a/tests/api_app/chatbot_manager/test_tasks.py
+++ b/tests/api_app/chatbot_manager/test_tasks.py
@@ -2,19 +2,45 @@
 # See the file 'LICENSE' for copying permission.
 
 import datetime
+from types import SimpleNamespace
 from unittest.mock import AsyncMock, MagicMock, patch
 
 from django.test import TestCase, override_settings
 from django.utils.timezone import now
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.errors import GraphRecursionError
 
 from api_app.chatbot_manager import events
-from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
 from api_app.chatbot_manager.tasks import delete_old_chat_sessions, process_chat_message
 from certego_saas.apps.user.models import User
 
 INMEMORY_CHANNEL_LAYER = {"default": {"BACKEND": "channels.layers.InMemoryChannelLayer"}}
+
+
+class _FakeRunnable:
+    """Stand-in for the compiled agent: replays scripted (mode, payload) tuples from .stream and
+    records the call, so the task's inputs/config hand-off contract can be asserted."""
+
+    def __init__(self, items=(), raises=None):
+        self._items = items
+        self._raises = raises
+        self.stream_calls = []
+
+    def stream(self, inputs, stream_mode=None, config=None):
+        self.stream_calls.append(SimpleNamespace(inputs=inputs, stream_mode=stream_mode, config=config))
+        if self._raises is not None:
+            raise self._raises
+        yield from self._items
+
+
+def _chat_agent(items=(), raises=None):
+    runnable = _FakeRunnable(items=items, raises=raises)
+    return SimpleNamespace(runnable=runnable, tool_names=frozenset()), runnable
+
+
+def _final(text):
+    return [("values", {"messages": [AIMessage(content=text)]})]
 
 
 @override_settings(CHATBOT_MESSAGE_RETENTION_DAYS=30)
@@ -38,38 +64,30 @@ class DeleteOldChatSessionsTestCase(TestCase):
 
         self.assertEqual(delete_old_chat_sessions(), 1)
         self.assertFalse(ChatSession.objects.filter(pk=session.pk).exists())
-        # CASCADE: the session's messages must be gone too
         self.assertFalse(ChatMessage.objects.filter(pk__in=message_pks).exists())
 
     def test_keeps_recent_session(self):
         session = self._session_with_last_message(days_old=5)
-
         self.assertEqual(delete_old_chat_sessions(), 0)
         self.assertTrue(ChatSession.objects.filter(pk=session.pk).exists())
 
     def test_boundary_around_cutoff(self):
-        # retention = 30 days: __lt cutoff means strictly older than 30 days is stale.
         stale = self._session_with_last_message(days_old=31)
         fresh = self._session_with_last_message(days_old=29)
-
         self.assertEqual(delete_old_chat_sessions(), 1)
         self.assertFalse(ChatSession.objects.filter(pk=stale.pk).exists())
         self.assertTrue(ChatSession.objects.filter(pk=fresh.pk).exists())
 
     def test_empty_session_uses_created_at(self):
-        # No messages -> last_activity falls back to created_at (the Coalesce branch).
         old_empty = ChatSession.objects.create(user=self.user, created_at=now() - datetime.timedelta(days=40))
         recent_empty = ChatSession.objects.create(
             user=self.user, created_at=now() - datetime.timedelta(days=5)
         )
-
         self.assertEqual(delete_old_chat_sessions(), 1)
         self.assertFalse(ChatSession.objects.filter(pk=old_empty.pk).exists())
         self.assertTrue(ChatSession.objects.filter(pk=recent_empty.pk).exists())
 
     def test_old_session_with_recent_message_is_kept(self):
-        # Long-running session: created long ago but still active. last_activity must come
-        # from the most recent message, NOT created_at, so it must survive.
         session = ChatSession.objects.create(user=self.user, created_at=now() - datetime.timedelta(days=40))
         ChatMessage.objects.create(
             session=session,
@@ -77,7 +95,6 @@ class DeleteOldChatSessionsTestCase(TestCase):
             content="still here",
             timestamp=now() - datetime.timedelta(days=2),
         )
-
         self.assertEqual(delete_old_chat_sessions(), 0)
         self.assertTrue(ChatSession.objects.filter(pk=session.pk).exists())
 
@@ -86,8 +103,8 @@ class DeleteOldChatSessionsTestCase(TestCase):
 class ProcessChatMessageTestCase(TestCase):
     """The Celery turn persists the exchange, streams start/end, and fails closed.
 
-    The agent executor is mocked, so the LLM/Ollama is never touched; the token/status events
-    come from the agent's own callbacks (covered in test_streaming) and are not exercised here.
+    The agent is mocked, so the LLM/Ollama is never touched; token/status/action events come from
+    the stream consumer (covered in test_streaming) and are not exercised here.
     """
 
     def setUp(self):
@@ -103,16 +120,14 @@ class ProcessChatMessageTestCase(TestCase):
 
     @staticmethod
     def _event_types(layer):
-        # client-facing payload type of each group_send (start/status/token/end/error)
         return [call.args[1]["payload"]["type"] for call in layer.group_send.call_args_list]
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_persists_turn_and_streams_start_end(self, mock_build, mock_get_layer):
         layer = self._patched_layer(mock_get_layer)
-        executor = MagicMock()
-        executor.invoke.return_value = {"output": "Hi there"}
-        mock_build.return_value = executor
+        chat_agent, runnable = _chat_agent(items=_final("Hi there"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "hello", self.user.id)
 
@@ -122,12 +137,10 @@ class ProcessChatMessageTestCase(TestCase):
             .values_list("role", "content")
         )
         self.assertEqual(
-            messages,
-            [(ChatMessage.Role.USER, "hello"), (ChatMessage.Role.ASSISTANT, "Hi there")],
+            messages, [(ChatMessage.Role.USER, "hello"), (ChatMessage.Role.ASSISTANT, "Hi there")]
         )
         self.assertEqual(
-            self._event_types(layer),
-            [events.ChatEventType.START.value, events.ChatEventType.END.value],
+            self._event_types(layer), [events.ChatEventType.START.value, events.ChatEventType.END.value]
         )
 
         end_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
@@ -135,101 +148,92 @@ class ProcessChatMessageTestCase(TestCase):
         self.assertEqual(end_payload["message_id"], assistant.id)
         self.assertEqual(end_payload["content"], "Hi there")
 
-        # streaming requested on the model + callbacks attached at run level (not on the LLM)
-        self.assertTrue(mock_build.call_args.kwargs["streaming"])
-        self.assertIn("callbacks", executor.invoke.call_args.kwargs["config"])
+        # the run streams both modes with the recursion bound in config
+        from api_app.chatbot_manager.agent.agent import RECURSION_LIMIT
+
+        call = runnable.stream_calls[0]
+        self.assertEqual(call.stream_mode, ["messages", "values"])
+        self.assertEqual(call.config, {"recursion_limit": RECURSION_LIMIT})
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_prior_turns_reach_the_agent_as_messages(self, mock_build, mock_get_layer):
         self._patched_layer(mock_get_layer)
         ChatMessage.objects.create(session=self.session, role=ChatMessage.Role.USER, content="prev q")
         ChatMessage.objects.create(session=self.session, role=ChatMessage.Role.ASSISTANT, content="prev a")
-        executor = MagicMock()
-        executor.invoke.return_value = {"output": "ok"}
-        mock_build.return_value = executor
+        chat_agent, runnable = _chat_agent(items=_final("ok"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "hello", self.user.id)
 
-        # history feeds the prompt's chat_history MessagesPlaceholder directly: LangChain
-        # message objects (not pre-rendered text), snapshotted before this turn is persisted
-        # so the current message is not part of it.
-        invoke_input = executor.invoke.call_args.args[0]
-        self.assertEqual(invoke_input["input"], "hello")
+        # history + the new user message feed the agent as LangChain message objects, snapshotted
+        # before this turn is persisted so the current message is not double-counted.
+        sent_messages = runnable.stream_calls[0].inputs["messages"]
         self.assertEqual(
-            [(type(m), m.content) for m in invoke_input["chat_history"]],
-            [(HumanMessage, "prev q"), (AIMessage, "prev a")],
+            [(type(m), m.content) for m in sent_messages],
+            [(HumanMessage, "prev q"), (AIMessage, "prev a"), (HumanMessage, "hello")],
         )
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_agent_failure_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
         layer = self._patched_layer(mock_get_layer)
-        executor = MagicMock()
-        executor.invoke.side_effect = ConnectionError("ollama down")
-        mock_build.return_value = executor
+        chat_agent, _ = _chat_agent(raises=ConnectionError("ollama down"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "hello", self.user.id)
 
-        # failed turn is dropped: neither the user nor the assistant message is stored
         self.assertFalse(ChatMessage.objects.filter(session=self.session).exists())
         self.assertEqual(
-            self._event_types(layer),
-            [events.ChatEventType.START.value, events.ChatEventType.ERROR.value],
+            self._event_types(layer), [events.ChatEventType.START.value, events.ChatEventType.ERROR.value]
         )
         error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
         self.assertEqual(error_payload["detail"], events.ChatErrorDetail.UNAVAILABLE.value)
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
-    def test_iteration_cap_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
+    def test_recursion_cap_streams_error_and_drops_the_turn(self, mock_build, mock_get_layer):
         layer = self._patched_layer(mock_get_layer)
-        executor = MagicMock()
-        # what AgentExecutor returns when max_iterations force-stops the run
-        executor.invoke.return_value = {"output": AGENT_STOPPED_OUTPUT}
-        mock_build.return_value = executor
+        chat_agent, _ = _chat_agent(raises=GraphRecursionError("recursion limit reached"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "hello", self.user.id)
 
-        # the canned framework string must never be persisted as an assistant message
+        # a looping run is dropped, not persisted
         self.assertFalse(ChatMessage.objects.filter(session=self.session).exists())
         self.assertEqual(
-            self._event_types(layer),
-            [events.ChatEventType.START.value, events.ChatEventType.ERROR.value],
+            self._event_types(layer), [events.ChatEventType.START.value, events.ChatEventType.ERROR.value]
         )
         error_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
         self.assertEqual(error_payload["detail"], events.ChatErrorDetail.ITERATION_LIMIT.value)
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_context_url_is_injected_as_page_context(self, mock_build, mock_get_layer):
         self._patched_layer(mock_get_layer)
-        executor = MagicMock()
-        executor.invoke.return_value = {"output": "ok"}
-        mock_build.return_value = executor
+        chat_agent, _ = _chat_agent(items=_final("ok"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "summarize this", self.user.id, "https://intelowl.test/jobs/42")
 
-        invoke_input = executor.invoke.call_args.args[0]
         self.assertEqual(
-            invoke_input["page_context"],
+            mock_build.call_args.kwargs["page_context"],
             "The user is currently viewing job #42 in the IntelOwl UI.",
         )
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_missing_context_url_yields_empty_page_context(self, mock_build, mock_get_layer):
         self._patched_layer(mock_get_layer)
-        executor = MagicMock()
-        executor.invoke.return_value = {"output": "ok"}
-        mock_build.return_value = executor
+        chat_agent, _ = _chat_agent(items=_final("ok"))
+        mock_build.return_value = chat_agent
 
         process_chat_message(self.session.id, "hello", self.user.id)  # no context_url
 
-        self.assertEqual(executor.invoke.call_args.args[0]["page_context"], "")
+        self.assertEqual(mock_build.call_args.kwargs["page_context"], "")
 
     @patch("api_app.chatbot_manager.tasks.get_channel_layer")
-    @patch("api_app.chatbot_manager.agent.agent.build_agent_executor")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
     def test_session_not_owned_by_user_is_rejected(self, mock_build, mock_get_layer):
         layer = self._patched_layer(mock_get_layer)
         other = User.objects.create(username="chatbot_task_other")

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -2,20 +2,31 @@
 # See the file 'LICENSE' for copying permission.
 
 from datetime import timedelta
+from types import SimpleNamespace
 from unittest.mock import MagicMock, patch
 
 from django.test import override_settings
 from django.utils.timezone import now
 from langchain_core.messages import AIMessage, HumanMessage
+from langgraph.errors import GraphRecursionError
 from rest_framework import status
 from rest_framework.test import APITestCase
 
-from api_app.chatbot_manager.agent.agent import AGENT_STOPPED_OUTPUT
 from api_app.chatbot_manager.events import ChatErrorDetail
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
 from certego_saas.apps.user.models import User
 
-MOCK_AGENT_OUTPUT = {"output": "Here are your recent jobs."}
+_ANSWER = "Here are your recent jobs."
+
+
+def _agent(invoke_return=None, invoke_side_effect=None):
+    """A stand-in ChatAgent whose runnable.invoke returns a create_agent result state (or raises)."""
+    runnable = MagicMock()
+    if invoke_side_effect is not None:
+        runnable.invoke.side_effect = invoke_side_effect
+    else:
+        runnable.invoke.return_value = invoke_return or {"messages": [AIMessage(content=_ANSWER)]}
+    return SimpleNamespace(runnable=runnable, tool_names=frozenset())
 
 
 class ChatSessionViewSetTestCase(APITestCase):
@@ -26,48 +37,29 @@ class ChatSessionViewSetTestCase(APITestCase):
         self.user, _ = User.objects.get_or_create(username="chatbot_view_user")
         self.client.force_authenticate(user=self.user)
 
-    @patch(
-        "api_app.chatbot_manager.views.build_agent_executor",
-        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
-    )
-    def test_message_creates_session_when_none_provided(self, mock_executor):
-        response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Show me recent jobs"},
-            format="json",
-        )
+    @patch("api_app.chatbot_manager.views.build_agent", return_value=_agent())
+    def test_message_creates_session_when_none_provided(self, mock_build):
+        response = self.client.post(self.MESSAGE_URL, data={"message": "Show me recent jobs"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         data = response.json()
         self.assertIn("session_id", data)
         self.assertIn("response", data)
         self.assertIn("message_id", data)
-        self.assertEqual(data["response"], MOCK_AGENT_OUTPUT["output"])
+        self.assertEqual(data["response"], _ANSWER)
         self.assertTrue(ChatSession.objects.filter(pk=data["session_id"]).exists())
 
-    @patch(
-        "api_app.chatbot_manager.views.build_agent_executor",
-        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
-    )
-    def test_message_reuses_existing_session(self, mock_executor):
+    @patch("api_app.chatbot_manager.views.build_agent", return_value=_agent())
+    def test_message_reuses_existing_session(self, mock_build):
         session = ChatSession.objects.create(user=self.user)
         response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello", "session_id": session.pk},
-            format="json",
+            self.MESSAGE_URL, data={"message": "Hello", "session_id": session.pk}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         self.assertEqual(response.json()["session_id"], session.pk)
 
-    @patch(
-        "api_app.chatbot_manager.views.build_agent_executor",
-        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
-    )
-    def test_message_saves_user_and_assistant_messages(self, mock_executor):
-        response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello"},
-            format="json",
-        )
+    @patch("api_app.chatbot_manager.views.build_agent", return_value=_agent())
+    def test_message_saves_user_and_assistant_messages(self, mock_build):
+        response = self.client.post(self.MESSAGE_URL, data={"message": "Hello"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_200_OK)
         session_id = response.json()["session_id"]
         msgs = list(ChatMessage.objects.filter(session_id=session_id).order_by("timestamp"))
@@ -75,45 +67,35 @@ class ChatSessionViewSetTestCase(APITestCase):
         self.assertEqual(msgs[0].role, ChatMessage.Role.USER)
         self.assertEqual(msgs[0].content, "Hello")
         self.assertEqual(msgs[1].role, ChatMessage.Role.ASSISTANT)
-        self.assertEqual(msgs[1].content, MOCK_AGENT_OUTPUT["output"])
+        self.assertEqual(msgs[1].content, _ANSWER)
 
-    @patch("api_app.chatbot_manager.views.build_agent_executor")
+    @patch("api_app.chatbot_manager.views.build_agent")
     def test_message_passes_prior_turns_as_messages(self, mock_build):
-        executor = MagicMock()
-        executor.invoke.return_value = MOCK_AGENT_OUTPUT
-        mock_build.return_value = executor
+        mock_build.return_value = _agent()
         session = ChatSession.objects.create(user=self.user)
         ChatMessage.objects.create(session=session, role=ChatMessage.Role.USER, content="prev q")
         ChatMessage.objects.create(session=session, role=ChatMessage.Role.ASSISTANT, content="prev a")
 
         response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello", "session_id": session.pk},
-            format="json",
+            self.MESSAGE_URL, data={"message": "Hello", "session_id": session.pk}, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_200_OK)
-        # history reaches the agent as LangChain message objects (the prompt's chat_history
-        # MessagesPlaceholder), read before this turn is persisted.
-        invoke_input = executor.invoke.call_args.args[0]
-        self.assertEqual(invoke_input["input"], "Hello")
+        # history + the new user message reach the agent as the create_agent messages list, read
+        # before this turn is persisted.
+        invoke_input = mock_build.return_value.runnable.invoke.call_args.args[0]
         self.assertEqual(
-            [(type(m), m.content) for m in invoke_input["chat_history"]],
-            [(HumanMessage, "prev q"), (AIMessage, "prev a")],
+            [(type(m), m.content) for m in invoke_input["messages"]],
+            [(HumanMessage, "prev q"), (AIMessage, "prev a"), (HumanMessage, "Hello")],
         )
 
-    @patch("api_app.chatbot_manager.views.build_agent_executor")
+    @patch("api_app.chatbot_manager.views.build_agent")
     def test_message_iteration_cap_returns_error_and_drops_the_turn(self, mock_build):
-        executor = MagicMock()
-        # what AgentExecutor returns when max_iterations force-stops the run
-        executor.invoke.return_value = {"output": AGENT_STOPPED_OUTPUT}
-        mock_build.return_value = executor
+        mock_build.return_value = _agent(invoke_side_effect=GraphRecursionError("recursion limit reached"))
         session = ChatSession.objects.create(user=self.user)
 
         response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello", "session_id": session.pk},
-            format="json",
+            self.MESSAGE_URL, data={"message": "Hello", "session_id": session.pk}, format="json"
         )
 
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
@@ -121,26 +103,20 @@ class ChatSessionViewSetTestCase(APITestCase):
         self.assertEqual(content["detail"], ChatErrorDetail.ITERATION_LIMIT.value)
         # the session id rides the error so a session created by this request stays usable
         self.assertEqual(content["session_id"], session.pk)
-        # the canned framework string must never be persisted as an assistant message
+        # a looping run must never be persisted as an assistant message
         self.assertFalse(ChatMessage.objects.filter(session=session).exists())
 
     def test_message_returns_404_for_other_users_session(self):
         other_user, _ = User.objects.get_or_create(username="chatbot_other_view_user")
         other_session = ChatSession.objects.create(user=other_user)
         response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello", "session_id": other_session.pk},
-            format="json",
+            self.MESSAGE_URL, data={"message": "Hello", "session_id": other_session.pk}, format="json"
         )
         self.assertEqual(response.status_code, status.HTTP_404_NOT_FOUND)
 
     def test_message_requires_authentication(self):
         self.client.force_authenticate(user=None)
-        response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello"},
-            format="json",
-        )
+        response = self.client.post(self.MESSAGE_URL, data={"message": "Hello"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_401_UNAUTHORIZED)
 
     def test_list_annotates_title_from_first_user_message(self):
@@ -175,34 +151,20 @@ class ChatSessionViewSetTestCase(APITestCase):
             "chatbot_rate_limit": {"BACKEND": "django.core.cache.backends.locmem.LocMemCache"},
         }
     )
-    @patch(
-        "api_app.chatbot_manager.views.build_agent_executor",
-        return_value=MagicMock(invoke=MagicMock(return_value=MOCK_AGENT_OUTPUT)),
-    )
-    def test_rate_limit_returns_429_envelope(self, mock_executor):
+    @patch("api_app.chatbot_manager.views.build_agent", return_value=_agent())
+    def test_rate_limit_returns_429_envelope(self, mock_build):
         """6th message in the same window returns 429 with IntelOwl error envelope."""
         limit = 5
         with self.settings(CHATBOT_RATE_LIMIT=limit, CHATBOT_RATE_LIMIT_WINDOW=60):
-            # Send 5 messages first — the mock agent returns success, so the first 5
-            # pass through to the executor (200, not 429).
             for i in range(limit):
-                response = self.client.post(
-                    self.MESSAGE_URL,
-                    data={"message": f"msg {i}"},
-                    format="json",
-                )
+                response = self.client.post(self.MESSAGE_URL, data={"message": f"msg {i}"}, format="json")
                 self.assertNotEqual(
                     response.status_code,
                     status.HTTP_429_TOO_MANY_REQUESTS,
                     f"request {i} should not be rate-limited",
                 )
 
-            # 6th message — rate-limited.
-            response = self.client.post(
-                self.MESSAGE_URL,
-                data={"message": "one too many"},
-                format="json",
-            )
+            response = self.client.post(self.MESSAGE_URL, data={"message": "one too many"}, format="json")
             self.assertEqual(response.status_code, status.HTTP_429_TOO_MANY_REQUESTS)
             data = response.json()
             self.assertIn("errors", data)
@@ -213,15 +175,11 @@ class ChatSessionViewSetTestCase(APITestCase):
             self.assertGreater(error["retry_after"], 0)
 
     @patch(
-        "api_app.chatbot_manager.views.build_agent_executor",
-        return_value=MagicMock(invoke=MagicMock(side_effect=RuntimeError("ollama down"))),
+        "api_app.chatbot_manager.views.build_agent",
+        return_value=_agent(invoke_side_effect=RuntimeError("ollama down")),
     )
-    def test_message_returns_503_when_agent_unavailable(self, mock_executor):
-        response = self.client.post(
-            self.MESSAGE_URL,
-            data={"message": "Hello"},
-            format="json",
-        )
+    def test_message_returns_503_when_agent_unavailable(self, mock_build):
+        response = self.client.post(self.MESSAGE_URL, data={"message": "Hello"}, format="json")
         self.assertEqual(response.status_code, status.HTTP_503_SERVICE_UNAVAILABLE)
         self.assertEqual(response.json()["detail"], ChatErrorDetail.UNAVAILABLE.value)
 
@@ -242,8 +200,6 @@ class ChatSessionMessagesActionTestCase(APITestCase):
         return f"/api/chatbot/sessions/{pk}/messages"
 
     def test_returns_messages_ordered_by_timestamp(self):
-        # Persist in reverse chronological order to prove the endpoint sorts by
-        # timestamp ascending rather than echoing insertion order.
         base = now()
         ChatMessage.objects.create(
             session=self.session,


### PR DESCRIPTION
Migrates the chatbot agent engine from the deprecated `AgentExecutor` + `create_tool_calling_agent` (LangChain 0.3.x) to `create_agent` on the LangGraph runtime (LangChain 1.3.11). Drop-in engine swap — external behavior and the chat WebSocket contract (`events.py`) are unchanged; the M-1 guardrail, `DjangoChatMessageHistory` memory, and multi-tenant tool scoping are untouched.

## Why
- `AgentExecutor` is deprecated; `create_agent` is the supported API.
- **Security:** GHSA-gr75-jv2w-4656 is fixed only in `langchain>=1.3.9`. Bumping to 1.3.11 removes the exposure, so the `dependency_review.yml` `allow-ghsas` entry for it is removed in this same PR.

## Changes
- `agent.py`: `build_agent() -> ChatAgent(runnable, tool_names)` via `create_agent(model, tools, system_prompt)`; `final_answer()` helper; `RECURSION_LIMIT = 2*rounds + 2` (=14, LangGraph counts supersteps, not agent rounds); `page_context` baked into the system prompt.
- `streaming.py`: `ChatStreamConsumer` consuming `stream_mode=["messages","values"]`, emitting identical `token`/`status`/`action_required` events and returning the terminal answer (no callback handler).
- `tasks.py` / `views.py`: `GraphRecursionError -> ITERATION_LIMIT` (the `AGENT_STOPPED_OUTPUT` sentinel no longer exists in 1.x); agent input is a `messages` list.
- deps: `langchain==1.3.11`, `langchain-ollama==1.1.0` (langchain-core / langgraph stay transitive, unpinned).

## Testing
All 168 `tests.api_app.chatbot_manager` tests pass on a rebuilt test image (LLM mocked, no real Ollama/HTTP). A live Ollama smoke (qwen2.5:3b) confirms token-by-token streaming, tool-call visibility, and the `analyze_observable` pending_id preview path are unchanged.

Refs #3833
