### PR TITLE
[GSoC 2026] chatbot: keep the Ollama model resident (OLLAMA_KEEP_ALIVE) — Refs #3855

### DIFF
--- a/api_app/chatbot_manager/agent/agent.py
+++ b/api_app/chatbot_manager/agent/agent.py
@@ -40,6 +40,19 @@ RECURSION_LIMIT = 2 * _MAX_AGENT_ITERATIONS + 2
 _NUM_CTX = 8192
 
 
+def _parse_keep_alive(value: str) -> int | str:
+    """Normalize the OLLAMA_KEEP_ALIVE setting to what ChatOllama/Ollama expect.
+
+    Ollama's keep_alive is either an integer number of seconds (-1 keeps the model resident
+    indefinitely, 0 unloads it immediately) or a Go-duration string like "5m"/"1h". The setting
+    arrives as a string, so coerce a numeric value to int and pass any duration string through.
+    """
+    try:
+        return int(value)
+    except (TypeError, ValueError):
+        return value
+
+
 @dataclass(frozen=True)
 class ChatAgent:
     """A user-scoped chat agent: the compiled LangGraph runnable plus its tool-name registry.
@@ -76,6 +89,7 @@ def build_agent(user, page_context: str = "") -> ChatAgent:
         base_url=settings.OLLAMA_BASE_URL,
         temperature=0,
         num_ctx=_NUM_CTX,
+        keep_alive=_parse_keep_alive(settings.OLLAMA_KEEP_ALIVE),
     )
     tools = build_tools(user=user)
     system_prompt = _SYSTEM_PROMPT if not page_context else f"{_SYSTEM_PROMPT}\n\n{page_context}"

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -89,6 +89,9 @@ FLOWER_PWD=flower
 OLLAMA_BASE_URL=http://ollama:11434
 # must be a model that supports Ollama tool calling
 OLLAMA_MODEL=qwen2.5:3b
+# how long Ollama keeps the model in memory after a request: -1 keeps it resident (no cold reload
+# after idle), a duration like 5m frees memory after inactivity, 0 unloads immediately. Default: -1
+OLLAMA_KEEP_ALIVE=-1
 # chat sessions whose last activity is older than this are flushed periodically. Default: 90 days
 CHATBOT_MESSAGE_RETENTION_DAYS=90
 CHATBOT_RATE_LIMIT=5

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -11,6 +11,11 @@ OLLAMA_BASE_URL = secrets.get_secret("OLLAMA_BASE_URL", "http://ollama:11434")
 # usable latency on a CPU-only deploy (mistral 7B took ~2.5 minutes per agent round). Stronger
 # hardware can override it with any tool-capable Ollama model via the OLLAMA_MODEL secret.
 OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "qwen2.5:3b")
+# keep_alive controls how long Ollama keeps the model resident after a request. Default -1 keeps it
+# loaded indefinitely so the chatbot never re-pays the ~70s cold reload after an idle period; the
+# chatbot is already opt-in (the separate ollama compose override), so an operator running it has
+# accepted the model's memory cost. Constrained deploys can set a duration ("5m") or "0" (unload now).
+OLLAMA_KEEP_ALIVE = secrets.get_secret("OLLAMA_KEEP_ALIVE", "-1")
 CHATBOT_QUEUE = secrets.get_secret("CHATBOT_QUEUE", "chatbot")
 CHATBOT_MESSAGE_RETENTION_DAYS = int(secrets.get_secret("CHATBOT_MESSAGE_RETENTION_DAYS", 90))
 

--- a/tests/api_app/chatbot_manager/test_agent.py
+++ b/tests/api_app/chatbot_manager/test_agent.py
@@ -5,7 +5,7 @@ from typing import Any, Optional
 from unittest.mock import patch
 
 from django.conf import settings
-from django.test import TestCase
+from django.test import TestCase, override_settings
 from langchain_core.callbacks import CallbackManagerForLLMRun
 from langchain_core.language_models.chat_models import BaseChatModel
 from langchain_core.messages import AIMessage, BaseMessage
@@ -19,6 +19,7 @@ from api_app.chatbot_manager.agent.agent import (
     _SYSTEM_PROMPT,
     RECURSION_LIMIT,
     ChatAgent,
+    _parse_keep_alive,
     build_agent,
     final_answer,
 )
@@ -129,6 +130,19 @@ class BuildAgentTestCase(TestCase):
         self.assertEqual(llm_kwargs["temperature"], 0)
         # without an explicit context window Ollama truncates the multi-tool prompt
         self.assertEqual(llm_kwargs["num_ctx"], _NUM_CTX)
+
+    def test_keep_alive_is_threaded_from_settings(self):
+        _, mock_llm_cls = self._build()
+        # default OLLAMA_KEEP_ALIVE "-1" is parsed to int -1 so Ollama keeps the model resident
+        self.assertEqual(
+            mock_llm_cls.call_args.kwargs["keep_alive"],
+            _parse_keep_alive(settings.OLLAMA_KEEP_ALIVE),
+        )
+
+    @override_settings(OLLAMA_KEEP_ALIVE="5m")
+    def test_keep_alive_duration_string_is_passed_through(self):
+        _, mock_llm_cls = self._build()
+        self.assertEqual(mock_llm_cls.call_args.kwargs["keep_alive"], "5m")
 
     def test_recursion_limit_maps_from_agent_rounds(self):
         # LangGraph counts supersteps, not agent rounds: one tool round is model->tools->model
@@ -281,3 +295,16 @@ class SystemPromptToolRoutingTestCase(TestCase):
         # the directional rule steering "own jobs" questions to search_jobs (not list_investigations)
         self.assertIn("jobs vs investigations", lower)
         self.assertIn("search_jobs", _SYSTEM_PROMPT)
+
+
+class ParseKeepAliveTestCase(TestCase):
+    """OLLAMA_KEEP_ALIVE is coerced to what Ollama expects: int seconds or a duration string."""
+
+    def test_numeric_strings_become_ints(self):
+        self.assertEqual(_parse_keep_alive("-1"), -1)
+        self.assertEqual(_parse_keep_alive("300"), 300)
+        self.assertEqual(_parse_keep_alive("0"), 0)
+
+    def test_duration_strings_pass_through(self):
+        self.assertEqual(_parse_keep_alive("5m"), "5m")
+        self.assertEqual(_parse_keep_alive("1h"), "1h")


### PR DESCRIPTION
Refs #3855

## What
Adds an `OLLAMA_KEEP_ALIVE` setting (default `-1`) threaded into the `ChatOllama` built by `build_agent`, so Ollama keeps the chat model resident instead of unloading it on idle. This removes the reload penalty the chatbot pays on the first turn after an idle period — the "ops lever" identified in the LangChain-1.x warm-latency benchmark.

## Why
Ollama's default `keep_alive` (~5 min) unloads the model after idle, so the next chat turn re-pays a full model reload (up to ~70s on a disk-cold CPU load). The chatbot is already opt-in (the separate `ollama` compose override), so an operator running it has accepted the model's memory cost — keeping it resident is the right default. Fully configurable: memory-constrained deploys can set a duration (`OLLAMA_KEEP_ALIVE=5m`) or `0` to unload immediately.

## Changes
- `intel_owl/settings/chatbot.py`: new `OLLAMA_KEEP_ALIVE` (default `-1`), documented with the memory tradeoff.
- `api_app/chatbot_manager/agent/agent.py`: `_parse_keep_alive` helper (str → int seconds, or duration string like `"5m"`) + `keep_alive=` on `ChatOllama`.
- `docker/env_file_app_template`: documents the new variable.
- tests: parser cases + `build_agent` threads the parsed setting (Ollama mocked).

## Validation
- 175 chatbot unit tests green; ruff lint + format green.
- Behavioral (in-proc, real `build_agent` path): with `keep_alive=-1`, `ollama ps` shows the model `UNTIL Forever` (never unloads → reload never re-paid); a `keep_alive=30s` control shows an expiring `UNTIL` (knob wired end-to-end). Warm inference latency unchanged (~0.3s). Reload penalty measured ~3s disk-warm locally, up to ~70s disk-cold per the earlier benchmark — eliminated in all cases since the model stays resident.

No new dependencies, no migration, no change to the tools / M-1 guardrail / memory / streaming or the multi-tenant scoping.
