### PR TITLE
Fix archive extension regex matching in FileJobSerializer. Closes #3968

### DIFF
--- a/api_app/serializers/job.py
+++ b/api_app/serializers/job.py
@@ -814,16 +814,22 @@ class FileJobSerializer(_AbstractJobCreateSerializer):
             pk__in=[config.pk for config in analyzers_to_execute]
         )
         if file_mimetype in [MimeTypes.ZIP1.value, MimeTypes.ZIP2.value]:
-            EXCEL_OFFICE_FILES = r"\.[xl]\w{0,3}$"
-            DOC_OFFICE_FILES = r"\.[doc]\w{0,3}$"
-            if re.search(DOC_OFFICE_FILES, file_name):
-                # its an excel file
-                file_mimetype = MimeTypes.DOC.value
-            elif re.search(EXCEL_OFFICE_FILES, file_name):
-                # its an excel file
-                file_mimetype = MimeTypes.EXCEL1.value
-            else:
-                # its an android file
+            DOC_OFFICE_FILES = r"\.(?:doc|docx|docm|dot|dotx)$"
+            EXCEL_OFFICE_FILES = r"\.(?:xls|xlsx|xlsm|xlt|xltx)$"
+            APK_FILES = r"\.apk$"
+            if re.search(DOC_OFFICE_FILES, file_name, re.IGNORECASE):
+                file_mimetype = (
+                    MimeTypes.WORD2.value
+                    if file_name.lower().endswith((".docx", ".docm", ".dotx"))
+                    else MimeTypes.WORD1.value
+                )
+            elif re.search(EXCEL_OFFICE_FILES, file_name, re.IGNORECASE):
+                file_mimetype = (
+                    MimeTypes.DOC.value
+                    if file_name.lower().endswith((".xlsx", ".xlsm", ".xltx"))
+                    else MimeTypes.EXCEL1.value
+                )
+            elif re.search(APK_FILES, file_name, re.IGNORECASE):
                 file_mimetype = MimeTypes.APK.value
 
         supported_query = (

--- a/tests/api_app/test_serializers.py
+++ b/tests/api_app/test_serializers.py
@@ -7,7 +7,7 @@ from django.utils.timezone import now
 from rest_framework.exceptions import ValidationError
 
 from api_app.analyzables_manager.models import Analyzable
-from api_app.analyzers_manager.models import AnalyzerConfig
+from api_app.analyzers_manager.models import AnalyzerConfig, MimeTypes
 from api_app.analyzers_manager.serializers import AnalyzerConfigSerializer
 from api_app.choices import Classification, PythonModuleBasePaths
 from api_app.connectors_manager.models import ConnectorConfig
@@ -494,6 +494,82 @@ class FileJobCreateSerializerTestCase(CustomTestCase):
         )
         self.assertCountEqual(analyzers, [a])
         a.delete()
+
+    def test_zip_disambiguation_extension_matching(self):
+        apk_analyzer = AnalyzerConfig.objects.create(
+            name="test_apk",
+            python_module=PythonModule.objects.get(
+                base_path=PythonModuleBasePaths.FileAnalyzer.value,
+                module="yara_scan.YaraScan",
+            ),
+            description="test apk",
+            disabled=False,
+            supported_filetypes=[MimeTypes.APK.value],
+            type="file",
+            run_hash=False,
+        )
+        zip_analyzer = AnalyzerConfig.objects.create(
+            name="test_zip",
+            python_module=PythonModule.objects.get(
+                base_path=PythonModuleBasePaths.FileAnalyzer.value,
+                module="yara_scan.YaraScan",
+            ),
+            description="test zip",
+            disabled=False,
+            supported_filetypes=[MimeTypes.ZIP1.value],
+            type="file",
+            run_hash=False,
+        )
+        word_analyzer = AnalyzerConfig.objects.create(
+            name="test_word",
+            python_module=PythonModule.objects.get(
+                base_path=PythonModuleBasePaths.FileAnalyzer.value,
+                module="yara_scan.YaraScan",
+            ),
+            description="test word",
+            disabled=False,
+            supported_filetypes=[MimeTypes.WORD2.value],
+            type="file",
+            run_hash=False,
+        )
+
+        all_analyzers = [apk_analyzer, zip_analyzer, word_analyzer]
+
+        # 1. APK file in zip container matches APK analyzer
+        apk_selected = FileJobSerializer.set_analyzers_to_execute(
+            self.fas, all_analyzers, tlp="CLEAR", file_mimetype=MimeTypes.ZIP1.value, file_name="app.apk"
+        )
+        self.assertCountEqual(apk_selected, [apk_analyzer])
+
+        # 2. DOCX file matches Word analyzer
+        word_selected = FileJobSerializer.set_analyzers_to_execute(
+            self.fas,
+            all_analyzers,
+            tlp="CLEAR",
+            file_mimetype=MimeTypes.ZIP1.value,
+            file_name="document.docx",
+        )
+        self.assertCountEqual(word_selected, [word_analyzer])
+
+        # 3. DLL or LOG files inside zip container retain ZIP mimetype and do not trigger Word/Excel/APK false positives
+        dll_selected = FileJobSerializer.set_analyzers_to_execute(
+            self.fas, all_analyzers, tlp="CLEAR", file_mimetype=MimeTypes.ZIP1.value, file_name="library.dll"
+        )
+        self.assertCountEqual(dll_selected, [zip_analyzer])
+
+        log_selected = FileJobSerializer.set_analyzers_to_execute(
+            self.fas, all_analyzers, tlp="CLEAR", file_mimetype=MimeTypes.ZIP1.value, file_name="server.log"
+        )
+        self.assertCountEqual(log_selected, [zip_analyzer])
+
+        generic_zip_selected = FileJobSerializer.set_analyzers_to_execute(
+            self.fas, all_analyzers, tlp="CLEAR", file_mimetype=MimeTypes.ZIP1.value, file_name="archive.zip"
+        )
+        self.assertCountEqual(generic_zip_selected, [zip_analyzer])
+
+        apk_analyzer.delete()
+        zip_analyzer.delete()
+        word_analyzer.delete()
 
 
 class ObservableJobCreateSerializerTestCase(CustomTestCase):


### PR DESCRIPTION
# Description

This PR fixes a regular expression pattern matching bug in `FileJobSerializer.set_analyzers_to_execute` (`api_app/serializers/job.py`) where character classes `[doc]` and `[xl]` were causing false positive MIME type overrides for uploaded zip archives.

Fixes #3968.

### Summary of Changes:
1. Replaced `r"\.[doc]\w{0,3}$"` with `r"\.(?:doc|docx|docm|dot|dotx)$"` to accurately match Word document extensions.
2. Replaced `r"\.[xl]\w{0,3}$"` with `r"\.(?:xls|xlsx|xlsm|xlt|xltx)$"` to accurately match Excel spreadsheet extensions.
3. Added an explicit check for `.apk` extensions (`r"\.apk$"`) before reclassifying to `MimeTypes.APK`, allowing generic ZIP archives to retain `MimeTypes.ZIP1` (`application/zip`).
4. Added test cases in `tests/api_app/test_serializers.py` (`FileJobCreateSerializerTestCase`) validating analyzer selection across `.docx`, `.xlsx`, `.apk`, `.dll`, `.log`, and `.zip` filenames.

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).
- [ ] New feature (non-breaking change which adds functionality).
- [ ] Breaking change (fix or feature that would cause existing functionality to not work as expected).
- [ ] Chore (refactoring, dependency updates, CI/CD changes, code cleanup, docs-only changes).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed, in which case:
    - [ ] I strictly followed the documentation ["How to create a Plugin"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-add-a-new-plugin)
    - [ ] [Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/usage.md) file was updated. A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] [Advanced-Usage](https://github.com/intelowlproject/docs/blob/main/docs/IntelOwl/advanced_usage.md) was updated (in case the plugin provides additional optional configuration). A link to the PR to the [docs](https://github.com/intelowlproject/docs) repo has been added as a comment here.
    - [ ] I have dumped the configuration from Django Admin using the `dumpplugin` command and added it in the project as a data migration. (["How to share a plugin with the community"](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-share-your-plugin-with-the-community))
    - [ ] If a File analyzer was added and it supports a mimetype which is not already supported, you added a sample of that type inside the archive `test_files.zip` and you added the default tests for that mimetype in [test_classes.py](https://github.com/intelowlproject/IntelOwl/blob/master/tests/api_app/analyzers_manager/test_classes.py).
    - [ ] If you created a new analyzer and it is free (does not require any API key), please add it in the `FREE_TO_USE_ANALYZERS` playbook by following [this guide](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-modify-a-plugin).
    - [ ] Check if it could make sense to add that analyzer/connector to other [freely available playbooks](https://intelowlproject.github.io/docs/IntelOwl/usage/#list-of-pre-built-playbooks).
    - [ ] I have provided the resulting raw JSON of a finished analysis and a screenshot of the results.
    - [ ] If the plugin interacts with an external service, I have created an attribute called precisely `url` that contains this information. This is required for Health Checks (HEAD HTTP requests). 
    - [ ] If a new analyzer has beed added, I have created a unittest for it in the appropriate dir. I have also mocked all the external calls, so that no real calls are being made while testing.
    - [ ] I have added that raw JSON sample to the `get_mocker_response()` method of the unittest class. This serves us to provide a valid sample for testing. 
    - [ ] I have created the corresponding `DataModel` for the new analyzer following the [documentation](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-create-a-datamodel)
- [x] I have inserted the copyright banner at the start of the file: ```# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl # See the file 'LICENSE' for copying permission.```
- [x] Please avoid adding new libraries as requirements whenever it is possible. Use new libraries only if strictly needed to solve the issue you are working for. In case of doubt, ask a maintainer permission to use a specific library.
- [x] If external libraries/packages with restrictive licenses were added, they were added in the [Legal Notice](https://github.com/certego/IntelOwl/blob/master/.github/legal_notice.md) section.
- [x] Linters (`Ruff`) gave 0 errors. If you have correctly installed [pre-commit](https://intelowlproject.github.io/docs/IntelOwl/contribute/#how-to-start-setup-project-and-development-instance), it does these checks and adjustments on your behalf.
- [x] I have added tests for the feature/bug I solved (see `tests` folder). All the tests (new and old ones) gave 0 errors.
- [ ] If the GUI has been modified:
    - [ ] I have a provided a screenshot of the result in the PR.
    - [ ] I have created new frontend tests for the new component or updated existing ones.
- [x] After you had submitted the PR, if `DeepSource`, `Django Doctors` or other third-party linters have triggered any alerts during the CI checks, I have solved those alerts.
- [x] I have addressed raised Copilot issues. In case of FPs, I have commented the Copilot issue and proved that it is wrong before having the comment resolved.
- [x] I have reviewed and verified any LLM-generated code included in this PR. Also, I have explicitly stated that I have used LLMs in this PR.
