### PR TITLE
docs: remove broken GitHub stars badge from README.

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,7 +1,6 @@
 <img src="static/intel_owl_positive.png" width=547 height=150 alt="Intel Owl"/>
 
 [![GitHub release (latest by date)](https://img.shields.io/github/v/release/intelowlproject/IntelOwl)](https://github.com/intelowlproject/IntelOwl/releases)
-[![GitHub Repo stars](https://img.shields.io/github/stars/intelowlproject/IntelOwl?style=social)](https://github.com/intelowlproject/IntelOwl/stargazers)
 [![Docker](https://img.shields.io/docker/pulls/intelowlproject/intelowl)](https://hub.docker.com/repository/docker/intelowlproject/intelowl)
 [![Twitter Follow](https://img.shields.io/twitter/follow/intel_owl?style=social)](https://twitter.com/intel_owl)
 [![Linkedin](https://img.shields.io/badge/LinkedIn-0077B5?style=flat&logo=linkedin&logoColor=white)](https://www.linkedin.com/company/intelowl/)


### PR DESCRIPTION
# Description

Removed the broken GitHub stars badge from the README because it was pointing to an invalid URL and displaying a 404 error.

Related issue:
Closes #3915 

## Type of change

- [ ] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [x] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
  - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
  - [ ] Usage file was updated.
  - [ ] Advanced-Usage file was updated.
  - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command.
- [x] I have inserted the copyright banner at the start of the file (if applicable).
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue.
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have reviewed and verified the changes included in this PR.

## Testing

- Verified that the README renders correctly after removing the invalid badge.
- Confirmed that no broken GitHub stars badge remains.