### PR TITLE
fix(exiftool): download from SourceForge (tarball moved off exiftool.org)

### DIFF
--- a/api_app/analyzers_manager/repo_downloader.sh
+++ b/api_app/analyzers_manager/repo_downloader.sh
@@ -50,8 +50,12 @@ echo "$version" >> exiftool_version.txt
 
 # 3. Handle wget errors
 # -q: quiet, -O: output file.
+# The tarball is no longer served from exiftool.org (that path now 404s);
+# exiftool.org itself links downloads to SourceForge. That URL ends in
+# "/download" and redirects to a mirror, so -O pins the expected filename
+# for the extraction step below.
 # Checking if the file actually exists after the command
-if ! wget -q "https://exiftool.org/Image-ExifTool-$version.tar.gz"; then
+if ! wget -q -O "Image-ExifTool-$version.tar.gz" "https://sourceforge.net/projects/exiftool/files/Image-ExifTool-$version.tar.gz/download"; then
     echo "Error: Failed to download ExifTool version $version."
     exit 1
 fi


### PR DESCRIPTION
Fixes #3861.

`api_app/analyzers_manager/repo_downloader.sh` fetches ExifTool from `https://exiftool.org/Image-ExifTool-$version.tar.gz`, which now returns **404**. exiftool.org no longer serves the tarball at that path — its own homepage links the Unix download to SourceForge:

```
$ curl -s https://exiftool.org/ver.txt
13.59
$ curl -sI https://exiftool.org/Image-ExifTool-13.59.tar.gz | head -1
HTTP/2 404
```

This breaks the ExifTool analyzer's install step.

**Fix:** point the download at the SourceForge URL that exiftool.org itself now advertises. That URL ends in `/download` and 302-redirects to a mirror, so I added `-O` to save the file as `Image-ExifTool-$version.tar.gz` for the extraction step that follows (the comment above the line already documented `-O` as the intent, it just wasn't being used).

**Verified** for 13.59 — the SourceForge URL delivers a valid gzip that extracts to `Image-ExifTool-13.59/` with the `exiftool` binary intact:

```
$ wget -q -O Image-ExifTool-13.59.tar.gz "https://sourceforge.net/projects/exiftool/files/Image-ExifTool-13.59.tar.gz/download"
$ file Image-ExifTool-13.59.tar.gz
Image-ExifTool-13.59.tar.gz: gzip compressed data ...
$ gzip -dc Image-ExifTool-13.59.tar.gz | tar -xf - && head -1 Image-ExifTool-13.59/exiftool
#!/usr/bin/env perl
```

`shellcheck` passes on the script. Targeting `develop` per the recent PR convention.