### PR TITLE
[Connectors] Feat: health check error messages in UI. Closes #3864

### DIFF
--- a/api_app/connectors_manager/connectors/misp.py
+++ b/api_app/connectors_manager/connectors/misp.py
@@ -116,9 +116,9 @@ class MISP(Connector):
         else:
             raise ConnectorRunException(f"{errors}{debug_info}")
 
-    def health_check(self, user=None) -> bool:
+    def health_check(self, user=None) -> tuple:
         if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
-            return True
+            return True, "Mock connection successful"
 
         params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
             self._config, user
@@ -142,10 +142,10 @@ class MISP(Connector):
 
         if not url:
             logger.info("Healthcheck failed: Missing config url")
-            return False
+            return False, "Missing config url"
         if not key:
             logger.info("Healthcheck failed: Missing config api key")
-            return False
+            return False, "Missing config api key"
 
         ssl_param = (
             f"{settings.PROJECT_LOCATION}/configuration/misp_ssl.crt"
@@ -168,11 +168,11 @@ class MISP(Connector):
             # the MISP instance if the connection is successful
             # Refs: https://pymisp.readthedocs.io/en/latest/modules.html?#pymisp.PyMISP.misp_instance_version
             misp.misp_instance_version
-            return True
+            return True, "Connected successfully"
 
         except Exception as e:
             logger.info(f"MISP health check failed: {e}")
-            return False
+            return False, f"Connection failed: {e}"
 
     def run(self):
         ssl_param = (

--- a/api_app/connectors_manager/connectors/opencti.py
+++ b/api_app/connectors_manager/connectors/opencti.py
@@ -183,9 +183,9 @@ class OpenCTI(classes.Connector):
                 id=report_id, stixObjectOrStixRelationshipId=observable_id
             )
 
-    def health_check(self, user=None) -> bool:
+    def health_check(self, user=None) -> tuple:
         if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
-            return True
+            return True, "Mock connection successful"
 
         params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
             self._config, user
@@ -208,10 +208,10 @@ class OpenCTI(classes.Connector):
 
         if not url:
             logger.info("Healthcheck failed: Missing config url")
-            return False
+            return False, "Missing config url"
         if not token:
             logger.info("Healthcheck failed: Missing config api key")
-            return False
+            return False, "Missing config api key"
 
         try:
             client = pycti.OpenCTIApiClient(url, token, ssl_verify=ssl_verify, proxies=proxies)
@@ -221,10 +221,13 @@ class OpenCTI(classes.Connector):
             # API key and reachability of the OpenCTI instance
             # Ref: https://opencti-python-client.readthedocs.io/en/latest/pycti/pycti.api.opencti_api_client.html#pycti.api.opencti_api_client.OpenCTIApiClient.health_check
             resp = client.health_check()
-            return resp
+            if resp:
+                return True, "Connected successfully"
+            else:
+                return False, "OpenCTI health check returned False"
         except Exception as e:
             logger.info(f"OpenCTI health check failed: {e}")
-            return False
+            return False, f"Connection failed: {e}"
 
     def run(self):
         # Initialize OpenCTI client for this run.

--- a/api_app/connectors_manager/connectors/slack.py
+++ b/api_app/connectors_manager/connectors/slack.py
@@ -38,9 +38,9 @@ class Slack(Connector):
             f"for <{self._job.url}/raw|{self._job.analyzable.name}>"
         )
 
-    def health_check(self, user=None) -> bool:
+    def health_check(self, user=None) -> tuple:
         if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
-            return True
+            return True, "Mock connection successful"
 
         params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
             self._config, user
@@ -53,7 +53,7 @@ class Slack(Connector):
 
         if not token:
             logger.info("Slack health check failed: Missing token configuration.")
-            return False
+            return False, "Missing token configuration"
 
         try:
             client = slack_sdk.WebClient(token=token)
@@ -64,10 +64,10 @@ class Slack(Connector):
             # authenticated user if the token is valid)
             # Ref: https://docs.slack.dev/tools/python-slack-sdk/reference/#slack_sdk.WebClient.auth_test
             client.auth_test()
-            return True
+            return True, "Connected successfully"
         except Exception as e:
             logger.info(f"Slack health check failed: {e}")
-            return False
+            return False, f"Connection failed: {e}"
 
     def run(self) -> dict:
         self.client.chat_postMessage(text=f"{self.title}\n{self.body}", channel=self._channel, mrkdwn=True)

--- a/api_app/connectors_manager/connectors/yeti.py
+++ b/api_app/connectors_manager/connectors/yeti.py
@@ -18,7 +18,7 @@ class YETI(classes.Connector):
     _url_key_name: str
     _api_key_name: str
 
-    def health_check(self, user=None) -> bool:
+    def health_check(self, user=None) -> tuple:
         params = self._config.parameters.annotate_configured(self._config, user).annotate_value_for_user(
             self._config, user
         )
@@ -33,13 +33,13 @@ class YETI(classes.Connector):
 
         if not url:
             logger.info("Healthcheck failed: Missing config url")
-            return False
+            return False, "Missing config url"
         if not api_key:
             logger.info("Healthcheck failed: Missing config api key")
-            return False
+            return False, "Missing config api key"
 
         if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
-            return True
+            return True, "Mock connection successful"
 
         base_url = url.rstrip("/")
         auth_url = f"{base_url}/api/v2/auth/api-token"
@@ -63,17 +63,17 @@ class YETI(classes.Connector):
             access_token = auth_resp.json().get("access_token")
 
             if access_token:
-                return True
+                return True, "Connected successfully"
             else:
                 logger.info(f"Healthcheck failed for {self}: No access token in response.")
-                return False
+                return False, "No access token in response"
 
         except requests.RequestException as e:
             logger.info(f"Healthcheck failed: YETI Auth Request failed for {self}. Error: {e}")
-            return False
+            return False, f"Auth Request failed: {e}"
         except Exception as e:
             logger.exception(f"Unexpected error in YETI health_check: {e}")
-            return False
+            return False, f"Unexpected error: {e}"
 
     def run(self):
         # get observable value and type

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -1311,15 +1311,22 @@ class PythonConfigViewSet(AbstractConfigViewSet):
         config: PythonConfig = self.get_object()
         python_obj = config.python_module.python_class(config)
         try:
-            health_status = python_obj.health_check(request.user)
+            health_result = python_obj.health_check(request.user)
+            if isinstance(health_result, tuple):
+                health_status, health_message = health_result
+            else:
+                health_status = health_result
+                health_message = "It is up and running" if health_status else "It is NOT up"
         except NotImplementedError as e:
             logger.info(f"NotImplementedError {e}, user {request.user}, name {name}")
             raise ValidationError({"detail": "No healthcheck implemented"})
         except Exception as e:
             logger.exception(e)
-            raise ValidationError({"detail": "Unexpected exception raised. Check the code."})
+            raise ValidationError({"detail": str(e) or "Unexpected exception raised. Check the code."})
         else:
-            return Response(data={"status": health_status}, status=status.HTTP_200_OK)
+            return Response(
+                data={"status": health_status, "message": health_message}, status=status.HTTP_200_OK
+            )
 
     @action(
         methods=["post"],

--- a/frontend/src/stores/usePluginConfigurationStore.jsx
+++ b/frontend/src/stores/usePluginConfigurationStore.jsx
@@ -198,14 +198,14 @@ export const usePluginConfigurationStore = create((set, get) => ({
       if (resp.data?.status)
         addToast(
           `${PluginName} - health check: success`,
-          "It is up and running",
+          resp.data?.message || "It is up and running",
           "success",
           true,
         );
       else
         addToast(
           `${PluginName} - health check: warning`,
-          "It is NOT up",
+          resp.data?.message || "It is NOT up",
           "warning",
           true,
         );

--- a/frontend/tests/components/plugins/tables/pluginActionsButtons.test.jsx
+++ b/frontend/tests/components/plugins/tables/pluginActionsButtons.test.jsx
@@ -49,61 +49,68 @@ jest.mock("../../../../src/stores/useAuthStore", () => ({
 
 describe("PluginHealthCheckButton test", () => {
   test.each([
-    // healthcheck true
+    // healthcheck true with fallback message
     {
       pluginName: "Plugin1",
       responseData: {
         status: 200,
         data: { status: true },
       },
+      expectedMessage: "It is up and running",
     },
-    // healthcheck false
+    // healthcheck false with custom message
     {
       pluginName: "Plugin2",
       responseData: {
         status: 200,
-        data: { status: false },
+        data: { status: false, message: "Missing API Key" },
       },
+      expectedMessage: "Missing API Key",
     },
-  ])("Health check - status 200 (%s)", async ({ pluginName, responseData }) => {
-    const userAction = userEvent.setup();
-    axios.get.mockImplementation(() => Promise.resolve(responseData));
+  ])(
+    "Health check - status 200 (%s)",
+    async ({ pluginName, responseData, expectedMessage }) => {
+      const userAction = userEvent.setup();
+      axios.get.mockImplementation(() => Promise.resolve(responseData));
 
-    const { container } = render(
-      <BrowserRouter>
-        <PluginHealthCheckButton
-          pluginName={pluginName}
-          pluginType_="analyzer"
-        />
-        <Toast />
-      </BrowserRouter>,
-    );
-
-    const healthCheckIcon = container.querySelector(
-      `#table-pluginhealthcheckbtn__${pluginName}`,
-    );
-    expect(healthCheckIcon).toBeInTheDocument();
-
-    await userAction.click(healthCheckIcon);
-
-    await waitFor(() => {
-      expect(axios.get).toHaveBeenCalledWith(
-        `${API_BASE_URI}/analyzer/${pluginName}/health_check`,
+      const { container } = render(
+        <BrowserRouter>
+          <PluginHealthCheckButton
+            pluginName={pluginName}
+            pluginType_="analyzer"
+          />
+          <Toast />
+        </BrowserRouter>,
       );
-      // toast
-      if (responseData.data.status) {
-        // status: true
-        expect(
-          screen.getByText(`${pluginName} - health check: success`),
-        ).toBeInTheDocument();
-      } else {
-        // status: false
-        expect(
-          screen.getByText(`${pluginName} - health check: warning`),
-        ).toBeInTheDocument();
-      }
-    });
-  });
+
+      const healthCheckIcon = container.querySelector(
+        `#table-pluginhealthcheckbtn__${pluginName}`,
+      );
+      expect(healthCheckIcon).toBeInTheDocument();
+
+      await userAction.click(healthCheckIcon);
+
+      await waitFor(() => {
+        expect(axios.get).toHaveBeenCalledWith(
+          `${API_BASE_URI}/analyzer/${pluginName}/health_check`,
+        );
+        // toast
+        if (responseData.data.status) {
+          // status: true
+          expect(
+            screen.getByText(`${pluginName} - health check: success`),
+          ).toBeInTheDocument();
+        } else {
+          // status: false
+          expect(
+            screen.getByText(`${pluginName} - health check: warning`),
+          ).toBeInTheDocument();
+        }
+        // verify the specific error or success message displays
+        expect(screen.getByText(expectedMessage)).toBeInTheDocument();
+      });
+    },
+  );
 });
 
 describe("PluginDeletionButton test", () => {

--- a/tests/api_app/connectors_manager/test_views.py
+++ b/tests/api_app/connectors_manager/test_views.py
@@ -36,7 +36,10 @@ class ConnectorConfigViewSetTestCase(AbstractConfigViewSetTestCaseMixin, CustomV
             connector_config=connector,
         )
 
-        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=True):
+        with patch(
+            "api_app.connectors_manager.connectors.yeti.YETI.health_check",
+            return_value=(True, "Connected successfully"),
+        ):
             response = self.client.get(f"{self.URL}/{connector.name}/health_check")
             self.assertEqual(response.status_code, 200)
 
@@ -47,6 +50,47 @@ class ConnectorConfigViewSetTestCase(AbstractConfigViewSetTestCaseMixin, CustomV
         result = response.json()
         self.assertIn("status", result)
         self.assertTrue(result["status"])
+        self.assertEqual(result["message"], "Connected successfully")
+        pc1.delete()
+        pc2.delete()
+
+    def test_health_check_legacy_boolean_return(self):
+        connector: ConnectorConfig = ConnectorConfig.objects.get(name="YETI")
+        pc1 = PluginConfig.objects.create(
+            parameter=connector.parameters.get(name="api_key_name"),
+            value="test",
+            for_organization=False,
+            owner=None,
+            connector_config=connector,
+        )
+        pc2 = PluginConfig.objects.create(
+            parameter=connector.parameters.get(name="url_key_name"),
+            value="https://test",
+            for_organization=False,
+            owner=None,
+            connector_config=connector,
+        )
+
+        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=True):
+            self.client.force_authenticate(self.superuser)
+            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
+            self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIn("status", result)
+        self.assertTrue(result["status"])
+        self.assertEqual(result["message"], "It is up and running")
+
+        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=False):
+            self.client.force_authenticate(self.superuser)
+            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
+            self.assertEqual(response.status_code, 200)
+
+        result = response.json()
+        self.assertIn("status", result)
+        self.assertFalse(result["status"])
+        self.assertEqual(result["message"], "It is NOT up")
+
         pc1.delete()
         pc2.delete()
 

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_misp.py
@@ -178,7 +178,7 @@ class MISPConnectorTestCase(BaseConnectorTest):
             mock_instance = mock_client_cls.return_value
             mock_instance.health_check.return_value = True
 
-            self.assertTrue(connector.health_check())
+            self.assertTrue(connector.health_check()[0])
 
     @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
     def test_misp_health_check_failures(self):
@@ -205,8 +205,8 @@ class MISPConnectorTestCase(BaseConnectorTest):
                 side_effect=Exception("Connection refused"),
             ),
         ):
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with self.subTest("Missing Configuration"):
             connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_opencti.py
@@ -310,7 +310,7 @@ class OpenCTIConnectorTestCase(BaseConnectorTest):
             mock_instance = mock_client_cls.return_value
             mock_instance.health_check.return_value = True
 
-            self.assertTrue(connector.health_check())
+            self.assertTrue(connector.health_check()[0])
 
     @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
     def test_opencti_health_check_failures(self):
@@ -336,7 +336,7 @@ class OpenCTIConnectorTestCase(BaseConnectorTest):
         ):
             mock_instance = mock_client_cls.return_value
             mock_instance.health_check.side_effect = Exception("Connection refused")
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with (
             self.subTest("OpenCTI Reports Unhealthy"),
@@ -344,8 +344,8 @@ class OpenCTIConnectorTestCase(BaseConnectorTest):
         ):
             mock_instance = mock_client_cls.return_value
             mock_instance.health_check.return_value = False
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with self.subTest("Missing Configuration"):
             connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_slack.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_slack.py
@@ -44,7 +44,7 @@ class SlackTestCase(BaseConnectorTest):
             mock_instance = mock_webclient_cls.return_value
             mock_instance.auth_test.return_value = {"ok": True}
 
-            self.assertTrue(connector.health_check())
+            self.assertTrue(connector.health_check()[0])
 
     @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
     def test_slack_health_check_failures(self):
@@ -65,8 +65,8 @@ class SlackTestCase(BaseConnectorTest):
         ):
             mock_instance = mock_webclient_cls.return_value
             mock_instance.auth_test.side_effect = Exception("invalid_auth")
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with self.subTest("Missing Token Configuration"):
             connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])

--- a/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
+++ b/tests/api_app/connectors_manager/unit_tests/connectors/test_yeti.py
@@ -162,7 +162,7 @@ class YETITestCase(BaseConnectorTest):
         with patch(
             "api_app.connectors_manager.connectors.yeti.requests.post", side_effect=mock_yeti_api_flow
         ):
-            self.assertTrue(connector.health_check())
+            self.assertTrue(connector.health_check()[0])
 
     @override_settings(STAGE_CI=False, MOCK_CONNECTIONS=False)
     def test_yeti_health_check_failures(self):
@@ -189,15 +189,15 @@ class YETITestCase(BaseConnectorTest):
                 side_effect=requests.exceptions.Timeout,
             ),
         ):
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with (
             self.subTest("Authentication Failure"),
             patch("api_app.connectors_manager.connectors.yeti.requests.post") as mock_post,
         ):
             mock_post.return_value = MockResponse({"error": "Unauthorized"}, 401)
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])
 
         with self.subTest("Missing Configuration"):
             connector._config.parameters.annotate_configured.return_value.annotate_value_for_user.return_value = []
-            self.assertFalse(connector.health_check())
+            self.assertFalse(connector.health_check()[0])


### PR DESCRIPTION
Closes #3864 

# Description

- updated health_check to return a tuple[] (bool, message)
- edited `api_app/views.py` to check both types tuple (for connectors which contain a message) and normal bool printing the default up/down message which was present before
- added/updated all relevant tests

## screenshots
- all connector test passing
<img width="2758" height="541" alt="image" src="https://github.com/user-attachments/assets/08021734-514b-4462-8d1e-88dbc4e0d04f" />
- frontend tests for this part also passing
<img width="2404" height="242" alt="image" src="https://github.com/user-attachments/assets/538b4e90-54a7-4a70-91fb-374f8d870781" />

- ui 
<img width="939" height="246" alt="image" src="https://github.com/user-attachments/assets/4dd20ca6-948d-4fce-b0fe-dc89f3b449bf" />
<img width="898" height="206" alt="image" src="https://github.com/user-attachments/assets/1d6869a6-b0f3-4412-a2ea-de3848ace9be" />
<img width="862" height="303" alt="image" src="https://github.com/user-attachments/assets/583ce794-927b-432a-8a96-09ba65768a1b" />

 
## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/post-mid-connectors`
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] If the GUI has been modified:
    - [x] I have a provided a screenshot of the result in the PR.
    - [x] I have created new frontend tests for the new component or updated existing ones.
- [x] I have reviewed and verified any LLM-generated code included in this PR. Also, I have explicitly stated that I have used LLMs in this PR.

