### PR TITLE
fix: eliminate N+1 queries in Investigation.total_jobs

### DIFF
--- a/api_app/investigations_manager/models.py
+++ b/api_app/investigations_manager/models.py
@@ -124,4 +124,15 @@ class Investigation(OwnershipAbstractModel, ListCachable):
 
     @property
     def total_jobs(self) -> int:
-        return sum(job.get_descendant_count() for job in self.jobs.all()) + self.jobs.count()
+        from django.db.models import Q
+
+        paths = list(self.jobs.values_list("path", flat=True))
+        if not paths:
+            return 0
+        # Count every job whose tree contains at least one of the
+        # investigation's root jobs using treebeard's materialized
+        # path (path prefix match) — one query instead of N+1
+        query = Q(path__startswith=paths[0])
+        for path in paths[1:]:
+            query |= Q(path__startswith=path)
+        return Job.objects.filter(query).count()

--- a/tests/api_app/investigations_manager/test_models.py
+++ b/tests/api_app/investigations_manager/test_models.py
@@ -103,6 +103,28 @@ class InvestigationTestCase(CustomTestCase):
         self.assertEqual(an.total_jobs, 0)
         an.delete()
 
+    def test_total_jobs_constant_queries(self):
+        # total_jobs must not run one query per job (N+1):
+        # it should count all descendant jobs in a constant number
+        # of queries regardless of how many jobs the investigation holds
+        an: Investigation = Investigation.objects.create(name="Test", owner=self.user)
+        for _ in range(3):
+            job = Job.objects.create(
+                analyzable=self.an,
+                user=self.user,
+                status="killed",
+            )
+            job.add_child(
+                analyzable=self.an,
+                user=self.user,
+                status="killed",
+            )
+            an.jobs.add(job)
+        an.refresh_from_db()
+        with self.assertNumQueries(2):
+            self.assertEqual(an.total_jobs, 6)
+        an.delete()
+
     def test_tlp(self):
         job = Job.objects.create(
             analyzable=self.an,


### PR DESCRIPTION
## Description

Fix #3955 — `Investigation.total_jobs` previously called `job.get_descendant_count()`
per job, causing N+1 queries. Now it uses treebeard's materialized path prefix matching
with a single `Q OR` query to count all descendant jobs at once.

## Changes

- `api_app/investigations_manager/models.py`: Replace `total_jobs` property with
a single-query implementation using `Q(path__startswith=...)`
- `tests/api_app/investigations_manager/test_models.py`: Add test confirming
query count is constant (2 queries) regardless of job count

## Verification

Existing test `test_jobs_count` passes unchanged (2 → 1 → 0).
New test `test_total_jobs_constant_queries` verifies 3 jobs with 1 child each
(6 total) returns correct count with only 2 DB queries.

## Checklist

- [x] Bug fix (non-breaking change)
- [x] Tests added/updated
- [x] Code follows project style
- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`