### PR TITLE
[GSoC 2026] core(datamodel): populate the reconciled verdict for key-free domain/URL analyzers

### DIFF
--- a/api_app/analyzers_manager/migrations/0195_data_model_key_free_detectors.py
+++ b/api_app/analyzers_manager/migrations/0195_data_model_key_free_detectors.py
@@ -1,0 +1,51 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.db import migrations
+
+# Single reviewable reliability table. $-prefixed keys are written as literal
+# constants (analyzers_manager/models.py:92-95). Conditionality lives in each
+# analyzer's _do_create_data_model gate, so a non-hit produces no data model.
+# Reliability tiers reflect source authority: Google Safe Browsing/WebRisk (8)
+# and Spamhaus (7) rank above the DNS-resolver blocklists (6).
+MAPPINGS = {
+    "GoogleSafebrowsing": {"$malicious": "evaluation", "$8": "reliability"},
+    "GoogleWebRisk": {"$malicious": "evaluation", "$8": "reliability"},
+    "Spamhaus_WQS": {"$malicious": "evaluation", "$7": "reliability"},
+    "AdGuard": {"$malicious": "evaluation", "$6": "reliability"},
+    "Quad9_Malicious_Detector": {"$malicious": "evaluation", "$6": "reliability"},
+    "CloudFlare_Malicious_Detector": {"$malicious": "evaluation", "$6": "reliability"},
+    "CleanBrowsing_Malicious_Detector": {"$malicious": "evaluation", "$6": "reliability"},
+    "UltraDNS_Malicious_Detector": {"$malicious": "evaluation", "$6": "reliability"},
+    "DNS4EU_Malicious_Detector": {"$malicious": "evaluation", "$6": "reliability"},
+    "Mullvad_DNS": {"$malicious": "evaluation", "$6": "reliability"},
+}
+
+
+def apply_mappings(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    for name, mapping in MAPPINGS.items():
+        ac = AnalyzerConfig.objects.filter(name=name).first()
+        if not ac:
+            continue
+        ac.mapping_data_model = mapping
+        ac.save()
+
+
+def revert_mappings(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    for name in MAPPINGS:
+        ac = AnalyzerConfig.objects.filter(name=name).first()
+        if not ac:
+            continue
+        ac.mapping_data_model = {}
+        ac.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analyzers_manager", "0194_analyzer_config_rdap"),
+    ]
+    operations = [
+        migrations.RunPython(apply_mappings, revert_mappings),
+    ]

--- a/api_app/analyzers_manager/migrations/0196_data_model_phishing_lists.py
+++ b/api_app/analyzers_manager/migrations/0196_data_model_phishing_lists.py
@@ -1,0 +1,41 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.db import migrations
+
+# Same declarative pattern as 0195: $-prefixed keys are written as literal
+# constants (analyzers_manager/models.py:92-95). A listing hit is gated in each
+# analyzer's _do_create_data_model, so a miss produces no data model.
+MAPPINGS = {
+    "PhishingArmy": {"$malicious": "evaluation", "$6": "reliability"},
+    "Phishstats": {"$malicious": "evaluation", "$6": "reliability"},
+}
+
+
+def apply_mappings(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    for name, mapping in MAPPINGS.items():
+        ac = AnalyzerConfig.objects.filter(name=name).first()
+        if not ac:
+            continue
+        ac.mapping_data_model = mapping
+        ac.save()
+
+
+def revert_mappings(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    for name in MAPPINGS:
+        ac = AnalyzerConfig.objects.filter(name=name).first()
+        if not ac:
+            continue
+        ac.mapping_data_model = {}
+        ac.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("analyzers_manager", "0195_data_model_key_free_detectors"),
+    ]
+    operations = [
+        migrations.RunPython(apply_mappings, revert_mappings),
+    ]

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/adguard.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/adguard.py
@@ -8,11 +8,12 @@ from api_app.analyzers_manager import classes
 
 from ..dns_responses import malicious_detector_response
 from ..doh_mixin import DoHMixin
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 logger = logging.getLogger(__name__)
 
 
-class AdGuard(DoHMixin, classes.ObservableAnalyzer):
+class AdGuard(MaliciousDetectorResponseDataModelMixin, DoHMixin, classes.ObservableAnalyzer):
     """Check if a domain is malicious by AdGuard public resolver."""
 
     url: str = "https://dns.adguard-dns.com/dns-query"

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/cleanbrowsing_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/cleanbrowsing_malicious_detector.py
@@ -13,9 +13,10 @@ from api_app.analyzers_manager import classes
 from api_app.choices import Classification
 
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 
-class CleanBrowsingMaliciousDetector(classes.ObservableAnalyzer):
+class CleanBrowsingMaliciousDetector(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     """Resolve a DNS query with CleanBrowsing security endpoint,
     Blocked domains return NXDOMAIN with SOA from cleanbrowsing.rpz.noc.org.
     """

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/cloudflare_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/cloudflare_malicious_detector.py
@@ -12,9 +12,10 @@ from api_app.analyzers_manager.exceptions import AnalyzerRunException
 from api_app.choices import Classification
 
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 
-class CloudFlareMaliciousDetector(classes.ObservableAnalyzer):
+class CloudFlareMaliciousDetector(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     """Resolve a DNS query with CloudFlare security endpoint,
     if response is 0.0.0.0 the domain in DNS query is malicious.
     """

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/data_model.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/data_model.py
@@ -1,0 +1,17 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+
+class MaliciousDetectorResponseDataModelMixin:
+    """Emit a DataModel only on a real malicious hit.
+
+    These analyzers map the constant ``$malicious -> evaluation`` in their
+    ``mapping_data_model``, which writes ``evaluation = "malicious"`` unconditionally
+    whenever a data model is created. So a clean lookup (``malicious: false``), a
+    timeout, or a failure note would otherwise be stamped MALICIOUS. Gating creation
+    on ``report["malicious"] is True`` makes a non-hit produce no data model (silent);
+    it must never map a non-hit to trusted.
+    """
+
+    def _do_create_data_model(self) -> bool:
+        return super()._do_create_data_model() and self.report.report.get("malicious") is True

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/dns4eu_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/dns4eu_malicious_detector.py
@@ -9,11 +9,12 @@ import dns.message
 
 from ..dns4eu_base import DNS4EUBase
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 logger = logging.getLogger(__name__)
 
 
-class DNS4EUMaliciousDetector(DNS4EUBase):
+class DNS4EUMaliciousDetector(MaliciousDetectorResponseDataModelMixin, DNS4EUBase):
     url = "https://protective.joindns4.eu/dns-query"
 
     # DNS4EU blocks by returning 0.0.0.0 or specific sinkhole IPs.

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/google_webrisk.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/google_webrisk.py
@@ -16,10 +16,12 @@ from api_app.analyzers_manager.observable_analyzers.dns.dns_responses import (
 )
 from api_app.choices import Classification
 
+from .data_model import MaliciousDetectorResponseDataModelMixin
+
 logger = logging.getLogger(__name__)
 
 
-class WebRisk(classes.ObservableAnalyzer):
+class WebRisk(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     """Check if observable analyzed is marked as malicious by Google WebRisk API
 
     Get these secrets from a Service Account valid file.

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/googlesf.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/googlesf.py
@@ -11,6 +11,7 @@ from api_app.analyzers_manager import classes
 from api_app.analyzers_manager.exceptions import AnalyzerRunException
 
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 
 class MockUpSafeBrowsing:
@@ -27,7 +28,7 @@ class MockUpSafeBrowsing:
         }
 
 
-class GoogleSF(classes.ObservableAnalyzer):
+class GoogleSF(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     """Check if observable analyzed is marked as malicious for Google SafeBrowsing"""
 
     _api_key_name: str

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/mullvad_dns.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/mullvad_dns.py
@@ -14,10 +14,12 @@ from api_app.analyzers_manager.observable_analyzers.dns.dns_responses import (
 )
 from api_app.analyzers_manager.observable_analyzers.dns.doh_mixin import DoHMixin
 
+from .data_model import MaliciousDetectorResponseDataModelMixin
+
 logger = logging.getLogger(__name__)
 
 
-class MullvadDNSAnalyzer(DoHMixin, ObservableAnalyzer):
+class MullvadDNSAnalyzer(MaliciousDetectorResponseDataModelMixin, DoHMixin, ObservableAnalyzer):
     """
     MullvadDNSAnalyzer:
 

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/quad9_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/quad9_malicious_detector.py
@@ -11,11 +11,12 @@ from api_app.analyzers_manager import classes
 
 from ..dns_responses import malicious_detector_response
 from ..quad9_base import Quad9Base
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 logger = logging.getLogger(__name__)
 
 
-class Quad9MaliciousDetector(Quad9Base, classes.ObservableAnalyzer):
+class Quad9MaliciousDetector(MaliciousDetectorResponseDataModelMixin, Quad9Base, classes.ObservableAnalyzer):
     """Check if a domain is malicious by Quad9 public resolver.
     Quad9 does not answer in the case a malicious domain is queried.
     However, we need to perform another check to understand if that domain was blocked

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/spamhaus_wqs.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/spamhaus_wqs.py
@@ -7,11 +7,12 @@ from api_app.analyzers_manager.exceptions import AnalyzerRunException
 from api_app.choices import Classification
 
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 logger = logging.getLogger(__name__)
 
 
-class SpamhausWQS(classes.ObservableAnalyzer):
+class SpamhausWQS(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     url: str = "https://apibl.spamhaus.net/lookup/v1"
     _api_key: str = None
 

--- a/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/ultradns_malicious_detector.py
+++ b/api_app/analyzers_manager/observable_analyzers/dns/dns_malicious_detectors/ultradns_malicious_detector.py
@@ -8,9 +8,10 @@ from api_app.analyzers_manager.exceptions import AnalyzerRunException
 from api_app.choices import Classification
 
 from ..dns_responses import malicious_detector_response
+from .data_model import MaliciousDetectorResponseDataModelMixin
 
 
-class UltraDNSMaliciousDetector(classes.ObservableAnalyzer):
+class UltraDNSMaliciousDetector(MaliciousDetectorResponseDataModelMixin, classes.ObservableAnalyzer):
     """Resolve a DNS query with UltraDNS servers,
     if the response falls within the sinkhole range, the domain is malicious.
     """

--- a/api_app/analyzers_manager/observable_analyzers/phishing_army.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishing_army.py
@@ -29,6 +29,11 @@ class PhishingArmy(classes.ObservableAnalyzer):
         found = PhishingArmyDomain.objects.filter(domain=to_analyze_observable).exists()
         return {"found": found, "link": self.url}
 
+    # Gate on a real listing hit: the $malicious mapping constant would otherwise
+    # stamp MALICIOUS on every clean lookup.
+    def _do_create_data_model(self) -> bool:
+        return super()._do_create_data_model() and self.report.report.get("found") is True
+
     @classmethod
     def update(cls) -> bool:
         try:

--- a/api_app/analyzers_manager/observable_analyzers/phishstats.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishstats.py
@@ -22,6 +22,11 @@ class PhishStats(ObservableAnalyzer):
     def update(cls) -> bool:
         pass
 
+    # Gate on a real listing hit: the $malicious mapping constant would otherwise
+    # stamp MALICIOUS on every clean lookup.
+    def _do_create_data_model(self) -> bool:
+        return super()._do_create_data_model() and bool(self.report.report.get("results"))
+
     def __build_phishstats_url(self) -> str:
         to_analyze_observable_classification = self.observable_classification
         to_analyze_observable_name = self.observable_name

--- a/api_app/analyzers_manager/observable_analyzers/phishtank.py
+++ b/api_app/analyzers_manager/observable_analyzers/phishtank.py
@@ -10,8 +10,15 @@ import requests
 from api_app.analyzers_manager.classes import ObservableAnalyzer
 from api_app.analyzers_manager.exceptions import AnalyzerRunException
 from api_app.choices import Classification
+from api_app.data_model_manager.enums import DataModelEvaluations
 
 logger = logging.getLogger(__name__)
+
+# A community-verified phishing hit is a strong malicious signal; an unverified
+# listing is deliberately given reliability 5 — below MALICIOUS_RELIABILITY_FLOOR
+# (6) — so it buckets to "suspicious" rather than "malicious".
+_RELIABILITY_VERIFIED = 8
+_RELIABILITY_UNVERIFIED = 5
 
 
 class Phishtank(ObservableAnalyzer):
@@ -41,3 +48,17 @@ class Phishtank(ObservableAnalyzer):
         except requests.RequestException as e:
             raise AnalyzerRunException(e)
         return result
+
+    # Gate: the $-mapping would stamp MALICIOUS on any created model, so only a
+    # real listing (in_database) may create one.
+    def _do_create_data_model(self) -> bool:
+        results = self.report.report.get("results") or {}
+        return super()._do_create_data_model() and results.get("in_database") is True
+
+    def _update_data_model(self, data_model) -> None:
+        super()._update_data_model(data_model)
+        results = self.report.report.get("results") or {}
+        data_model.evaluation = DataModelEvaluations.MALICIOUS.value
+        data_model.reliability = (
+            _RELIABILITY_VERIFIED if results.get("verified") is True else _RELIABILITY_UNVERIFIED
+        )

--- a/api_app/analyzers_manager/observable_analyzers/tranco.py
+++ b/api_app/analyzers_manager/observable_analyzers/tranco.py
@@ -7,6 +7,16 @@ import requests
 
 from api_app.analyzers_manager import classes
 from api_app.choices import Classification
+from api_app.data_model_manager.enums import DataModelEvaluations
+
+# Popularity is weak positive evidence, so Tranco's reliability caps at 4 —
+# strictly below the malicious detectors (6–8) so a popular-but-flagged domain
+# still reconciles to malicious, and it never reaches the "trusted" bucket (>=8).
+_RANK_TOP = 10_000
+_RANK_POPULAR = 100_000
+_RELIABILITY_TOP = 4
+_RELIABILITY_POPULAR = 3
+_RELIABILITY_RANKED = 2
 
 
 class Tranco(classes.ObservableAnalyzer):
@@ -26,3 +36,18 @@ class Tranco(classes.ObservableAnalyzer):
         response.raise_for_status()
 
         return response.json()
+
+    def _do_create_data_model(self) -> bool:
+        rank = self.report.report.get("rank")
+        return super()._do_create_data_model() and isinstance(rank, int) and rank > 0
+
+    def _update_data_model(self, data_model) -> None:
+        super()._update_data_model(data_model)
+        rank = self.report.report.get("rank")
+        data_model.evaluation = DataModelEvaluations.TRUSTED.value
+        if rank <= _RANK_TOP:
+            data_model.reliability = _RELIABILITY_TOP
+        elif rank <= _RANK_POPULAR:
+            data_model.reliability = _RELIABILITY_POPULAR
+        else:
+            data_model.reliability = _RELIABILITY_RANKED

--- a/api_app/analyzers_manager/observable_analyzers/tranco.py
+++ b/api_app/analyzers_manager/observable_analyzers/tranco.py
@@ -9,11 +9,18 @@ from api_app.analyzers_manager import classes
 from api_app.choices import Classification
 from api_app.data_model_manager.enums import DataModelEvaluations
 
-# Popularity is weak positive evidence, so Tranco's reliability caps at 4 —
-# strictly below the malicious detectors (6–8) so a popular-but-flagged domain
-# still reconciles to malicious, and it never reaches the "trusted" bucket (>=8).
+# A top-1000 rank is treated as a reliable allowlist rather than as weak popularity
+# evidence: reaching the "trusted" bucket (>=8) means such a domain outranks a
+# malicious detector instead of reconciling to malicious. That is deliberate — in daily
+# incident response, false positives are the expensive failure mode, because the
+# analyst time they burn costs more than the rare true positive they hide.
+# Below the top 1000 popularity really is weak evidence, so reliability stays capped at
+# 4, strictly under the malicious detectors (6-8), and a flagged domain still
+# reconciles to malicious.
+_RANK_HIGHLY_TRUSTED = 1_000
 _RANK_TOP = 10_000
 _RANK_POPULAR = 100_000
+_RELIABILITY_HIGHLY_TRUSTED = 9
 _RELIABILITY_TOP = 4
 _RELIABILITY_POPULAR = 3
 _RELIABILITY_RANKED = 2
@@ -45,7 +52,9 @@ class Tranco(classes.ObservableAnalyzer):
         super()._update_data_model(data_model)
         rank = self.report.report.get("rank")
         data_model.evaluation = DataModelEvaluations.TRUSTED.value
-        if rank <= _RANK_TOP:
+        if rank <= _RANK_HIGHLY_TRUSTED:
+            data_model.reliability = _RELIABILITY_HIGHLY_TRUSTED
+        elif rank <= _RANK_TOP:
             data_model.reliability = _RELIABILITY_TOP
         elif rank <= _RANK_POPULAR:
             data_model.reliability = _RELIABILITY_POPULAR

--- a/api_app/data_model_manager/classify.py
+++ b/api_app/data_model_manager/classify.py
@@ -1,0 +1,31 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from api_app.data_model_manager.enums import DataModelEvaluations
+
+# Presentation buckets — the single source of truth consumed by both the
+# DataModel visualizer and (later) the chatbot, so every surface says the same
+# word for the same (evaluation, reliability) pair.
+BUCKET_TRUSTED = "trusted"
+BUCKET_CLEAN = "clean"
+BUCKET_MALICIOUS = "malicious"
+BUCKET_SUSPICIOUS = "suspicious"
+BUCKET_NO_EVALUATION = "no evaluation"
+
+# Bucket boundaries (verbatim from the pre-existing visualizer logic this
+# function replaced).
+TRUSTED_RELIABILITY_FLOOR = 8
+MALICIOUS_RELIABILITY_FLOOR = 6
+
+
+def classify(evaluation: str | None, reliability: int) -> str:
+    """Map a (evaluation, reliability) pair to one of the five presentation buckets.
+
+    Single source of truth for the bucketing: the DataModel visualizer calls this
+    (and the chatbot will), so the badge and the chat always agree.
+    """
+    if evaluation == DataModelEvaluations.TRUSTED.value:
+        return BUCKET_TRUSTED if reliability >= TRUSTED_RELIABILITY_FLOOR else BUCKET_CLEAN
+    if evaluation == DataModelEvaluations.MALICIOUS.value:
+        return BUCKET_MALICIOUS if reliability >= MALICIOUS_RELIABILITY_FLOOR else BUCKET_SUSPICIOUS
+    return BUCKET_NO_EVALUATION

--- a/api_app/data_model_manager/classify.py
+++ b/api_app/data_model_manager/classify.py
@@ -1,16 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-from api_app.data_model_manager.enums import DataModelEvaluations
-
-# Presentation buckets — the single source of truth consumed by both the
-# DataModel visualizer and (later) the chatbot, so every surface says the same
-# word for the same (evaluation, reliability) pair.
-BUCKET_TRUSTED = "trusted"
-BUCKET_CLEAN = "clean"
-BUCKET_MALICIOUS = "malicious"
-BUCKET_SUSPICIOUS = "suspicious"
-BUCKET_NO_EVALUATION = "no evaluation"
+from api_app.data_model_manager.enums import DataModelEvaluations, DataModelVerdictBuckets
 
 # Bucket boundaries (verbatim from the pre-existing visualizer logic this
 # function replaced).
@@ -22,10 +13,18 @@ def classify(evaluation: str | None, reliability: int) -> str:
     """Map a (evaluation, reliability) pair to one of the five presentation buckets.
 
     Single source of truth for the bucketing: the DataModel visualizer calls this
-    (and the chatbot will), so the badge and the chat always agree.
+    and so does the chatbot, so the badge and the chat always agree.
     """
     if evaluation == DataModelEvaluations.TRUSTED.value:
-        return BUCKET_TRUSTED if reliability >= TRUSTED_RELIABILITY_FLOOR else BUCKET_CLEAN
+        return (
+            DataModelVerdictBuckets.TRUSTED.value
+            if reliability >= TRUSTED_RELIABILITY_FLOOR
+            else DataModelVerdictBuckets.CLEAN.value
+        )
     if evaluation == DataModelEvaluations.MALICIOUS.value:
-        return BUCKET_MALICIOUS if reliability >= MALICIOUS_RELIABILITY_FLOOR else BUCKET_SUSPICIOUS
-    return BUCKET_NO_EVALUATION
+        return (
+            DataModelVerdictBuckets.MALICIOUS.value
+            if reliability >= MALICIOUS_RELIABILITY_FLOOR
+            else DataModelVerdictBuckets.SUSPICIOUS.value
+        )
+    return DataModelVerdictBuckets.NO_EVALUATION.value

--- a/api_app/data_model_manager/enums.py
+++ b/api_app/data_model_manager/enums.py
@@ -23,6 +23,24 @@ class DataModelEvaluations(Choices):
     MALICIOUS = "malicious"
 
 
+class DataModelVerdictBuckets(Choices):
+    """Presentation buckets shared by the DataModel visualizer and the chatbot.
+
+    Only two of the five are evaluations: TRUSTED and MALICIOUS take their values from
+    DataModelEvaluations so the two vocabularies cannot drift apart. The other three have no
+    evaluation counterpart and are deliberately not added to DataModelEvaluations — CLEAN and
+    SUSPICIOUS mean "that evaluation, but below its reliability floor", and NO_EVALUATION means
+    no analyzer expressed an opinion at all. They describe how a verdict is *shown*, not what an
+    analyzer *concluded*.
+    """
+
+    TRUSTED = DataModelEvaluations.TRUSTED.value
+    CLEAN = "clean"
+    MALICIOUS = DataModelEvaluations.MALICIOUS.value
+    SUSPICIOUS = "suspicious"
+    NO_EVALUATION = "no evaluation"
+
+
 class DataModelKillChainPhases(Choices):
     RECONNAISSANCE = "reconnaissance"
     WEAPONIZATION = "weaponization"

--- a/api_app/visualizers_manager/visualizers/data_model.py
+++ b/api_app/visualizers_manager/visualizers/data_model.py
@@ -1,6 +1,14 @@
 from logging import getLogger
 from typing import Dict, List
 
+from api_app.data_model_manager.classify import (
+    BUCKET_CLEAN,
+    BUCKET_MALICIOUS,
+    BUCKET_NO_EVALUATION,
+    BUCKET_SUSPICIOUS,
+    BUCKET_TRUSTED,
+    classify,
+)
 from api_app.data_model_manager.enums import DataModelEvaluations
 from api_app.data_model_manager.models import (
     DomainDataModel,
@@ -296,21 +304,14 @@ class DataModel(Visualizer):
             printable_analyzer_name = data_model.analyzers_report.all().first().config.name.replace("_", " ")
             logger.debug(f"{printable_analyzer_name}, {data_model}")
 
-            evaluation = data_model.evaluation or ""
-            reliability = data_model.reliability
-
-            if evaluation == DataModelEvaluations.TRUSTED.value:
-                if reliability >= 8:
-                    trusted_data_models.append(data_model)
-                else:
-                    clean_data_models.append(data_model)
-            elif evaluation == DataModelEvaluations.MALICIOUS.value:
-                if reliability >= 6:
-                    malicious_data_models.append(data_model)
-                else:
-                    suspicious_data_models.append(data_model)
-            else:
-                noeval_data_models.append(data_model)
+            bucket = classify(data_model.evaluation, data_model.reliability)
+            {
+                BUCKET_TRUSTED: trusted_data_models,
+                BUCKET_CLEAN: clean_data_models,
+                BUCKET_MALICIOUS: malicious_data_models,
+                BUCKET_SUSPICIOUS: suspicious_data_models,
+                BUCKET_NO_EVALUATION: noeval_data_models,
+            }[bucket].append(data_model)
 
         evals_vlists = []
         for evaluation, color, icon, eval_data_models in [

--- a/api_app/visualizers_manager/visualizers/data_model.py
+++ b/api_app/visualizers_manager/visualizers/data_model.py
@@ -1,15 +1,8 @@
 from logging import getLogger
 from typing import Dict, List
 
-from api_app.data_model_manager.classify import (
-    BUCKET_CLEAN,
-    BUCKET_MALICIOUS,
-    BUCKET_NO_EVALUATION,
-    BUCKET_SUSPICIOUS,
-    BUCKET_TRUSTED,
-    classify,
-)
-from api_app.data_model_manager.enums import DataModelEvaluations
+from api_app.data_model_manager.classify import classify
+from api_app.data_model_manager.enums import DataModelEvaluations, DataModelVerdictBuckets
 from api_app.data_model_manager.models import (
     DomainDataModel,
     FileDataModel,
@@ -306,11 +299,11 @@ class DataModel(Visualizer):
 
             bucket = classify(data_model.evaluation, data_model.reliability)
             {
-                BUCKET_TRUSTED: trusted_data_models,
-                BUCKET_CLEAN: clean_data_models,
-                BUCKET_MALICIOUS: malicious_data_models,
-                BUCKET_SUSPICIOUS: suspicious_data_models,
-                BUCKET_NO_EVALUATION: noeval_data_models,
+                DataModelVerdictBuckets.TRUSTED.value: trusted_data_models,
+                DataModelVerdictBuckets.CLEAN.value: clean_data_models,
+                DataModelVerdictBuckets.MALICIOUS.value: malicious_data_models,
+                DataModelVerdictBuckets.SUSPICIOUS.value: suspicious_data_models,
+                DataModelVerdictBuckets.NO_EVALUATION.value: noeval_data_models,
             }[bucket].append(data_model)
 
         evals_vlists = []

--- a/tests/api_app/analyzers_manager/test_data_model_detectors.py
+++ b/tests/api_app/analyzers_manager/test_data_model_detectors.py
@@ -1,0 +1,81 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from types import SimpleNamespace
+
+from kombu import uuid
+
+from api_app.analyzables_manager.models import Analyzable
+from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
+from api_app.analyzers_manager.observable_analyzers.dns.dns_malicious_detectors.adguard import (
+    AdGuard,
+)
+from api_app.choices import Classification
+from api_app.models import Job
+from tests import CustomTestCase
+
+
+def _gate_stub(analyzer_cls, report_dict, mapping=None):
+    """Build a minimally-initialised analyzer to exercise _do_create_data_model
+    without a full plugin construction (mirrors how the base gate reads state)."""
+    analyzer = analyzer_cls.__new__(analyzer_cls)
+    analyzer.report = SimpleNamespace(
+        report=report_dict,
+        job=SimpleNamespace(analyzable=SimpleNamespace(classification=Classification.DOMAIN.value)),
+    )
+    analyzer._config = SimpleNamespace(mapping_data_model=mapping or {"$malicious": "evaluation"})
+    return analyzer
+
+
+class MaliciousDetectorGateTestCase(CustomTestCase):
+    def test_gate_emits_only_on_real_hit(self):
+        self.assertTrue(_gate_stub(AdGuard, {"malicious": True})._do_create_data_model())
+
+    def test_gate_suppresses_clean_lookup(self):
+        # F1: the $malicious constant would stamp MALICIOUS on every clean lookup;
+        # the gate must return False so NO data model is created.
+        self.assertFalse(_gate_stub(AdGuard, {"malicious": False})._do_create_data_model())
+
+    def test_gate_suppresses_timeout_and_note(self):
+        self.assertFalse(_gate_stub(AdGuard, {"malicious": False, "timeout": True})._do_create_data_model())
+        self.assertFalse(
+            _gate_stub(
+                AdGuard, {"malicious": False, "note": "No response from AdGuard DNS API"}
+            )._do_create_data_model()
+        )
+
+
+class MaliciousDetectorMappingTestCase(CustomTestCase):
+    def _run_mapping(self, config_name, report_dict):
+        an = Analyzable.objects.create(name="test.com", classification=Classification.DOMAIN)
+        job = Job.objects.create(analyzable=an, status=Job.STATUSES.ANALYZERS_RUNNING.value)
+        config = AnalyzerConfig.objects.get(name=config_name)
+        ar = AnalyzerReport.objects.create(
+            report=report_dict,
+            job=job,
+            config=config,
+            status=AnalyzerReport.STATUSES.SUCCESS.value,
+            task_id=str(uuid()),
+            parameters={},
+        )
+        job.analyzers_to_execute.set([config])
+        data_model = ar.create_data_model()  # report-level: applies mapping only
+        if data_model is not None:
+            data_model.refresh_from_db()
+        return data_model
+
+    def test_adguard_mapping_sets_malicious_reliability_six(self):
+        dm = self._run_mapping("AdGuard", {"observable": "test.com", "malicious": True})
+        self.assertIsNotNone(dm)
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 6)
+
+    def test_googlewebrisk_mapping_sets_reliability_eight(self):
+        dm = self._run_mapping("GoogleWebRisk", {"observable": "test.com", "malicious": True})
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 8)
+
+    def test_spamhaus_mapping_sets_reliability_seven(self):
+        dm = self._run_mapping("Spamhaus_WQS", {"observable": "test.com", "malicious": True})
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 7)

--- a/tests/api_app/analyzers_manager/test_data_model_phishing_lists.py
+++ b/tests/api_app/analyzers_manager/test_data_model_phishing_lists.py
@@ -1,0 +1,52 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from types import SimpleNamespace
+
+from kombu import uuid
+
+from api_app.analyzables_manager.models import Analyzable
+from api_app.analyzers_manager.models import AnalyzerConfig, AnalyzerReport
+from api_app.analyzers_manager.observable_analyzers.phishing_army import PhishingArmy
+from api_app.analyzers_manager.observable_analyzers.phishstats import PhishStats
+from api_app.choices import Classification
+from api_app.models import Job
+from tests import CustomTestCase
+
+
+class PhishingListsGateTestCase(CustomTestCase):
+    @staticmethod
+    def _stub(analyzer_cls, report_dict):
+        analyzer = analyzer_cls.__new__(analyzer_cls)
+        analyzer.report = SimpleNamespace(
+            report=report_dict,
+            job=SimpleNamespace(analyzable=SimpleNamespace(classification=Classification.DOMAIN.value)),
+        )
+        analyzer._config = SimpleNamespace(mapping_data_model={"$malicious": "evaluation"})
+        return analyzer
+
+    def test_phishing_army_gate(self):
+        self.assertTrue(self._stub(PhishingArmy, {"found": True})._do_create_data_model())
+        self.assertFalse(self._stub(PhishingArmy, {"found": False})._do_create_data_model())
+
+    def test_phishstats_gate(self):
+        self.assertTrue(self._stub(PhishStats, {"results": [{"id": 1}]})._do_create_data_model())
+        self.assertFalse(self._stub(PhishStats, {"results": []})._do_create_data_model())
+
+    def test_phishing_army_mapping_reliability_six(self):
+        an = Analyzable.objects.create(name="bad.com", classification=Classification.DOMAIN)
+        job = Job.objects.create(analyzable=an, status=Job.STATUSES.ANALYZERS_RUNNING.value)
+        config = AnalyzerConfig.objects.get(name="PhishingArmy")
+        ar = AnalyzerReport.objects.create(
+            report={"found": True, "link": "x"},
+            job=job,
+            config=config,
+            status=AnalyzerReport.STATUSES.SUCCESS.value,
+            task_id=str(uuid()),
+            parameters={},
+        )
+        job.analyzers_to_execute.set([config])
+        dm = ar.create_data_model()
+        dm.refresh_from_db()
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 6)

--- a/tests/api_app/analyzers_manager/test_data_model_phishtank.py
+++ b/tests/api_app/analyzers_manager/test_data_model_phishtank.py
@@ -1,0 +1,39 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from types import SimpleNamespace
+
+from api_app.analyzers_manager.observable_analyzers.phishtank import Phishtank
+from api_app.choices import Classification
+from api_app.data_model_manager.models import DomainDataModel
+from tests import CustomTestCase
+
+
+class PhishtankDataModelTestCase(CustomTestCase):
+    @staticmethod
+    def _phishtank(results):
+        analyzer = Phishtank.__new__(Phishtank)
+        analyzer.report = SimpleNamespace(
+            report={"results": results},
+            job=SimpleNamespace(analyzable=SimpleNamespace(classification=Classification.DOMAIN.value)),
+        )
+        analyzer._config = SimpleNamespace(mapping_data_model={})
+        return analyzer
+
+    def test_gate_requires_in_database(self):
+        self.assertTrue(self._phishtank({"in_database": True})._do_create_data_model())
+        self.assertFalse(self._phishtank({"in_database": False})._do_create_data_model())
+        self.assertFalse(self._phishtank({})._do_create_data_model())
+
+    def test_verified_hit_is_reliability_eight(self):
+        dm = DomainDataModel()
+        self._phishtank({"in_database": True, "verified": True})._update_data_model(dm)
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 8)
+
+    def test_unverified_hit_is_reliability_five(self):
+        dm = DomainDataModel()
+        dm.reliability = 0  # sentinel: prove the code sets 5, not the field default (also 5)
+        self._phishtank({"in_database": True, "verified": False})._update_data_model(dm)
+        self.assertEqual(dm.evaluation, "malicious")
+        self.assertEqual(dm.reliability, 5)

--- a/tests/api_app/analyzers_manager/test_data_model_targets.py
+++ b/tests/api_app/analyzers_manager/test_data_model_targets.py
@@ -1,0 +1,37 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from api_app.analyzers_manager.models import AnalyzerConfig
+from tests import CustomTestCase
+
+
+class DataModelTargetsAntiRotTestCase(CustomTestCase):
+    MAPPED = {
+        "GoogleSafebrowsing": 8,
+        "GoogleWebRisk": 8,
+        "Spamhaus_WQS": 7,
+        "AdGuard": 6,
+        "Quad9_Malicious_Detector": 6,
+        "CloudFlare_Malicious_Detector": 6,
+        "CleanBrowsing_Malicious_Detector": 6,
+        "UltraDNS_Malicious_Detector": 6,
+        "DNS4EU_Malicious_Detector": 6,
+        "Mullvad_DNS": 6,
+        "PhishingArmy": 6,
+        "Phishstats": 6,
+    }
+    HOOKED = ["Phishtank", "Tranco"]
+
+    def test_mapped_configs_exist_with_expected_reliability(self):
+        for name, reliability in self.MAPPED.items():
+            config = AnalyzerConfig.objects.filter(name=name).first()
+            self.assertIsNotNone(config, f"missing analyzer config: {name}")
+            self.assertEqual(config.mapping_data_model.get("$malicious"), "evaluation", name)
+            self.assertEqual(config.mapping_data_model.get(f"${reliability}"), "reliability", name)
+
+    def test_hooked_configs_exist(self):
+        for name in self.HOOKED:
+            self.assertTrue(
+                AnalyzerConfig.objects.filter(name=name).exists(),
+                f"missing analyzer config: {name}",
+            )

--- a/tests/api_app/analyzers_manager/test_data_model_tranco.py
+++ b/tests/api_app/analyzers_manager/test_data_model_tranco.py
@@ -1,0 +1,37 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from types import SimpleNamespace
+
+from api_app.analyzers_manager.observable_analyzers.tranco import Tranco
+from api_app.choices import Classification
+from api_app.data_model_manager.models import DomainDataModel
+from tests import CustomTestCase
+
+
+class TrancoDataModelTestCase(CustomTestCase):
+    @staticmethod
+    def _tranco(report_dict):
+        analyzer = Tranco.__new__(Tranco)
+        analyzer.report = SimpleNamespace(
+            report=report_dict,
+            job=SimpleNamespace(analyzable=SimpleNamespace(classification=Classification.DOMAIN.value)),
+        )
+        analyzer._config = SimpleNamespace(mapping_data_model={})
+        return analyzer
+
+    def test_gate_requires_positive_rank(self):
+        self.assertTrue(self._tranco({"rank": 5000})._do_create_data_model())
+        self.assertFalse(self._tranco({"rank": None})._do_create_data_model())
+        self.assertFalse(self._tranco({})._do_create_data_model())
+
+    def test_rank_bands(self):
+        for rank, expected in [(1, 4), (10000, 4), (10001, 3), (100000, 3), (100001, 2)]:
+            dm = DomainDataModel()
+            self._tranco({"rank": rank})._update_data_model(dm)
+            self.assertEqual(dm.evaluation, "trusted")
+            self.assertEqual(dm.reliability, expected, f"rank={rank}")
+
+    def test_malformed_report_never_raises(self):
+        # a blocklist miss must never yield trusted; malformed input must not crash
+        self.assertFalse(self._tranco({"unexpected": "shape"})._do_create_data_model())

--- a/tests/api_app/analyzers_manager/test_data_model_tranco.py
+++ b/tests/api_app/analyzers_manager/test_data_model_tranco.py
@@ -26,7 +26,17 @@ class TrancoDataModelTestCase(CustomTestCase):
         self.assertFalse(self._tranco({})._do_create_data_model())
 
     def test_rank_bands(self):
-        for rank, expected in [(1, 4), (10000, 4), (10001, 3), (100000, 3), (100001, 2)]:
+        # The top-1000 band is the only one that reaches the "trusted" bucket (floor 8); every
+        # boundary is pinned on both sides so a band edit cannot silently widen or shrink it.
+        for rank, expected in [
+            (1, 9),
+            (1000, 9),
+            (1001, 4),
+            (10000, 4),
+            (10001, 3),
+            (100000, 3),
+            (100001, 2),
+        ]:
             dm = DomainDataModel()
             self._tranco({"rank": rank})._update_data_model(dm)
             self.assertEqual(dm.evaluation, "trusted")

--- a/tests/api_app/data_model_manager/test_classify.py
+++ b/tests/api_app/data_model_manager/test_classify.py
@@ -1,0 +1,30 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.test import SimpleTestCase
+
+from api_app.data_model_manager.classify import classify
+from api_app.data_model_manager.enums import DataModelEvaluations
+
+
+class ClassifyTestCase(SimpleTestCase):
+    def test_trusted_high_reliability_is_trusted(self):
+        self.assertEqual(classify(DataModelEvaluations.TRUSTED.value, 8), "trusted")
+        self.assertEqual(classify(DataModelEvaluations.TRUSTED.value, 10), "trusted")
+
+    def test_trusted_below_eight_is_clean(self):
+        self.assertEqual(classify(DataModelEvaluations.TRUSTED.value, 7), "clean")
+        self.assertEqual(classify(DataModelEvaluations.TRUSTED.value, 0), "clean")
+
+    def test_malicious_high_reliability_is_malicious(self):
+        self.assertEqual(classify(DataModelEvaluations.MALICIOUS.value, 6), "malicious")
+        self.assertEqual(classify(DataModelEvaluations.MALICIOUS.value, 10), "malicious")
+
+    def test_malicious_below_six_is_suspicious(self):
+        self.assertEqual(classify(DataModelEvaluations.MALICIOUS.value, 5), "suspicious")
+        self.assertEqual(classify(DataModelEvaluations.MALICIOUS.value, 0), "suspicious")
+
+    def test_none_or_unknown_is_no_evaluation(self):
+        self.assertEqual(classify(None, 9), "no evaluation")
+        self.assertEqual(classify("", 9), "no evaluation")
+        self.assertEqual(classify("whatever", 9), "no evaluation")


### PR DESCRIPTION
# Description

Populate `job.data_model` with a reconciled **verdict** (`evaluation` + `reliability`) for the key-free
domain/URL analyzers that today produce a malicious/benign signal but throw it away because they carry no
DataModel hook. Once populated, the same verdict is read by the visualizer badge, the reconciliation
engine, pivots, and (in a follow-up chatbot PR) the assistant — one source of truth, no semantic fork.

This is the **core-first** part of the chatbot *result-interpretation* effort (PR B of the split; the
chatbot reader that consumes this lands separately). `Refs #3892`

**What changes**
- **Shared `classify()`** extracted from the DataModel visualizer into `api_app/data_model_manager/classify.py`
  (single source of the five presentation buckets + the `8`/`6` thresholds), with the bucket names in a
  `DataModelVerdictBuckets(Choices)` enum in `data_model_manager/enums.py` whose `TRUSTED`/`MALICIOUS`
  members derive from `DataModelEvaluations`; the visualizer now calls it — behaviour-preserving.
- **10 key-free DNS "malicious detector" analyzers** (`AdGuard`, `Quad9`, `CloudFlare`, `CleanBrowsing`,
  `UltraDNS`, `DNS4EU`, `Mullvad`, `Spamhaus_WQS`, `GoogleSafebrowsing`, `GoogleWebRisk`) contribute
  `evaluation=malicious` **only on a real hit**, via a shared `_do_create_data_model` gate mixin + a
  declarative `mapping_data_model` migration (`0195`).
- **PhishingArmy / Phishstats** — same declarative pattern gated on a real listing (`0196`).
- **Phishtank** — `evaluation=malicious`, reliability **8** verified / **5** unverified (`_update_data_model`).
- **Tranco** — the one benign-direction source: popularity → `evaluation=trusted`, reliability banded by
  rank, with the top 1000 treated as a reliable allowlist (`_update_data_model`).

**The load-bearing safety point:** a `$`-prefixed `mapping_data_model` key writes its constant
*unconditionally* whenever a data model is created (`analyzers_manager/models.py:92-95`), so
`{"$malicious":"evaluation"}` would stamp MALICIOUS on **every clean lookup**. Each analyzer's
`_do_create_data_model` gate is what suppresses non-hits (miss / timeout / failure → **no** data model,
never `trusted`). This is unit-tested per analyzer, incl. the critical clean-lookup case.

**Reliability table (single reviewable source; `reliability` = trust in the source):**

| source (on a hit) | evaluation | reliability | bucket |
|---|---|---|---|
| GoogleSafebrowsing, GoogleWebRisk | malicious | 8 | malicious |
| Spamhaus_WQS | malicious | 7 | malicious |
| AdGuard, Quad9, CloudFlare, CleanBrowsing, UltraDNS, DNS4EU, Mullvad | malicious | 6 | malicious |
| Phishtank (verified) | malicious | 8 | malicious |
| Phishtank (unverified) | malicious | 5 | suspicious |
| PhishingArmy, Phishstats | malicious | 6 | malicious |
| Tranco rank ≤ 1k | trusted | 9 | **trusted** |
| Tranco rank ≤ 10k / ≤ 100k / ranked | trusted | 4 / 3 / 2 | clean |
| any miss / timeout / note | — (no DataModel) | — | — |

Two regimes, following review feedback:

- **Top 1000 (reliability 9 → `trusted`)** — treated as a reliable allowlist, and *intended* to outrank a
  malicious hit under the engine's average-reliability reconciliation. Rationale (@mlodic): in daily
  incident response false positives are the expensive failure mode, because the analyst time they burn
  costs more than the rare true positive they hide, so reliable allowlists must be enforced where
  available. This puts Tranco's top band at the same reliability as the pre-existing `HuntingAbuseAPI`
  allowlist (9).
- **Below the top 1000 (reliability ≤4 → `clean`)** — popularity is weak positive evidence: every malicious
  reliability (≥5) stays above it, so a *popular-but-flagged* domain still resolves to malicious.

The malicious tiers (8/7/6) reflect source authority and can be flattened on request.

**Notes for reviewers (pre-empting two accurate observations from self-review):**
- "Tranco is the only trusted source" is scoped to the verdicts *this PR adds* — `HuntingAbuseAPI` already
  maps `$trusted`/reliability 9 (allowlist, `0158`) and is untouched here; it sits above the malicious
  range by design and does not affect the two regimes above.
- Pre-existing engine mechanics (informational, not a regression): metadata-only DataModels with a `None`
  evaluation default to reliability 5; a *lone* Tranco `trusted` from the lower bands (2–4) can be
  out-averaged by such a group and reconcile to `no evaluation` rather than `clean`. This is orthogonal
  to the malicious guarantee (malicious ≥6 always wins) and is existing `EvaluationEngineModule`
  behaviour, surfaced here for transparency.

## Type of change

- [x] New feature (non-breaking change which adds functionality).
- [x] Chore (behaviour-preserving refactor: shared `classify()` extraction).

# Checklist

- [x] I have read and understood the rules about how to Contribute to this project
- [x] The pull request is for the branch `develop`
- [x] A new plugin (analyzer, connector, …) was added or changed, in which case:
    - [x] I created the corresponding `DataModel` population for the changed analyzers following the
      documentation (declarative `mapping_data_model` + `_do_create_data_model`/`_update_data_model` hooks,
      mirroring the URLhaus / HuntingAbuseAPI precedents). *No new analyzer was added — existing key-free
      analyzers gain DataModel hooks; the plugin sub-items about new-analyzer samples/`FREE_TO_USE`/`url`
      attributes do not apply.*
    - [x] Unit tests were added for every changed analyzer with all external calls mocked (no network in
      tests).
- [x] I have inserted the copyright banner at the start of every new file.
- [x] No new libraries were added.
- [x] Linters (`Ruff`) gave 0 errors (`check` + `format --check` clean on all 25 files).
- [x] I have added tests for the change (6 new test modules); all tests (new and old) gave 0 errors locally
  against a rebuilt test image (`makemigrations --check` clean; affected suite green, incl.
  `engines_manager` + `visualizers_manager` regression checks).
- [ ] GUI modified — N/A (the visualizer refactor is backend, behaviour-preserving; no rendered output
  changes).
- [ ] I will address any `DeepSource` / `Django Doctors` alerts raised on the PR.
- [ ] I will address raised Copilot issues.
- [x] **I have used LLMs (Claude Code) to help implement this PR, and I have reviewed and verified the
  generated code** (design, per-analyzer implementation, and tests were reviewed; behaviour verified via the
  local test suite).

