### PR TITLE
fix: update broken OpenCTI docs link in analyzer and connector configs

### DIFF
--- a/api_app/analyzers_manager/migrations/0002_0086_analyzer_config_opencti.py
+++ b/api_app/analyzers_manager/migrations/0002_0086_analyzer_config_opencti.py
@@ -11,7 +11,7 @@ plugin = {
         "module": "opencti.OpenCTI",
         "base_path": "api_app.analyzers_manager.observable_analyzers",
     },
-    "description": "scan an observable on a custom OpenCTI instance. CARE! This may require additional advanced configuration. Check the docs [here](https://intelowl.readthedocs.io/en/latest/Advanced-Configuration.html#opencti)",
+    "description": "scan an observable on a custom OpenCTI instance. CARE! This may require additional advanced configuration. Check the docs [here](https://intelowlproject.github.io/docs/IntelOwl/advanced_configuration/#opencti)",
     "disabled": False,
     "soft_time_limit": 30,
     "routing_key": "default",

--- a/api_app/connectors_manager/migrations/0002_0001_connector_config_opencti.py
+++ b/api_app/connectors_manager/migrations/0002_0001_connector_config_opencti.py
@@ -11,7 +11,7 @@ plugin = {
         "module": "opencti.OpenCTI",
         "base_path": "api_app.connectors_manager.connectors",
     },
-    "description": "Automatically creates an observable and a linked report on your OpenCTI instance, linking the successful analysis on IntelOwl. CARE! This may require additional advanced configuration. Check the docs [here](https://intelowl.readthedocs.io/en/latest/Advanced-Configuration.html#opencti)",
+    "description": "Automatically creates an observable and a linked report on your OpenCTI instance, linking the successful analysis on IntelOwl. CARE! This may require additional advanced configuration. Check the docs [here](https://intelowlproject.github.io/docs/IntelOwl/advanced_configuration/#opencti)",
     "disabled": False,
     "soft_time_limit": 30,
     "routing_key": "default",


### PR DESCRIPTION
## Description

This PR fixes the broken OpenCTI documentation link in both the analyzer and connector configuration migrations.

### Changes
- Updated the documentation URL from https://intelowl.readthedocs.io/en/latest/Advanced-Configuration.html#opencti to https://intelowlproject.github.io/docs/IntelOwl/advanced_configuration/#opencti

### Files Changed
- pi_app/connectors_manager/migrations/0002_0001_connector_config_opencti.py
- pi_app/analyzers_manager/migrations/0002_0086_analyzer_config_opencti.py

### Motivation
The old readthedocs URL returns a 404 error. The new GitHub Pages URL is the correct location for the OpenCTI advanced configuration documentation.

Fixes #3814