### PR TITLE
Avoid one COUNT query per pivoted job in Investigation.total_jobs. Closes #3955

### DIFF
--- a/api_app/investigations_manager/models.py
+++ b/api_app/investigations_manager/models.py
@@ -124,4 +124,21 @@ class Investigation(OwnershipAbstractModel, ListCachable):
 
     @property
     def total_jobs(self) -> int:
-        return sum(job.get_descendant_count() for job in self.jobs.all()) + self.jobs.count()
+        from functools import reduce
+        from operator import or_
+
+        from django.db.models import Q
+
+        # self.jobs are the root jobs; their descendants live only in the
+        # job tree. Count all descendants in a single query instead of one
+        # COUNT per pivoted job: treebeard stores the materialized path, so
+        # the descendants of a job share its path prefix.
+        paths = list(self.jobs.values_list("path", flat=True))
+        if not paths:
+            return 0
+        descendants = (
+            Job.objects.filter(reduce(or_, (Q(path__startswith=path) for path in paths)))
+            .exclude(path__in=paths)
+            .count()
+        )
+        return descendants + len(paths)

--- a/tests/api_app/investigations_manager/test_models.py
+++ b/tests/api_app/investigations_manager/test_models.py
@@ -97,6 +97,32 @@ class InvestigationTestCase(CustomTestCase):
         an.jobs.add(job)
         an.refresh_from_db()
         self.assertEqual(an.total_jobs, 2)
+        # a second root job with its own pivoted child must not add one
+        # COUNT query per pivoted job
+        # https://github.com/intelowlproject/IntelOwl/issues/3955
+        job2 = Job.objects.create(
+            analyzable=self.an,
+            user=self.user,
+            status="killed",
+        )
+        job2.add_child(
+            analyzable=self.an,
+            user=self.user,
+            status="killed",
+        )
+        an.jobs.add(job2)
+        an.refresh_from_db()
+        from django.db import connection
+        from django.test.utils import CaptureQueriesContext
+
+        with CaptureQueriesContext(connection) as ctx:
+            self.assertEqual(an.total_jobs, 4)
+        # the CI test runner EXPLAINs every query, so count only the real ones
+        real_queries = [q for q in ctx.captured_queries if not q["sql"].startswith("EXPLAIN")]
+        self.assertEqual(len(real_queries), 2)
+        job2.refresh_from_db()
+        job2.delete()
+        self.assertEqual(an.total_jobs, 2)
         j2.delete()
         self.assertEqual(an.total_jobs, 1)
         job.delete()


### PR DESCRIPTION
# Description

`Investigation.total_jobs` called `get_descendant_count()` on every job of the investigation. `django-treebeard` answers that from memory for leaf jobs, but for every job with pivoted children it fires a real `COUNT(*)` query -- one per pivoted job, every time. Since the property is exposed by `InvestigationSerializer` on the `GET /api/investigation/` list endpoint, the query count grew linearly with the number of pivoted jobs in the page, as measured in the issue.

The investigation's jobs are the tree roots (their descendants live only in the job tree, as the codebase already relies on elsewhere), and treebeard stores the materialized path, so all descendants of all roots can be counted in one query filtering on the roots' path prefixes. `total_jobs` now runs exactly 2 queries (one for the roots' paths, one aggregated descendant `COUNT`) regardless of how many jobs have pivots. The counting semantics are unchanged.

The existing `test_jobs_count` test is extended with a second root job that has a pivoted child, wrapped in `assertNumQueries(2)` so a regression back to per-job counting fails the test.

Closes #3955

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [x] Please avoid adding new libraries as requirements whenever it is possible. -- no new libraries
- [x] The commit contains the `Closes` clause as it is a single-commit PR
