### PR TITLE
[GSoC 2026] fix(settings): single, env-driven definition for CHATBOT_QUEUE

### DIFF
--- a/docker/entrypoints/celery_chatbot.sh
+++ b/docker/entrypoints/celery_chatbot.sh
@@ -5,11 +5,15 @@ do
     echo "Waiting for server volume..."
 done
 
+# Same variable Django routes the chat task with (settings.CHATBOT_QUEUE): the two must name the
+# same queue, or turns are published where no worker is listening.
+chatbot_queue="${CHATBOT_QUEUE:-chatbot}"
+
 if [ "$AWS_SQS" = "True" ]
 then
-  queues="chatbot.fifo,config.fifo"
+  queues="${chatbot_queue}.fifo,config.fifo"
 else
-  queues="chatbot,broadcast,config"
+  queues="${chatbot_queue},broadcast,config"
 fi
 
 # Concurrency is intentionally low (-c 2): a chat turn is a long, LLM-bound ReAct run

--- a/docker/env_file_app_template
+++ b/docker/env_file_app_template
@@ -96,3 +96,6 @@ OLLAMA_KEEP_ALIVE=-1
 CHATBOT_MESSAGE_RETENTION_DAYS=90
 CHATBOT_RATE_LIMIT=5
 CHATBOT_RATE_LIMIT_WINDOW=60
+# Celery queue carrying the chat turns. Read by both the task routing and the dedicated chatbot
+# worker, so changing it moves both ends together. Default: chatbot
+CHATBOT_QUEUE=chatbot

--- a/intel_owl/settings/celery.py
+++ b/intel_owl/settings/celery.py
@@ -21,7 +21,9 @@ CONFIG_QUEUE = "config"
 # The dedicated chatbot worker consumes this same variable (docker/entrypoints/celery_chatbot.sh),
 # so the queue the chat task is published to and the queue that worker drains cannot drift apart.
 # `or` instead of a default argument: an empty value falls back like the shell's
-# ${CHATBOT_QUEUE:-chatbot}, so both ends agree on unset *and* blank.
+# ${CHATBOT_QUEUE:-chatbot}, so both ends agree on unset *and* blank. Read from the environment
+# only (not intel_owl.secrets, which would also consult AWS Secrets Manager) precisely because the
+# worker entrypoint is a shell script: a value only Django could resolve would re-create the drift.
 CHATBOT_QUEUE = get_secret("CHATBOT_QUEUE") or "chatbot"
 
 CELERY_QUEUES = get_secret("CELERY_QUEUES", DEFAULT_QUEUE).split(",")

--- a/intel_owl/settings/celery.py
+++ b/intel_owl/settings/celery.py
@@ -18,7 +18,11 @@ DEFAULT_QUEUE = "default"
 BROADCAST_QUEUE = "broadcast"
 CONFIG_QUEUE = "config"
 
-CHATBOT_QUEUE = "chatbot"
+# The dedicated chatbot worker consumes this same variable (docker/entrypoints/celery_chatbot.sh),
+# so the queue the chat task is published to and the queue that worker drains cannot drift apart.
+# `or` instead of a default argument: an empty value falls back like the shell's
+# ${CHATBOT_QUEUE:-chatbot}, so both ends agree on unset *and* blank.
+CHATBOT_QUEUE = get_secret("CHATBOT_QUEUE") or "chatbot"
 
 CELERY_QUEUES = get_secret("CELERY_QUEUES", DEFAULT_QUEUE).split(",")
 for queue in [DEFAULT_QUEUE, CONFIG_QUEUE, CHATBOT_QUEUE]:

--- a/intel_owl/settings/chatbot.py
+++ b/intel_owl/settings/chatbot.py
@@ -16,7 +16,9 @@ OLLAMA_MODEL = secrets.get_secret("OLLAMA_MODEL", "qwen2.5:3b")
 # chatbot is already opt-in (the separate ollama compose override), so an operator running it has
 # accepted the model's memory cost. Constrained deploys can set a duration ("5m") or "0" (unload now).
 OLLAMA_KEEP_ALIVE = secrets.get_secret("OLLAMA_KEEP_ALIVE", "-1")
-CHATBOT_QUEUE = secrets.get_secret("CHATBOT_QUEUE", "chatbot")
+# CHATBOT_QUEUE is defined in .celery, next to the other queue names and the CELERY_QUEUES loop
+# that registers it. Defining it here too would shadow that one depending on the wildcard import
+# order in settings/__init__.py.
 CHATBOT_MESSAGE_RETENTION_DAYS = int(secrets.get_secret("CHATBOT_MESSAGE_RETENTION_DAYS", 90))
 
 # Per-user rate limiting (messages / minute). Shared between REST and WebSocket;

--- a/tests/intel_owl/test_settings.py
+++ b/tests/intel_owl/test_settings.py
@@ -1,0 +1,148 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import ast
+import json
+import os
+import subprocess
+import sys
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterator, List, Optional, Set, Tuple
+
+from django.test import SimpleTestCase
+
+REPO_ROOT = Path(__file__).resolve().parents[2]
+SETTINGS_DIR = REPO_ROOT / "intel_owl" / "settings"
+CHAT_TASK = "api_app.chatbot_manager.tasks.process_chat_message"
+
+# Settings are read at import time, so the effect of an environment variable can only be observed
+# in a freshly booted interpreter: override_settings would assign the value we are trying to prove
+# is computed, and reloading the settings package in-process corrupts it for every other test.
+# This probe reports what a real deployment would end up with, from the setting down to the queue
+# the chat task is actually routed to.
+SETTINGS_PROBE = """
+import json
+
+import django
+
+django.setup()
+
+from django.conf import settings
+from intel_owl.celery import app, get_queue_name
+
+print(
+    json.dumps(
+        {
+            "chatbot_queue": settings.CHATBOT_QUEUE,
+            "celery_queues": settings.CELERY_QUEUES,
+            "routed_queue": app.conf.task_routes["%s"]["queue"],
+            "declared_queues": [queue.name for queue in app.conf.task_queues],
+            "expected_queue_name": get_queue_name(settings.CHATBOT_QUEUE),
+        }
+    )
+)
+"""
+
+
+class ChatbotQueueSettingTestCase(SimpleTestCase):
+    """The chatbot queue name must be configurable end to end: whatever the environment says has
+    to reach ``settings.CHATBOT_QUEUE`` *and* the Celery route of the chat task, otherwise turns
+    are published to a queue no worker drains."""
+
+    def _boot_settings(self, chatbot_queue: Optional[str] = None) -> Dict:
+        env = os.environ.copy()
+        env["DJANGO_SETTINGS_MODULE"] = "intel_owl.settings"
+        if chatbot_queue is None:
+            env.pop("CHATBOT_QUEUE", None)
+        else:
+            env["CHATBOT_QUEUE"] = chatbot_queue
+        result = subprocess.run(
+            [sys.executable, "-c", SETTINGS_PROBE % CHAT_TASK],
+            capture_output=True,
+            cwd=REPO_ROOT,
+            env=env,
+            text=True,
+            timeout=300,
+        )
+        self.assertEqual(
+            result.returncode,
+            0,
+            msg=f"settings probe crashed\nstdout:\n{result.stdout}\nstderr:\n{result.stderr}",
+        )
+        # django.setup() is free to log on the way up, so only the last line is the payload
+        return json.loads(result.stdout.strip().splitlines()[-1])
+
+    def test_custom_chatbot_queue_reaches_settings_and_task_routing(self):
+        booted = self._boot_settings(chatbot_queue="my_custom_queue")
+
+        self.assertEqual(booted["chatbot_queue"], "my_custom_queue")
+        self.assertIn("my_custom_queue", booted["celery_queues"])
+        # get_queue_name appends .fifo under SQS, so compare against what the deployment derives
+        self.assertEqual(booted["routed_queue"], booted["expected_queue_name"])
+        self.assertIn(
+            booted["expected_queue_name"],
+            booted["declared_queues"],
+            msg="the chat task is routed to a queue that is never declared",
+        )
+
+    def test_chatbot_queue_falls_back_to_the_default_when_unset_or_blank(self):
+        for chatbot_queue in (None, ""):
+            with self.subTest(chatbot_queue=chatbot_queue):
+                booted = self._boot_settings(chatbot_queue=chatbot_queue)
+
+                self.assertEqual(booted["chatbot_queue"], "chatbot")
+                self.assertIn("chatbot", booted["celery_queues"])
+
+
+def _assigned_names(node: ast.AST) -> Iterator[Tuple[str, int]]:
+    """Names bound by a module-level assignment, including inside if/try blocks (where settings are
+    conditionally defined). Function and class bodies are skipped: their locals are not settings."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(child, ast.Assign):
+            for target in child.targets:
+                if isinstance(target, ast.Name):
+                    yield target.id, child.lineno
+        elif isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
+            yield child.target.id, child.lineno
+        yield from _assigned_names(child)
+
+
+def _wildcard_imported_modules() -> List[str]:
+    tree = ast.parse((SETTINGS_DIR / "__init__.py").read_text())
+    return [
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+    ]
+
+
+class SettingsSingleSourceTestCase(SimpleTestCase):
+    """intel_owl/settings/__init__.py pulls every submodule in with a wildcard import, so a name
+    assigned in two of them silently resolves to whichever module is imported last. Re-ordering
+    those lines then changes the deployment's behaviour, which is exactly how CHATBOT_QUEUE ended
+    up ignoring its environment variable. One assignment per setting removes the ordering
+    dependency altogether."""
+
+    def test_no_setting_is_assigned_in_two_wildcard_imported_modules(self):
+        origins: Dict[str, Set[str]] = defaultdict(set)
+        for module in _wildcard_imported_modules():
+            module_path = SETTINGS_DIR / f"{module}.py"
+            for name, lineno in _assigned_names(ast.parse(module_path.read_text())):
+                origins[name].add(f"{module}.py:{lineno}")
+
+        shadowed = {
+            name: sorted(locations)
+            for name, locations in origins.items()
+            # locations within a single module are re-assignments, not shadowing
+            if len({location.split(":")[0] for location in locations}) > 1
+        }
+
+        self.assertEqual(
+            shadowed,
+            {},
+            msg="these settings are assigned in more than one wildcard-imported module, so their "
+            "value depends on the import order in intel_owl/settings/__init__.py",
+        )

--- a/tests/intel_owl/test_settings_chatbot_queue.py
+++ b/tests/intel_owl/test_settings_chatbot_queue.py
@@ -69,6 +69,7 @@ class ChatbotQueueSettingTestCase(SimpleTestCase):
             env=env,
             text=True,
             timeout=PROBE_TIMEOUT_SECONDS,
+            check=False,
         )
         self.assertEqual(
             result.returncode,

--- a/tests/intel_owl/test_settings_chatbot_queue.py
+++ b/tests/intel_owl/test_settings_chatbot_queue.py
@@ -1,26 +1,28 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import ast
 import json
 import os
+import re
 import subprocess
 import sys
-from collections import defaultdict
 from pathlib import Path
-from typing import Dict, Iterator, List, Optional, Set, Tuple
+from typing import Dict, Optional
 
 from django.test import SimpleTestCase
 
 REPO_ROOT = Path(__file__).resolve().parents[2]
-SETTINGS_DIR = REPO_ROOT / "intel_owl" / "settings"
-CHAT_TASK = "api_app.chatbot_manager.tasks.process_chat_message"
+WORKER_ENTRYPOINT = REPO_ROOT / "docker" / "entrypoints" / "celery_chatbot.sh"
+# A cold django.setup() imports every plugin module, so this is generous on purpose: it is a guard
+# against a hung interpreter, not a latency assertion, and a slow CI box must not flake on it.
+PROBE_TIMEOUT_SECONDS = 300
 
 # Settings are read at import time, so the effect of an environment variable can only be observed
 # in a freshly booted interpreter: override_settings would assign the value we are trying to prove
 # is computed, and reloading the settings package in-process corrupts it for every other test.
 # This probe reports what a real deployment would end up with, from the setting down to the queue
-# the chat task is actually routed to.
+# the chat task is actually routed to. The task name is read from the task itself so a drift
+# between the route key and the real name surfaces here too.
 SETTINGS_PROBE = """
 import json
 
@@ -28,6 +30,7 @@ import django
 
 django.setup()
 
+from api_app.chatbot_manager.tasks import process_chat_message
 from django.conf import settings
 from intel_owl.celery import app, get_queue_name
 
@@ -36,7 +39,7 @@ print(
         {
             "chatbot_queue": settings.CHATBOT_QUEUE,
             "celery_queues": settings.CELERY_QUEUES,
-            "routed_queue": app.conf.task_routes["%s"]["queue"],
+            "routed_queue": app.conf.task_routes[process_chat_message.name]["queue"],
             "declared_queues": [queue.name for queue in app.conf.task_queues],
             "expected_queue_name": get_queue_name(settings.CHATBOT_QUEUE),
         }
@@ -51,6 +54,8 @@ class ChatbotQueueSettingTestCase(SimpleTestCase):
     are published to a queue no worker drains."""
 
     def _boot_settings(self, chatbot_queue: Optional[str] = None) -> Dict:
+        """Boot Django in a subprocess with CHATBOT_QUEUE set to *chatbot_queue* (unset when None)
+        and return the probe's report. Fails the test if the interpreter does not exit cleanly."""
         env = os.environ.copy()
         env["DJANGO_SETTINGS_MODULE"] = "intel_owl.settings"
         if chatbot_queue is None:
@@ -58,12 +63,12 @@ class ChatbotQueueSettingTestCase(SimpleTestCase):
         else:
             env["CHATBOT_QUEUE"] = chatbot_queue
         result = subprocess.run(
-            [sys.executable, "-c", SETTINGS_PROBE % CHAT_TASK],
+            [sys.executable, "-c", SETTINGS_PROBE],
             capture_output=True,
             cwd=REPO_ROOT,
             env=env,
             text=True,
-            timeout=300,
+            timeout=PROBE_TIMEOUT_SECONDS,
         )
         self.assertEqual(
             result.returncode,
@@ -94,55 +99,26 @@ class ChatbotQueueSettingTestCase(SimpleTestCase):
                 self.assertEqual(booted["chatbot_queue"], "chatbot")
                 self.assertIn("chatbot", booted["celery_queues"])
 
+    def test_worker_entrypoint_derives_its_queue_from_the_setting(self):
+        """Django publishes the chat task and the dedicated worker consumes it, each reading
+        CHATBOT_QUEUE on its own side. Re-hardcoding either one, or letting the two defaults drift,
+        silently sends turns to a queue nobody drains -- the same failure this setting already had,
+        one layer down. Only the shell can be checked statically, so it is checked here."""
+        script = WORKER_ENTRYPOINT.read_text()
 
-def _assigned_names(node: ast.AST) -> Iterator[Tuple[str, int]]:
-    """Names bound by a module-level assignment, including inside if/try blocks (where settings are
-    conditionally defined). Function and class bodies are skipped: their locals are not settings."""
-    for child in ast.iter_child_nodes(node):
-        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
-            continue
-        if isinstance(child, ast.Assign):
-            for target in child.targets:
-                if isinstance(target, ast.Name):
-                    yield target.id, child.lineno
-        elif isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
-            yield child.target.id, child.lineno
-        yield from _assigned_names(child)
-
-
-def _wildcard_imported_modules() -> List[str]:
-    tree = ast.parse((SETTINGS_DIR / "__init__.py").read_text())
-    return [
-        node.module
-        for node in ast.walk(tree)
-        if isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
-    ]
-
-
-class SettingsSingleSourceTestCase(SimpleTestCase):
-    """intel_owl/settings/__init__.py pulls every submodule in with a wildcard import, so a name
-    assigned in two of them silently resolves to whichever module is imported last. Re-ordering
-    those lines then changes the deployment's behaviour, which is exactly how CHATBOT_QUEUE ended
-    up ignoring its environment variable. One assignment per setting removes the ordering
-    dependency altogether."""
-
-    def test_no_setting_is_assigned_in_two_wildcard_imported_modules(self):
-        origins: Dict[str, Set[str]] = defaultdict(set)
-        for module in _wildcard_imported_modules():
-            module_path = SETTINGS_DIR / f"{module}.py"
-            for name, lineno in _assigned_names(ast.parse(module_path.read_text())):
-                origins[name].add(f"{module}.py:{lineno}")
-
-        shadowed = {
-            name: sorted(locations)
-            for name, locations in origins.items()
-            # locations within a single module are re-assignments, not shadowing
-            if len({location.split(":")[0] for location in locations}) > 1
-        }
-
-        self.assertEqual(
-            shadowed,
-            {},
-            msg="these settings are assigned in more than one wildcard-imported module, so their "
-            "value depends on the import order in intel_owl/settings/__init__.py",
+        shell_default = re.search(r"\$\{CHATBOT_QUEUE:-([^}]+)\}", script)
+        self.assertIsNotNone(
+            shell_default,
+            msg="the worker entrypoint no longer derives its queue from CHATBOT_QUEUE",
         )
+        self.assertEqual(
+            shell_default.group(1),
+            self._boot_settings()["chatbot_queue"],
+            msg="the entrypoint's default queue differs from the one the settings fall back to",
+        )
+        for hardcoded in ('queues="chatbot', "chatbot.fifo"):
+            self.assertNotIn(
+                hardcoded,
+                script,
+                msg=f"{hardcoded!r} is hardcoded again in the worker entrypoint",
+            )

--- a/tests/intel_owl/test_settings_shadowing.py
+++ b/tests/intel_owl/test_settings_shadowing.py
@@ -1,0 +1,76 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import ast
+from collections import defaultdict
+from pathlib import Path
+from typing import Dict, Iterator, List, Set, Tuple
+
+from django.test import SimpleTestCase
+
+SETTINGS_DIR = Path(__file__).resolve().parents[2] / "intel_owl" / "settings"
+SETTINGS_INIT = SETTINGS_DIR / "__init__.py"
+
+
+def _assigned_names(node: ast.AST) -> Iterator[Tuple[str, int]]:
+    """Names bound by a module-level assignment, including inside if/try blocks (where settings are
+    conditionally defined). Function and class bodies are skipped: their locals are not settings."""
+    for child in ast.iter_child_nodes(node):
+        if isinstance(child, (ast.FunctionDef, ast.AsyncFunctionDef, ast.ClassDef)):
+            continue
+        if isinstance(child, ast.Assign):
+            for target in child.targets:
+                if isinstance(target, ast.Name):
+                    yield target.id, child.lineno
+        elif isinstance(child, ast.AnnAssign) and isinstance(child.target, ast.Name):
+            yield child.target.id, child.lineno
+        yield from _assigned_names(child)
+
+
+def _wildcard_imported_modules() -> List[str]:
+    """The submodule names __init__.py pulls in with `from .x import *`, in source order."""
+    tree = ast.parse(SETTINGS_INIT.read_text())
+    return [
+        node.module
+        for node in ast.walk(tree)
+        if isinstance(node, ast.ImportFrom) and any(alias.name == "*" for alias in node.names)
+    ]
+
+
+class SettingsSingleSourceTestCase(SimpleTestCase):
+    """intel_owl/settings/__init__.py pulls every submodule in with a wildcard import, so a name
+    assigned in two of them silently resolves to whichever module is imported last. Re-ordering
+    those lines then changes the deployment's behaviour, which is exactly how CHATBOT_QUEUE ended
+    up ignoring its environment variable. One assignment per setting removes the ordering
+    dependency altogether."""
+
+    def test_no_setting_is_assigned_in_two_wildcard_imported_modules(self):
+        # __init__.py assigns settings of its own (INSTALLED_APPS, TEST_RUNNER) before the wildcard
+        # block, and a submodule shadowing one of those is the same bug in the other direction
+        sources: Dict[str, Path] = {SETTINGS_INIT.name: SETTINGS_INIT}
+        for module in _wildcard_imported_modules():
+            module_path = SETTINGS_DIR / f"{module}.py"
+            self.assertTrue(
+                module_path.is_file(),
+                msg=f"cannot audit the wildcard import of .{module}: {module_path} is not a file",
+            )
+            sources[module_path.name] = module_path
+
+        origins: Dict[str, Set[str]] = defaultdict(set)
+        for name, path in sources.items():
+            for setting, lineno in _assigned_names(ast.parse(path.read_text())):
+                origins[setting].add(f"{name}:{lineno}")
+
+        shadowed = {
+            setting: sorted(locations)
+            for setting, locations in origins.items()
+            # locations within a single module are re-assignments, not shadowing
+            if len({location.split(":")[0] for location in locations}) > 1
+        }
+
+        self.assertEqual(
+            shadowed,
+            {},
+            msg="these settings are assigned in more than one module of intel_owl/settings, so "
+            "their value depends on the import order in intel_owl/settings/__init__.py",
+        )


### PR DESCRIPTION
# Description

Fixes the duplicate `CHATBOT_QUEUE` definition reported by @Aditya30ag in #3910 — thanks for
catching it, the analysis in the issue was exactly right.

@Aditya30ag also proposed a fix in #3911, which @mlodic decided to supersede with this one. The
settings change there was correct; this PR additionally covers the worker entrypoint, the env
template and the regression tests.

`CHATBOT_QUEUE` was assigned in two settings modules:

| module | value |
|---|---|
| `intel_owl/settings/chatbot.py:19` | `secrets.get_secret("CHATBOT_QUEUE", "chatbot")` (env-driven) |
| `intel_owl/settings/celery.py:21` | `"chatbot"` (hardcoded literal) |

Both are wildcard-imported by `intel_owl/settings/__init__.py` (`.chatbot` at line 76, `.celery` at
line 79). The last wildcard wins, so the literal shadowed the env read and `CHATBOT_QUEUE` in the
environment never reached `settings.CHATBOT_QUEUE`. Reproduced before the fix:

```console
$ docker exec -e CHATBOT_QUEUE=my_custom_queue -i intelowl_uwsgi python manage.py shell
intel_owl.settings.chatbot.CHATBOT_QUEUE : my_custom_queue
settings.CHATBOT_QUEUE                   : chatbot          # <- the literal wins
```

### The fix

The surviving definition is the env-driven one, moved into `settings/celery.py`:

```python
CHATBOT_QUEUE = get_secret("CHATBOT_QUEUE") or "chatbot"
```

`settings/celery.py` already owns `DEFAULT_QUEUE` / `BROADCAST_QUEUE` / `CONFIG_QUEUE` and the
`CELERY_QUEUES` loop that consumes them, and it is the lower-level module (it carries
`# this module must run before the others` and imports only `._util` and `.aws`). Keeping the
definition in `chatbot.py` instead would have forced `celery.py` to `from .chatbot import
CHATBOT_QUEUE`, inverting that layering and pulling `.cache` into the module that must run first.

**The fix is order-independent by construction**: with a single assignment, no arrangement of the
wildcard imports in `__init__.py` can change the resulting value — which is the property the issue
asks for.

Trade-off worth flagging: the lookup moves from `intel_owl.secrets.get_secret` (AWS Secrets Manager
fallback) to `settings/_util.get_secret` (`os.environ.get`), matching the sibling `BROKER_URL` and
`CELERY_QUEUES`. A queue name is not a secret, and the AWS fallback for this key never worked
anyway since the value was being overwritten.

### The other half of the bug

Making the setting configurable is not enough on its own: `docker/entrypoints/celery_chatbot.sh`
hardcoded the consumer side (`queues="chatbot,broadcast,config"`, or `chatbot.fifo,config.fifo`
under SQS), and `CHATBOT_QUEUE` was missing from `docker/env_file_app_template`. A custom queue name
would therefore have published chat turns to a queue no worker drains, hanging the chat. The
entrypoint now reads the same variable, with `${CHATBOT_QUEUE:-chatbot}` matching the `or` fallback
on the Python side so both ends agree on *unset* and on *blank*. `test.ollama.override.yml` and
`ci.ollama.override.yml` inherit the entrypoint from `ollama.override.yml`, so they are covered.

`api_app/chatbot_manager/health.py` needs no change — it already derives the queue from
`settings.CHATBOT_QUEUE`, and it remains the detector for a producer/consumer mismatch.

### Audit: is any other setting defined twice?

No. `CHATBOT_QUEUE` was the only name *assigned* in two wildcard-imported settings modules. The
other 15 name collisions (`DEBUG`, `CACHES`, `AWS_SQS`, `get_secret`, `WEB_CLIENT_URL`, …) are
re-exports of the same object via `from .X import Y`, so every import order yields the same value.

### Tests

Two new files under `tests/intel_owl/`, one per concern. The first two tests below fail on the code
before this PR:

- `test_settings_chatbot_queue.py` — `test_custom_chatbot_queue_reaches_settings_and_task_routing`
  boots Django in a subprocess with
  `CHATBOT_QUEUE=my_custom_queue` and asserts the value reaches `settings.CHATBOT_QUEUE`
  (`AssertionError: 'chatbot' != 'my_custom_queue'` before the fix), lands in `CELERY_QUEUES`, is
  the routing target of `process_chat_message` via `get_queue_name`, and that a queue is actually
  declared for it. A second case pins the fallback for unset and blank values. The subprocess is
  necessary: settings are read at import time, so `override_settings` would assign the value the
  test is trying to prove is computed, and reloading the settings package in-process corrupts it
  for the rest of the suite.
- `test_settings_shadowing.py` — `test_no_setting_is_assigned_in_two_wildcard_imported_modules` is
  an AST guard over `intel_owl/settings/`: it fails if any setting is ever again assigned in two of
  those modules (before the fix it reports
  `{'CHATBOT_QUEUE': ['celery.py:21', 'chatbot.py:19']}`). It audits `__init__.py`'s own
  assignments too — `TEST_RUNNER` and `INSTALLED_APPS` are set before the wildcard block and a
  submodule shadowing one of them is the same bug in the opposite direction. It distinguishes
  assignment from re-export, so the 15 benign collisions above do not trip it.
- `test_settings_chatbot_queue.py` — `test_worker_entrypoint_derives_its_queue_from_the_setting`
  closes the gap the fix itself opens: with both layers reading `CHATBOT_QUEUE`, the default queue
  name now exists in two places, and letting them drift reproduces this very bug one layer down. It
  extracts `${CHATBOT_QUEUE:-…}` from the entrypoint, compares it with the settings fallback, and
  fails if either side hardcodes the queue again.

Both guards were verified by mutation rather than assumed: flipping the shell default to `chat`
fails with `'chat' != 'chatbot'`, and assigning `TEST_RUNNER` in a submodule (on a throwaway copy of
the settings package) is reported as `{'TEST_RUNNER': ['__init__.py:7', 'websocket.py:20']}`.

```console
$ docker exec intelowl_uwsgi python manage.py test tests.api_app.chatbot_manager tests.intel_owl --keepdb
Ran 206 tests in 14.083s

OK
```

Ruff (`check` + `format --check`) and `shellcheck` are clean on the changed files.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible — no new dependencies.
- [x] Linters (`Ruff`) gave 0 errors.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
- [x] I have addressed raised Copilot issues.
- [x] I have reviewed and verified any LLM-generated code included in this PR. LLM assistance was used while working on this change, and every line was reviewed and verified locally (tests run before and after the fix, plus a manual reproduction in the running stack).

Refs #3910
