### PR TITLE
[GSoC 2026] chatbot: post-generation guard against fabricated placeholder names

### DIFF
--- a/api_app/chatbot_manager/agent/memory.py
+++ b/api_app/chatbot_manager/agent/memory.py
@@ -4,6 +4,8 @@
 from langchain_core.chat_history import BaseChatMessageHistory
 from langchain_core.messages import AIMessage, BaseMessage, HumanMessage
 
+from api_app.chatbot_manager.placeholder_guard import strip_notice
+
 
 class DjangoChatMessageHistory(BaseChatMessageHistory):
     """LangChain chat history backed by the Django ChatMessage model.
@@ -27,7 +29,10 @@ class DjangoChatMessageHistory(BaseChatMessageHistory):
             if msg.role == ChatMessage.Role.USER:
                 result.append(HumanMessage(content=msg.content))
             else:
-                result.append(AIMessage(content=msg.content))
+                # The placeholder notice is an annotation added for the user after generation, not
+                # something the model wrote. Replaying it would put it in the model's context, where
+                # a small model may start imitating the format.
+                result.append(AIMessage(content=strip_notice(msg.content)))
         return result
 
     def add_message(self, message: BaseMessage) -> None:

--- a/api_app/chatbot_manager/placeholder_guard.py
+++ b/api_app/chatbot_manager/placeholder_guard.py
@@ -1,0 +1,101 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+"""Post-generation guard against fabricated bracketed names in a chat answer.
+
+The system prompt tells the model to copy analyzer, playbook and job names verbatim from tool
+results and never emit bracketed labels like ``[Analyzer 1]``. A rule that lives only in the prompt
+is probabilistic by construction: measured answers show the model can still invent a whole section
+(typically a playbook list) and, having no names to copy, fill it with placeholders. This module is
+the deterministic backstop, and it never calls the LLM.
+
+It detects and annotates; it deliberately does not repair. In the observed failures the tool payload
+carried no playbook data at all, so there is no real name to substitute, and rewriting would mean a
+second inference on a local CPU-bound model — a plain retry would not even change the answer, since
+the agent runs at temperature 0.
+
+Precision is preferred over coverage: a false positive would stamp a warning onto a correct answer,
+which is worse than missing a rare shape. The criterion is therefore anchored to the entity nouns
+the prompt rule protects, and the prompt rule remains the first line of defense for the shapes this
+misses (``[X]``, ``[TBD]``, ``[insert name]``).
+"""
+
+import logging
+import re
+
+logger = logging.getLogger(__name__)
+
+# What the notice claims is exactly what the criterion below checks: a bracketed span *shaped* like
+# a name slot. The guard never inspects the tool results, so it cannot assert the name is ungrounded
+# — only that it does not look like a real IntelOwl name.
+PLACEHOLDER_NOTICE = (
+    "_Note: this answer contains bracketed names that look like placeholders rather than real "
+    "IntelOwl names. Treat them as unverified._"
+)
+_NOTICE_SEPARATOR = "\n\n"
+
+# Every notice wording ever persisted, newest first. `strip_notice` has to recognize all of them,
+# not just the current one: assistant rows written by an earlier version stay in the database and
+# are replayed into the prompt on the next turn, so rewording the notice without this would
+# silently start leaking it back into the model's context with no test failing.
+# APPEND a new wording here when PLACEHOLDER_NOTICE changes; never edit or drop an entry.
+_HISTORICAL_NOTICES = (PLACEHOLDER_NOTICE,)
+
+# A candidate is a single-line `[...]` span NOT followed by "(": that lookahead excludes markdown
+# links `[text](url)`, which the chat panel renders as real anchors. The length bound keeps a
+# candidate at name-slot size (the longest occurrence measured is 46 characters) so bracketed prose
+# is not a candidate at all.
+_MAX_PLACEHOLDER_LEN = 80
+_CANDIDATE_RE = re.compile(rf"\[([^\[\]\n]{{1,{_MAX_PLACEHOLDER_LEN}}})\](?!\()")
+
+# A candidate is a placeholder only when it STARTS with one of the entity nouns the prompt rule
+# protects. The start anchor is what keeps out defanged indicators (`example[.]com`), footnote
+# markers (`[1]`), GFM task-list boxes (`- [x]`) and JSON echoes of a tool result.
+#
+# This list is the Python side of the rule stated in `agent/system_prompt.txt` ([Rules], the "Copy
+# analyzer, playbook and job names verbatim" line). The prompt file carries no reciprocal comment on
+# purpose — it is sent to the model verbatim, so a note to maintainers would become prompt tokens;
+# the coupling is pinned from this side instead, by a test that derives the rule's own examples from
+# the prompt text. The two lists are deliberately not identical: the prompt names three nouns, while
+# a detector can afford two more, because widening a regex cannot degrade generation, whereas
+# widening the prompt spends context budget and forces the narration gate to be re-measured.
+_ENTITY_RE = re.compile(r"^(analyzer|playbook|job|investigation|observable)s?\b", re.IGNORECASE)
+
+
+def find_placeholders(text: str) -> list[str]:
+    """Return the bracketed placeholder spans in ``text``, brackets included, in order."""
+    return [
+        match.group(0) for match in _CANDIDATE_RE.finditer(text) if _ENTITY_RE.match(match.group(1).strip())
+    ]
+
+
+def guard_answer(text: str, *, session_id: int) -> str:
+    """Annotate ``text`` when it names entities no tool result provided; return it unchanged if not.
+
+    The model's prose is never edited: removing the spans would leave empty list bullets and an
+    orphan lead-in. One notice is appended however many spans matched, because the annotation is a
+    statement about the answer, not about each occurrence. The notice is appended unconditionally,
+    so an answer that ends inside an unterminated code fence renders it as code; closing the fence
+    would mean editing the model's output, which this guard exists not to do.
+
+    The warning is the only telemetry this has (IntelOwl has no metrics pipeline for the chatbot),
+    so the message prefix is kept stable and greppable to count the real production frequency.
+    """
+    placeholders = find_placeholders(text)
+    if not placeholders:
+        return text
+    logger.warning("chatbot placeholder guard: session=%s placeholders=%s", session_id, placeholders)
+    return f"{text}{_NOTICE_SEPARATOR}{PLACEHOLDER_NOTICE}"
+
+
+def strip_notice(text: str) -> str:
+    """Remove a notice previously appended by ``guard_answer``, in any wording ever shipped.
+
+    Only a *trailing* notice is removed: anything else in the text is the model's own output and
+    must survive verbatim.
+    """
+    for notice in _HISTORICAL_NOTICES:
+        stripped = text.removesuffix(f"{_NOTICE_SEPARATOR}{notice}")
+        if stripped != text:
+            return stripped
+    return text

--- a/api_app/chatbot_manager/tasks.py
+++ b/api_app/chatbot_manager/tasks.py
@@ -22,6 +22,7 @@ from api_app.chatbot_manager.events import (
     StartEvent,
     chat_group_for_user,
 )
+from api_app.chatbot_manager.placeholder_guard import guard_answer
 from intel_owl.tasks import FailureLoggedTask
 
 logger = logging.getLogger(__name__)
@@ -92,6 +93,12 @@ def process_chat_message(session_id: int, user_message: str, user_id: int, conte
         # as a messages list, the create_agent input shape.
         inputs = {"messages": [*chat_history, HumanMessage(content=user_message)]}
         response_text = consumer.run(chat_agent.runnable, inputs, {"recursion_limit": RECURSION_LIMIT})
+        # Deterministic backstop for the prompt's anti-placeholder rule. It runs before the answer
+        # is persisted and emitted, so the stored history and the text the user reads never
+        # disagree; the tokens already streamed are only a live preview, and the frontend replaces
+        # them with chat.end's content. Kept inside the try so a failure here surfaces as a clean
+        # chat.error like any other turn failure.
+        response_text = guard_answer(response_text, session_id=session_id)
     except SoftTimeLimitExceeded:
         logger.warning(f"process_chat_message: timed out for session {session_id}")
         emit(ErrorEvent(session_id, ChatErrorDetail.TIMEOUT.value))

--- a/api_app/chatbot_manager/views.py
+++ b/api_app/chatbot_manager/views.py
@@ -25,6 +25,7 @@ from .events import ChatErrorDetail
 from .health import chatbot_health
 from .models import ChatMessage, ChatSession
 from .pending_action import consume_pending_analysis
+from .placeholder_guard import guard_answer
 from .rate_limit import _build_rate_limiter
 from .serializers.analyze_observable import ConfirmAnalysisResultSerializer, flatten_errors
 from .serializers.chat import (
@@ -136,6 +137,10 @@ class ChatSessionViewSet(ModelViewSet):
                 status=status.HTTP_503_SERVICE_UNAVAILABLE,
             )
         response_text = final_answer(result["messages"])
+        # Same guard as the WebSocket path (tasks.py), at the same point in the flow: on the final
+        # answer, before it is persisted and returned. It sits outside the try/except because
+        # final_answer does too — the block guards the agent run itself, not the post-processing.
+        response_text = guard_answer(response_text, session_id=session.pk)
 
         history.add_user_message(user_message)
         history.add_ai_message(response_text)

--- a/tests/api_app/chatbot_manager/test_memory.py
+++ b/tests/api_app/chatbot_manager/test_memory.py
@@ -1,0 +1,49 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from django.test import TestCase
+from langchain_core.messages import AIMessage, HumanMessage
+
+from api_app.chatbot_manager.agent.memory import DjangoChatMessageHistory
+from api_app.chatbot_manager.models import ChatMessage, ChatSession
+from api_app.chatbot_manager.placeholder_guard import PLACEHOLDER_NOTICE, guard_answer
+from certego_saas.apps.user.models import User
+
+
+class DjangoChatMessageHistoryTestCase(TestCase):
+    """History is what the model re-reads each turn, so the guard's annotation must not ride along."""
+
+    def setUp(self):
+        self.user, _ = User.objects.get_or_create(username="chatbot_memory_user")
+        self.session = ChatSession.objects.create(user=self.user)
+
+    def _add(self, role, content):
+        ChatMessage.objects.create(session=self.session, role=role, content=content)
+
+    def test_the_placeholder_notice_is_not_replayed_into_the_prompt(self):
+        answer = "Use [Playbook X]."
+        self._add(ChatMessage.Role.USER, "which playbook?")
+        self._add(ChatMessage.Role.ASSISTANT, guard_answer(answer, session_id=self.session.id))
+
+        messages = DjangoChatMessageHistory(session=self.session).messages
+
+        self.assertEqual(
+            [(type(message), message.content) for message in messages],
+            [(HumanMessage, "which playbook?"), (AIMessage, answer)],
+        )
+
+    def test_a_user_message_is_replayed_verbatim(self):
+        # Only assistant rows are annotated by the guard, so a user who happens to paste the same
+        # text must get it back unchanged.
+        self._add(ChatMessage.Role.USER, f"look at this: {PLACEHOLDER_NOTICE}")
+
+        messages = DjangoChatMessageHistory(session=self.session).messages
+
+        self.assertEqual(messages[0].content, f"look at this: {PLACEHOLDER_NOTICE}")
+
+    def test_an_unannotated_assistant_answer_is_replayed_verbatim(self):
+        self._add(ChatMessage.Role.ASSISTANT, "Job #42 is malicious.")
+
+        messages = DjangoChatMessageHistory(session=self.session).messages
+
+        self.assertEqual(messages[0].content, "Job #42 is malicious.")

--- a/tests/api_app/chatbot_manager/test_placeholder_guard.py
+++ b/tests/api_app/chatbot_manager/test_placeholder_guard.py
@@ -1,6 +1,7 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
+import logging
 import re
 
 from django.test import SimpleTestCase
@@ -88,6 +89,15 @@ class FindPlaceholdersTestCase(SimpleTestCase):
 
 class GuardAnswerTestCase(SimpleTestCase):
     """A flagged answer is annotated, never edited; a clean answer is untouched and silent."""
+
+    def setUp(self):
+        super().setUp()
+        self._disabled_level = logging.root.manager.disable
+        logging.disable(logging.NOTSET)
+
+    def tearDown(self):
+        logging.disable(self._disabled_level)
+        super().tearDown()
 
     def test_clean_answer_is_returned_byte_for_byte(self):
         text = "Job #42 is malicious (reliability 7/10), supported by AILTypoSquatting."

--- a/tests/api_app/chatbot_manager/test_placeholder_guard.py
+++ b/tests/api_app/chatbot_manager/test_placeholder_guard.py
@@ -1,0 +1,127 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import re
+
+from django.test import SimpleTestCase
+
+from api_app.chatbot_manager.agent.agent import _SYSTEM_PROMPT
+from api_app.chatbot_manager.placeholder_guard import (
+    _MAX_PLACEHOLDER_LEN,
+    PLACEHOLDER_NOTICE,
+    find_placeholders,
+    guard_answer,
+    strip_notice,
+)
+
+SESSION_ID = 11
+GUARD_LOGGER = "api_app.chatbot_manager.placeholder_guard"
+
+
+class FindPlaceholdersTestCase(SimpleTestCase):
+    """The detector fires on fabricated bracketed names — and on nothing else.
+
+    The two detection cases are answers actually recorded during the 2026-08-03 narration
+    measurement, kept verbatim so a future change to the criterion is measured against real model
+    output rather than against invented examples.
+    """
+
+    def test_detects_a_bracketed_list_of_invented_playbooks(self):
+        text = (
+            "The playbooks that can analyze this type of observable are:\n\n"
+            "- [Playbook X]  \n"
+            "- [Playbook Y]\n"
+        )
+        self.assertEqual(find_placeholders(text), ["[Playbook X]", "[Playbook Y]"])
+
+    def test_detects_a_whole_sentence_used_as_a_name_slot(self):
+        # The failure is not always shaped like [Label N]: a detector tuned on that shape alone
+        # would miss this one, which was recorded in the same campaign.
+        text = (
+            "This analysis is based on the following playbook(s): "
+            "[Playbook names will be listed here if available]."
+        )
+        self.assertEqual(find_placeholders(text), ["[Playbook names will be listed here if available]"])
+
+    def test_detects_every_example_the_prompt_rule_itself_names(self):
+        # Coupling test: the guard is the deterministic half of a rule whose canonical wording lives
+        # in system_prompt.txt. Deriving the examples from the prompt instead of hardcoding them
+        # means rewording that rule breaks this test loudly, rather than leaving the guard silently
+        # out of step with the instruction it backs up.
+        rule_lines = [line for line in _SYSTEM_PROMPT.splitlines() if "bracketed labels" in line]
+        self.assertEqual(len(rule_lines), 1, "the anti-placeholder rule is no longer in the prompt")
+        examples = re.findall(r"\[[^\[\]\n]+\]", rule_lines[0])
+        self.assertTrue(examples, "the rule no longer shows bracketed examples")
+        self.assertEqual(find_placeholders(" and ".join(examples)), examples)
+
+    def test_ignores_markdown_links(self):
+        # The chat panel renders links as real anchors (chatMarkdown.jsx), so this is live output.
+        text = "Supported by [AILTypoSquatting](https://intelowl.example/analyzer/1)."
+        self.assertEqual(find_placeholders(text), [])
+
+    def test_ignores_defanged_indicators(self):
+        text = "Observable example[.]com resolved to 1.1.1[.]1 over hxxp[:]//example[.]com."
+        self.assertEqual(find_placeholders(text), [])
+
+    def test_ignores_gfm_task_list_boxes(self):
+        self.assertEqual(find_placeholders("- [x] done\n- [ ] pending\n"), [])
+
+    def test_ignores_footnote_markers_and_json_echoes_of_tool_output(self):
+        text = 'Silent analyzers [1]: ["AbuseIPDB", "Abusix"]'
+        self.assertEqual(find_placeholders(text), [])
+
+    def test_ignores_the_prompt_section_headers(self):
+        self.assertEqual(find_placeholders("[Rules] and [Response style] are prompt sections."), [])
+
+    def test_ignores_a_span_too_long_to_be_a_name_slot(self):
+        # Prose in brackets is not a name placeholder; the length bound keeps the criterion narrow.
+        self.assertEqual(find_placeholders(f"text [job {'x' * 90}] more"), [])
+
+    def test_the_length_bound_is_inclusive_at_the_boundary(self):
+        # The decision the bound encodes is only exercised at the boundary itself, not 90 chars past
+        # it: one character either side must land on opposite sides of the criterion.
+        at_limit = "job " + "x" * (_MAX_PLACEHOLDER_LEN - len("job "))
+        over_limit = f"{at_limit}x"
+        self.assertEqual(find_placeholders(f"text [{at_limit}] more"), [f"[{at_limit}]"])
+        self.assertEqual(find_placeholders(f"text [{over_limit}] more"), [])
+
+
+class GuardAnswerTestCase(SimpleTestCase):
+    """A flagged answer is annotated, never edited; a clean answer is untouched and silent."""
+
+    def test_clean_answer_is_returned_byte_for_byte(self):
+        text = "Job #42 is malicious (reliability 7/10), supported by AILTypoSquatting."
+        self.assertEqual(guard_answer(text, session_id=SESSION_ID), text)
+
+    def test_flagged_answer_keeps_the_model_prose_and_gains_one_notice(self):
+        text = "- [Playbook X]\n- [Playbook Y]"
+        guarded = guard_answer(text, session_id=SESSION_ID)
+        self.assertTrue(guarded.startswith(text))
+        self.assertEqual(guarded.count(PLACEHOLDER_NOTICE), 1)
+
+    def test_detection_is_logged_with_the_session_and_the_spans(self):
+        with self.assertLogs(GUARD_LOGGER, level="WARNING") as logs:
+            guard_answer("Use [Playbook X].", session_id=SESSION_ID)
+        self.assertIn("session=11", logs.output[0])
+        self.assertIn("[Playbook X]", logs.output[0])
+
+    def test_clean_answer_logs_nothing(self):
+        with self.assertNoLogs(GUARD_LOGGER, level="WARNING"):
+            guard_answer("Job #42 is malicious.", session_id=SESSION_ID)
+
+
+class StripNoticeTestCase(SimpleTestCase):
+    """The notice is an annotation for the user, so it must be removable exactly."""
+
+    def test_strip_reverses_guard(self):
+        text = "Use [Playbook X]."
+        self.assertEqual(strip_notice(guard_answer(text, session_id=SESSION_ID)), text)
+
+    def test_answer_without_a_notice_is_unchanged(self):
+        text = "Job #42 is malicious."
+        self.assertEqual(strip_notice(text), text)
+
+    def test_only_a_trailing_notice_is_stripped(self):
+        # Anything not at the end is the model's own text and must survive verbatim.
+        text = f"{PLACEHOLDER_NOTICE} and then more prose"
+        self.assertEqual(strip_notice(text), text)

--- a/tests/api_app/chatbot_manager/test_placeholder_guard.py
+++ b/tests/api_app/chatbot_manager/test_placeholder_guard.py
@@ -1,8 +1,8 @@
 # This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
 # See the file 'LICENSE' for copying permission.
 
-import logging
 import re
+from unittest.mock import patch
 
 from django.test import SimpleTestCase
 
@@ -16,7 +16,6 @@ from api_app.chatbot_manager.placeholder_guard import (
 )
 
 SESSION_ID = 11
-GUARD_LOGGER = "api_app.chatbot_manager.placeholder_guard"
 
 
 class FindPlaceholdersTestCase(SimpleTestCase):
@@ -90,15 +89,6 @@ class FindPlaceholdersTestCase(SimpleTestCase):
 class GuardAnswerTestCase(SimpleTestCase):
     """A flagged answer is annotated, never edited; a clean answer is untouched and silent."""
 
-    def setUp(self):
-        super().setUp()
-        self._disabled_level = logging.root.manager.disable
-        logging.disable(logging.NOTSET)
-
-    def tearDown(self):
-        logging.disable(self._disabled_level)
-        super().tearDown()
-
     def test_clean_answer_is_returned_byte_for_byte(self):
         text = "Job #42 is malicious (reliability 7/10), supported by AILTypoSquatting."
         self.assertEqual(guard_answer(text, session_id=SESSION_ID), text)
@@ -110,14 +100,18 @@ class GuardAnswerTestCase(SimpleTestCase):
         self.assertEqual(guarded.count(PLACEHOLDER_NOTICE), 1)
 
     def test_detection_is_logged_with_the_session_and_the_spans(self):
-        with self.assertLogs(GUARD_LOGGER, level="WARNING") as logs:
+        with patch("api_app.chatbot_manager.placeholder_guard.logger.warning") as mock_warning:
             guard_answer("Use [Playbook X].", session_id=SESSION_ID)
-        self.assertIn("session=11", logs.output[0])
-        self.assertIn("[Playbook X]", logs.output[0])
+        mock_warning.assert_called_once()
+        args = mock_warning.call_args[0]
+        self.assertIn("session=%s", args[0])
+        self.assertEqual(args[1], SESSION_ID)
+        self.assertEqual(args[2], ["[Playbook X]"])
 
     def test_clean_answer_logs_nothing(self):
-        with self.assertNoLogs(GUARD_LOGGER, level="WARNING"):
+        with patch("api_app.chatbot_manager.placeholder_guard.logger.warning") as mock_warning:
             guard_answer("Job #42 is malicious.", session_id=SESSION_ID)
+        mock_warning.assert_not_called()
 
 
 class StripNoticeTestCase(SimpleTestCase):

--- a/tests/api_app/chatbot_manager/test_tasks.py
+++ b/tests/api_app/chatbot_manager/test_tasks.py
@@ -12,6 +12,7 @@ from langgraph.errors import GraphRecursionError
 
 from api_app.chatbot_manager import events
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
+from api_app.chatbot_manager.placeholder_guard import PLACEHOLDER_NOTICE
 from api_app.chatbot_manager.tasks import delete_old_chat_sessions, process_chat_message
 from certego_saas.apps.user.models import User
 
@@ -246,3 +247,32 @@ class ProcessChatMessageTestCase(TestCase):
         self.assertEqual(self._event_types(layer), [events.ChatEventType.ERROR.value])
         error_payload = layer.group_send.call_args_list[0].args[1]["payload"]
         self.assertEqual(error_payload["detail"], events.ChatErrorDetail.SESSION_NOT_FOUND.value)
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
+    def test_fabricated_names_are_annotated_before_persist_and_end(self, mock_build, mock_get_layer):
+        layer = self._patched_layer(mock_get_layer)
+        chat_agent, _ = _chat_agent(items=_final("Use [Playbook X] for this observable."))
+        mock_build.return_value = chat_agent
+
+        process_chat_message(self.session.id, "which playbook?", self.user.id)
+
+        stored = ChatMessage.objects.get(session=self.session, role=ChatMessage.Role.ASSISTANT)
+        self.assertIn(PLACEHOLDER_NOTICE, stored.content)
+        # chat.end is what the frontend renders (it discards the streamed buffer), so the notice
+        # must be on the wire too, not only in the database.
+        end_payload = layer.group_send.call_args_list[-1].args[1]["payload"]
+        self.assertEqual(end_payload["content"], stored.content)
+        self.assertEqual(end_payload["message_id"], stored.id)
+
+    @patch("api_app.chatbot_manager.tasks.get_channel_layer")
+    @patch("api_app.chatbot_manager.agent.agent.build_agent")
+    def test_clean_answer_is_persisted_unannotated(self, mock_build, mock_get_layer):
+        self._patched_layer(mock_get_layer)
+        chat_agent, _ = _chat_agent(items=_final("Job #42 is malicious."))
+        mock_build.return_value = chat_agent
+
+        process_chat_message(self.session.id, "is job 42 malicious?", self.user.id)
+
+        stored = ChatMessage.objects.get(session=self.session, role=ChatMessage.Role.ASSISTANT)
+        self.assertEqual(stored.content, "Job #42 is malicious.")

--- a/tests/api_app/chatbot_manager/test_views.py
+++ b/tests/api_app/chatbot_manager/test_views.py
@@ -14,6 +14,7 @@ from rest_framework.test import APITestCase
 
 from api_app.chatbot_manager.events import ChatErrorDetail
 from api_app.chatbot_manager.models import ChatMessage, ChatSession
+from api_app.chatbot_manager.placeholder_guard import PLACEHOLDER_NOTICE
 from certego_saas.apps.user.models import User
 
 _ANSWER = "Here are your recent jobs."
@@ -88,6 +89,21 @@ class ChatSessionViewSetTestCase(APITestCase):
             [(type(m), m.content) for m in invoke_input["messages"]],
             [(HumanMessage, "prev q"), (AIMessage, "prev a"), (HumanMessage, "Hello")],
         )
+
+    @patch(
+        "api_app.chatbot_manager.views.build_agent",
+        return_value=_agent(invoke_return={"messages": [AIMessage(content="Use [Playbook X].")]}),
+    )
+    def test_message_annotates_fabricated_names(self, mock_build):
+        # The REST fallback must behave exactly like the WebSocket path; a divergence between the
+        # two is its own defect.
+        response = self.client.post(self.MESSAGE_URL, data={"message": "which playbook?"}, format="json")
+
+        self.assertEqual(response.status_code, status.HTTP_200_OK)
+        data = response.json()
+        self.assertIn(PLACEHOLDER_NOTICE, data["response"])
+        stored = ChatMessage.objects.get(pk=data["message_id"])
+        self.assertEqual(stored.content, data["response"])
 
     @patch("api_app.chatbot_manager.views.build_agent")
     def test_message_iteration_cap_returns_error_and_drops_the_turn(self, mock_build):


### PR DESCRIPTION
# Description

`Refs #3909`

The `[Rules]` line added in #3881 tells the model to copy analyzer, playbook and job names verbatim
and never emit bracketed labels like `[Analyzer 1]`. It works in the large majority of answers, but a
rule expressed only in the system prompt is probabilistic by construction — and the failure is
silent: the user sees a plausible answer with fabricated names.

This adds the deterministic backstop @mlodic asked for in #3909: an LLM-free check that runs on the
final answer of every chat turn, on **both** answer paths, and annotates an answer whose bracketed
names look like placeholders instead of letting it through unremarked.

## What it does — and deliberately does not

On detection it logs one warning and appends a single line to the answer:

> _Note: this answer contains bracketed names that look like placeholders rather than real IntelOwl
> names. Treat them as unverified._

It does **not** edit the model's prose and does **not** re-run the model. Two reasons, both
structural:

- **There is no correct name to substitute.** In the recorded failures the tool payload contained no
  playbook data at all — the names were invented outright, not degraded from real ones.
- **A retry would change nothing.** The agent runs at `temperature=0`, so re-running the same input
  reproduces the same answer; any "retry" would have to be a corrective rewrite, i.e. a second
  inference on a CPU-bound local model, which can itself hallucinate.

Removing the offending spans was considered and rejected: in the real case it would leave empty list
bullets under an orphan lead-in (*"The playbooks that can analyze this observable are:"*).

## Honest scope of the claim

Neither archived occurrence was produced by the prompt exactly as it ships today — one came from a
prompt variant that was measured and discarded, the other predates the rule #3881 added. So this is
**defense-in-depth against a measured model tendency, not a fix for a bug reproducible on demand.**
The guard catches the failure; it does not prevent it.

The tendency is not accidental, though: both occurrences belong to the same "playbook" confabulation
family recorded during the #3898 narration measurement (in 4 of 9 answers the model introduced the
analyzer list as *"the playbooks used for this job"*, a word no payload contains). Its root cause —
`system_prompt.txt` advertising `recommend_playbook` while #3881's rule repeats "playbook" — is still
in the shipped prompt.

## The detection criterion, and why it is not `\[.*\]`

A false positive would stamp a warning onto a correct answer, so the criterion is two conditions, not
one regex:

1. a single-line `[...]` span **not** followed by `(` — that lookahead excludes markdown links
   `[text](url)`, which the chat panel renders as real anchors;
2. whose content **starts with** one of the entity nouns the prompt rule protects
   (`analyzer|playbook|job|investigation|observable`).

The start anchor is what keeps out the things that legitimately carry brackets in a threat-intel
product: defanged indicators (`example[.]com`, `1.1.1[.]1`, `hxxp[:]//`), GFM task-list boxes
(`- [x]`), footnote markers (`[1]`), and JSON echoes of a tool result. Every one of those is a test.

Deliberately missed shapes (`[X]`, `[TBD]`, `[insert name]`): precision is preferred over coverage,
and the prompt rule remains the first line of defense. A second family gets added when a real
occurrence justifies it — exactly how this one came to be.

## Measurements

**Offline, 43 archived answers.** The detector was run over every answer archived during the
2026-08-03 narration campaign plus the 9 live answers from the smoke below:

```
scanned 43 archived answer files
  dev3-run2.txt:  ['[Playbook X]', '[Playbook Y]']
  smoke-run4.txt: ['[Playbook names will be listed here if available]']
files flagged: 2
```

Exactly the two known occurrences, with the exact spans, and **zero false positives on the other
41** — real model output containing analyzer names, job ids, verdict headlines and markdown.

Note the shape of the second one: a whole sentence used as a name slot. A detector tuned only on
`[Label N]` would have missed it.

**Live, 3 runs × 3 phrasings.** Real Ollama, `qwen2.5:3b`, production invocation path: **9 answers,
0 guard firings.** Narration is unchanged from the baseline, which is expected by construction — this
PR touches no prompt and no tool.

## What the user sees

Screenshot and a 35s clip below.

The guard fires on ~2-3% of answers and not under the shipped prompt, so it cannot be triggered on
demand for a recording: the conversation in the first scene is **seeded**, and both answer texts in
it are real model output taken verbatim from the measurement archive (the flagged one is the
`[Playbook X]` / `[Playbook Y]` answer from the 2026-08-03 campaign). The rendering, the stored
content and the notice are exactly what a user would get; only the turn that produced them is
simulated.

The second scene is **not** seeded: it is a real turn against live Ollama, and it is deliberately a
name-dense one — *"What analyzers can I use for a domain?"* returns a numbered list of real analyzer
names (`ApiVoid`, `BBOT`, `CheckDMARC`, `Classic_DNS`, `CleanBrowsing_Malicious_Detector`, …). That
is the answer shape a naive `\[.*\]` detector would trip over. No note is added; the recorder asserts
it (`LIVE_TURN_NOTICES: 0`, on each of the three runs recorded).

## Where it hooks in

- `tasks.py` — the Celery/WebSocket turn, before the message is persisted and `chat.end` is emitted.
  The tokens have already streamed by then, but the frontend's `applyEnd` discards the streamed
  buffer and renders `chat.end`'s content, so the guarded text is both what the user reads and what
  is stored.
- `views.py` — the synchronous REST fallback, at the same point in the flow.
- `agent/memory.py` — `DjangoChatMessageHistory` strips the notice when replaying prior turns. The
  notice is an annotation for the user, not model output; without this it would re-enter the prompt,
  where a 3B model may start imitating it.

## Out of scope

- **No prompt change.** Four prompt attempts were measured on 2026-08-03; each traded one failure for
  another, and the fourth actively produced this very bug. Editing the prompt would also force a full
  re-measurement of the narration gate.
- **No structured field** on `ChatMessage` / `EndEvent`. A dedicated flag would allow a warning chip
  in the UI instead of a text line, at the cost of a migration, a serializer change and frontend
  work. Happy to do it as a follow-up if you prefer that treatment.

## Type of change

- [x] New feature (non-breaking change which adds functionality).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] I have inserted the copyright banner at the start of the file
- [x] Please avoid adding new libraries as requirements whenever it is possible — no new dependency; the new module is stdlib-only (`logging`, `re`)
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the feature/bug I solved. All the tests (new and old ones) gave 0 errors — `tests.api_app.chatbot_manager` 223/223 green
- [x] If the GUI has been modified: no frontend file is touched; the change is visible in the panel because the answer text itself changes, so a screenshot is provided
- [x] I have reviewed and verified any LLM-generated code included in this PR. **LLM usage: yes** — Claude Code was used for the implementation, the detector's test corpus and this description; every line was reviewed, and the criterion was validated against 43 archived real answers and 9 live ones rather than against generated examples.
