### PR TITLE
fix(OpenCTI): update OpenCTI documentation links in migrations Closes #3814 

### DIFF
--- a/api_app/analyzers_manager/migrations/0197_update_opencti_description.py
+++ b/api_app/analyzers_manager/migrations/0197_update_opencti_description.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.db.models import Value
+from django.db.models.functions import Replace
+
+OLD_URL = (
+    "https://intelowl.readthedocs.io/en/latest/"
+    "Advanced-Configuration.html#opencti"
+)
+NEW_URL = (
+    "https://intelowlproject.github.io/docs/IntelOwl/"
+    "advanced_configuration/#opencti"
+)
+
+
+def update_opencti_description(apps, schema_editor):
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+    AnalyzerConfig.objects.filter(
+        name="OpenCTI",
+        description__contains=OLD_URL,
+    ).update(
+        description=Replace(
+            "description", Value(OLD_URL), Value(NEW_URL)
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("analyzers_manager", "0196_data_model_phishing_lists"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_opencti_description,
+            migrations.RunPython.noop,
+        ),
+    ]

--- a/api_app/connectors_manager/migrations/0033_update_opencti_description.py
+++ b/api_app/connectors_manager/migrations/0033_update_opencti_description.py
@@ -1,0 +1,38 @@
+from django.db import migrations
+from django.db.models import Value
+from django.db.models.functions import Replace
+
+OLD_URL = (
+    "https://intelowl.readthedocs.io/en/latest/"
+    "Advanced-Configuration.html#opencti"
+)
+NEW_URL = (
+    "https://intelowlproject.github.io/docs/IntelOwl/"
+    "advanced_configuration/#opencti"
+)
+
+
+def update_opencti_description(apps, schema_editor):
+    ConnectorConfig = apps.get_model("connectors_manager", "ConnectorConfig")
+    ConnectorConfig.objects.filter(
+        name="OpenCTI",
+        description__contains=OLD_URL,
+    ).update(
+        description=Replace(
+            "description", Value(OLD_URL), Value(NEW_URL)
+        )
+    )
+
+
+class Migration(migrations.Migration):
+
+    dependencies = [
+        ("connectors_manager", "0032_more_params_emails"),
+    ]
+
+    operations = [
+        migrations.RunPython(
+            update_opencti_description,
+            migrations.RunPython.noop,
+        ),
+    ]


### PR DESCRIPTION
Closes #3814 
# Description
- updated OpenCTI doc links in both analyzer and connector configs
<img width="2024" height="594" alt="image" src="https://github.com/user-attachments/assets/8d88fdb9-379d-48bf-bbc8-a20d000b2ff5" />

## Type of change
- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
