### PR TITLE
[Health Check] Refactor health_check methods to return a tuple (status, message) Closes #3906

### DIFF
--- a/api_app/analyzers_manager/classes.py
+++ b/api_app/analyzers_manager/classes.py
@@ -452,15 +452,13 @@ class DockerBasedAnalyzer(BaseAnalyzerMixin, metaclass=ABCMeta):
             raise AssertionError
         return resp
 
-    def health_check(self, user: User = None) -> bool:
+    def health_check(self, user: User = None) -> Tuple[bool, str]:
         """
         basic health check: if instance is up or not (timeout - 10s)
         """
         try:
             requests.head(self.url, timeout=10)
         except requests.exceptions.RequestException:
-            health_status = False
+            return False, "It is NOT up"
         else:
-            health_status = True
-
-        return health_status
+            return True, "It is up and running"

--- a/api_app/classes.py
+++ b/api_app/classes.py
@@ -360,7 +360,7 @@ class Plugin(metaclass=ABCMeta):
             return self.url
         return None
 
-    def health_check(self, user: User = None) -> bool:
+    def health_check(self, user: User = None) -> typing.Tuple[bool, str]:
         """
         Perform a health check for the plugin.
 
@@ -368,12 +368,12 @@ class Plugin(metaclass=ABCMeta):
             user (User): The user instance.
 
         Returns:
-            bool: Whether the health check was successful.
+            typing.Tuple[bool, str]: A tuple of (status, message).
         """
         url = self._get_health_check_url(user)
         if url and url.startswith("http"):
             if settings.STAGE_CI or settings.MOCK_CONNECTIONS:
-                return True
+                return True, "It is up and running"
             logger.info(f"healthcheck url {url} for {self}")
             try:
                 # momentarily set this to False to
@@ -385,7 +385,7 @@ class Plugin(metaclass=ABCMeta):
                 # So, in this case, we will consider it as check passed because we got an answer
                 # For ex 405 code is when HEADs are not allowed. But it is the same. The service answered.
                 if 400 <= response.status_code <= 408:
-                    return True
+                    return True, "It is up and running"
                 response.raise_for_status()
             except (
                 requests.exceptions.ConnectionError,
@@ -393,9 +393,9 @@ class Plugin(metaclass=ABCMeta):
                 requests.exceptions.HTTPError,
             ) as e:
                 logger.info(f"healthcheck failed: url {url} for {self}. Error: {e}")
-                return False
+                return False, "It is NOT up"
             else:
-                return True
+                return True, "It is up and running"
         raise NotImplementedError()
 
     def disable_for_rate_limit(self):

--- a/api_app/views.py
+++ b/api_app/views.py
@@ -1311,12 +1311,7 @@ class PythonConfigViewSet(AbstractConfigViewSet):
         config: PythonConfig = self.get_object()
         python_obj = config.python_module.python_class(config)
         try:
-            health_result = python_obj.health_check(request.user)
-            if isinstance(health_result, tuple):
-                health_status, health_message = health_result
-            else:
-                health_status = health_result
-                health_message = "It is up and running" if health_status else "It is NOT up"
+            health_status, health_message = python_obj.health_check(request.user)
         except NotImplementedError as e:
             logger.info(f"NotImplementedError {e}, user {request.user}, name {name}")
             raise ValidationError({"detail": "No healthcheck implemented"})

--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -197,7 +197,7 @@ def health_check(python_module_pk: int, plugin_config_pk: str):
     )
     if not config.disabled:
         try:
-            enabled = plugin.health_check(user=None)
+            enabled, _ = plugin.health_check(user=None)
         except NotImplementedError:
             logger.error(f"Unable to check healthcheck for {config.name}")
         else:

--- a/tests/api_app/analyzers_manager/integration_tests/file_analyzers/test_strings_info.py
+++ b/tests/api_app/analyzers_manager/integration_tests/file_analyzers/test_strings_info.py
@@ -17,7 +17,7 @@ class StringsInfoTestCase(CustomTestCase):
         Job.objects.all().delete()
 
     @skipIf(
-        not StringsInfo(None).health_check(),
+        not StringsInfo(None).health_check()[0],
         "malware tools analyzer container not active",
     )
     def test_urls(self):

--- a/tests/api_app/connectors_manager/test_classes.py
+++ b/tests/api_app/connectors_manager/test_classes.py
@@ -46,12 +46,12 @@ class ConnectorTestCase(CustomTestCase):
 
         with patch("requests.head") as mock_head:
             mock_head.return_value.status_code = 200
-            result = MockUpConnector(cc).health_check(self.user)
-            self.assertTrue(result)
+            status, message = MockUpConnector(cc).health_check(self.user)
+            self.assertTrue(status)
             cc.disabled = False
             cc.save()
-            result = MockUpConnector(cc).health_check(self.user)
-            self.assertTrue(result)
+            status, message = MockUpConnector(cc).health_check(self.user)
+            self.assertTrue(status)
 
         cc.delete()
         pc.delete()

--- a/tests/api_app/connectors_manager/test_classes.py
+++ b/tests/api_app/connectors_manager/test_classes.py
@@ -46,11 +46,11 @@ class ConnectorTestCase(CustomTestCase):
 
         with patch("requests.head") as mock_head:
             mock_head.return_value.status_code = 200
-            status, message = MockUpConnector(cc).health_check(self.user)
+            status, _ = MockUpConnector(cc).health_check(self.user)
             self.assertTrue(status)
             cc.disabled = False
             cc.save()
-            status, message = MockUpConnector(cc).health_check(self.user)
+            status, _ = MockUpConnector(cc).health_check(self.user)
             self.assertTrue(status)
 
         cc.delete()

--- a/tests/api_app/connectors_manager/test_views.py
+++ b/tests/api_app/connectors_manager/test_views.py
@@ -54,46 +54,6 @@ class ConnectorConfigViewSetTestCase(AbstractConfigViewSetTestCaseMixin, CustomV
         pc1.delete()
         pc2.delete()
 
-    def test_health_check_legacy_boolean_return(self):
-        connector: ConnectorConfig = ConnectorConfig.objects.get(name="YETI")
-        pc1 = PluginConfig.objects.create(
-            parameter=connector.parameters.get(name="api_key_name"),
-            value="test",
-            for_organization=False,
-            owner=None,
-            connector_config=connector,
-        )
-        pc2 = PluginConfig.objects.create(
-            parameter=connector.parameters.get(name="url_key_name"),
-            value="https://test",
-            for_organization=False,
-            owner=None,
-            connector_config=connector,
-        )
-
-        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=True):
-            self.client.force_authenticate(self.superuser)
-            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
-            self.assertEqual(response.status_code, 200)
-
-        result = response.json()
-        self.assertIn("status", result)
-        self.assertTrue(result["status"])
-        self.assertEqual(result["message"], "It is up and running")
-
-        with patch("api_app.connectors_manager.connectors.yeti.YETI.health_check", return_value=False):
-            self.client.force_authenticate(self.superuser)
-            response = self.client.get(f"{self.URL}/{connector.name}/health_check")
-            self.assertEqual(response.status_code, 200)
-
-        result = response.json()
-        self.assertIn("status", result)
-        self.assertFalse(result["status"])
-        self.assertEqual(result["message"], "It is NOT up")
-
-        pc1.delete()
-        pc2.delete()
-
     def test_get(self):
         # 1 - existing connector
         self.client.force_authenticate(user=self.user)


### PR DESCRIPTION
closes #3906 

# Description

- updated return type of health_check methods of plugins to return a tuple[bool, str] (status - true/false, message)
- updated tests related to this change

## Type of change

Please delete options that are not relevant.

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `gsoc-2026/post-mid-connectors`
- [ ] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.


