### PR TITLE
[GSoC 2026] chatbot: harden jobs-vs-investigations routing + accept null filter args (Refs #3843)

### DIFF
--- a/api_app/chatbot_manager/agent/system_prompt.txt
+++ b/api_app/chatbot_manager/agent/system_prompt.txt
@@ -3,7 +3,7 @@ You are IntelOwl AI, a concise assistant for the IntelOwl threat intelligence pl
 Answer with short, data-driven summaries. Always cite the tools you used at the end.
 
 [Tools — when to use each]
-- search_jobs: find jobs by observable value, tag, or md5. Use for "show me jobs", "find jobs for domain X".
+- search_jobs: find or list the current user's own jobs — by observable value, tag, or md5, or with no filter to list their recent jobs. Use for any question about the user's jobs: "show me my jobs", "list my jobs", "what jobs do I have?", "do I have any jobs?", "find my recent jobs", "find jobs for domain X".
 - get_job_details: full detail of ONE job by id. Use after search_jobs, or when the user asks "details of job #N".
 - summarize_job: high-level summary of ONE job (status, analyzers, findings). Use for "summarize job #N".
 - list_investigations: browse investigations with optional status/name filters. Use for "show my investigations", "what investigations are open?".
@@ -17,6 +17,7 @@ Answer with short, data-driven summaries. Always cite the tools you used at the 
 [Rules]
 - Only access data belonging to the current user. Never reveal other users' data.
 - Call the right tool instead of guessing. Say so when a tool returns no data.
+- Jobs vs investigations: any question about the user's own jobs ("show/list/find my jobs", "what jobs do I have?") uses search_jobs. list_investigations is only for investigations — a named, grouped collection of analyses — so never answer a plain "jobs" question with list_investigations.
 - When a tool needs a value from a previous tool's result (an id, an md5), pass that actual value — never a placeholder like <job_id>.
 - analyze_observable only previews; never tell the user an analysis has started — they approve it themselves via the Confirm button.
 

--- a/api_app/chatbot_manager/agent/tools/list_investigations.py
+++ b/api_app/chatbot_manager/agent/tools/list_investigations.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from typing import Optional
+
 from langchain_core.tools import tool
 
 from api_app.chatbot_manager.agent.tools._common import clamp_limit
@@ -17,7 +19,9 @@ def make_list_investigations_tool(user):
     # and the LLM can never widen it. LangChain feeds a tool's return value back as the
     # tool-call observation, so it must be a string: we return a JSON-serialized envelope.
     @tool("list_investigations")
-    def list_investigations(query: str = "", status: str = "", limit: int = 10) -> str:
+    def list_investigations(
+        query: Optional[str] = None, status: Optional[str] = None, limit: int = 10
+    ) -> str:
         """List IntelOwl investigations visible to you (owned or shared with your org).
 
         Args:

--- a/api_app/chatbot_manager/agent/tools/search_jobs.py
+++ b/api_app/chatbot_manager/agent/tools/search_jobs.py
@@ -1,6 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+from typing import Optional
+
 from django.db import models
 from langchain_core.tools import tool
 
@@ -15,7 +17,7 @@ def make_search_jobs_tool(user):
     # as the tool-call observation, so it must be a string; we return a JSON-serialized
     # envelope.
     @tool("search_jobs")
-    def search_jobs(query: str = "", status: str = "", limit: int = 10) -> str:
+    def search_jobs(query: Optional[str] = None, status: Optional[str] = None, limit: int = 10) -> str:
         """Search IntelOwl jobs by observable name, MD5, or status.
 
         Args:

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -264,3 +264,20 @@ class OnInvalidToolArgsTestCase(TestCase):
         self.assertIsInstance(msg, str)
         self.assertIn("job_id: not an integer", msg)  # the underlying error reaches the model
         self.assertIn("placeholder", msg.lower())  # tell it not to pass a placeholder
+
+
+class SystemPromptToolRoutingTestCase(TestCase):
+    """String-level guard for the #3843 jobs-vs-investigations routing cues.
+
+    The behavioral evidence is the tool-selection reliability harness re-run (documented in the
+    benchmark report), not this test; it only locks the specific prompt cues and rule the harness
+    validated so a later prompt edit can't silently drop them. It never touches Ollama.
+    """
+
+    def test_jobs_questions_are_anchored_to_search_jobs(self):
+        lower = _SYSTEM_PROMPT.lower()
+        # the phrasing that mis-routed to list_investigations 0/10 is now an explicit search_jobs cue
+        self.assertIn("what jobs do i have?", lower)
+        # the directional rule steering "own jobs" questions to search_jobs (not list_investigations)
+        self.assertIn("jobs vs investigations", lower)
+        self.assertIn("search_jobs", _SYSTEM_PROMPT)

--- a/tests/api_app/chatbot_manager/tools/test_investigations.py
+++ b/tests/api_app/chatbot_manager/tools/test_investigations.py
@@ -119,6 +119,16 @@ class InvestigationToolsTestCase(TestCase):
         ids = [i["id"] for i in data["investigations"]]
         self.assertIn(self.inv_created.pk, ids)
 
+    def test_list_investigations_accepts_null_query_and_status(self):
+        # Mirror the search_jobs null-arg fix: the model may emit query=None/status=None; the
+        # widened Optional[str] signature must treat them as "no filter" and list the visible
+        # investigations without error. Scoping is unchanged -- a non-shared one stays hidden.
+        data = json.loads(self.list_investigations.invoke({"query": None, "status": None}))
+        self.assertEqual(data["errors"], [])
+        ids = [i["id"] for i in data["investigations"]]
+        self.assertIn(self.inv_created.pk, ids)
+        self.assertNotIn(self.inv_private.pk, ids)
+
     def test_list_investigations_limit_over_cap_reports_error(self):
         result = self.list_investigations.invoke({"limit": 100})
         data = json.loads(result)

--- a/tests/api_app/chatbot_manager/tools/test_search_jobs.py
+++ b/tests/api_app/chatbot_manager/tools/test_search_jobs.py
@@ -153,6 +153,18 @@ class SearchJobsToolTestCase(TestCase):
         self.assertEqual(data["errors"], [])
         self.assertEqual([d["id"] for d in data["jobs"]], [self.job.pk])
 
+    def test_search_jobs_accepts_null_query_and_status(self):
+        # The 3B model emits explicit nulls (query=None, status=None) for "what jobs do I have?";
+        # the widened Optional[str] signature must accept them as "no filter" (falsy) and list the
+        # user's recent jobs instead of raising a validation error. Scoping is unchanged -- another
+        # user's RED job stays hidden.
+        result = self.search_jobs.invoke({"query": None, "status": None})
+        data = json.loads(result)
+        self.assertEqual(data["errors"], [])
+        ids = [d["id"] for d in data["jobs"]]
+        self.assertIn(self.job.pk, ids)
+        self.assertNotIn(self.other_job.pk, ids)
+
     def test_search_jobs_limit_over_cap_reports_error(self):
         result = self.search_jobs.invoke({"limit": 100})
         data = json.loads(result)


### PR DESCRIPTION
Refs #3843.

## What
Two coupled changes; the second is the null-arg gap the first exposed.

1. **Routing (prompt).** The local 3B agent (`qwen2.5:3b`, temp=0) mis-routed several "jobs" phrasings
   to `list_investigations`. Strengthen the `search_jobs` side of `system_prompt.txt` only (broaden the
   cue with the failing phrasings incl. the verbatim "what jobs do I have?"; one `[Rules]`
   disambiguation line). `list_investigations` cue untouched, so its routing controls are unaffected.
2. **Null filter args (tools).** With routing fixed, the model calls `search_jobs(query=None, ...)`;
   the `query: str = ""` / `status: str = ""` signatures rejected the explicit `None`, so the answer
   was still empty. Widen `query`/`status` to `Optional[str] = None` on `search_jobs` **and**
   `list_investigations` (signature only — the bodies already guard with `if query:` / `if status:`,
   and `visible_for_user(user)` scoping is unchanged).

## Evidence (same-session A/B/C, tool-selection reliability harness)
Correct = expected tool called; "delivered" = the actual job list was returned. Warm n=8, cold n=2.

| phrasing | before: tool / jobs | after: tool / jobs |
|---|---|---|
| **"what jobs do I have?"** | **0/10 / 0/10** | **10/10 / 10/10** |
| "show my recent jobs" | 2/10 / 2/10 | 10/10 / 10/10 |
| "show me my jobs" | 8/10 / 8/10 | 10/10 / 10/10 |
| "list my jobs" / "find my recent jobs" | 10/10 / 10/10 | 10/10 / 10/10 |
| investigations controls; analyze_observable (M-1) / summarize_job controls | pass | pass (unchanged) |

Zero regressions; all controls hold; `analyze_observable` keeps its M-1 `action_required` preview.
171 chatbot unit tests green.

## Data-isolation note
The tool change is a type-only widening of already-optional filter args; the querysets stay scoped by
`visible_for_user(user)` and the bodies are unchanged, so a `null` filter behaves exactly like an
empty one (no widening). New tool tests assert isolation still holds under `query=None` / `status=None`
(another user's RED job / a non-shared investigation stay hidden). `agent-data-isolation-reviewer` was
not spawnable in the authoring session; the review was done inline.
