### PR TITLE
fix: update Job status to FAILED when job_pipeline raises an exception

### DIFF
--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -248,12 +248,18 @@ def job_pipeline(
     job_id: int,
 ):
     from api_app.models import Job
+    from api_app.websocket import JobConsumer
 
     job = Job.objects.get(pk=job_id)
     try:
         job.execute()
     except Exception as e:
         logger.exception(e)
+        job.status = Job.STATUSES.FAILED.value
+        max_error_len = Job._meta.get_field("errors").base_field.max_length
+        job.errors = list(job.errors or []) + [str(e)[:max_error_len]]
+        job.finished_analysis_time = now()
+        job.save(update_fields=["status", "errors", "finished_analysis_time"])
         for report in (
             list(job.analyzerreports.all())
             + list(job.connectorreports.all())
@@ -262,6 +268,12 @@ def job_pipeline(
         ):
             report.status = report.STATUSES.FAILED.value
             report.save()
+        JobConsumer.serialize_and_send_job(job)
+        if root_investigation := job.get_root().investigation:
+            from api_app.investigations_manager.models import Investigation
+
+            root_investigation: Investigation
+            root_investigation.set_correct_status(save=True)
 
 
 @shared_task(base=FailureLoggedTask, name="run_plugin", soft_time_limit=500)

--- a/tests/intel_owl/test_job_pipeline.py
+++ b/tests/intel_owl/test_job_pipeline.py
@@ -1,0 +1,83 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+import datetime
+from unittest.mock import patch
+
+from api_app.analyzables_manager.models import Analyzable
+from api_app.choices import Classification
+from api_app.models import Job
+from intel_owl.tasks import job_pipeline
+from tests import CustomTestCase
+
+_FAKE_NOW = datetime.datetime(2026, 8, 28, 12, 0, 0, tzinfo=datetime.timezone.utc)
+
+
+@patch("intel_owl.tasks.now", return_value=_FAKE_NOW)
+@patch("api_app.websocket.JobConsumer.serialize_and_send_job")
+class JobPipelineExceptionTestCase(CustomTestCase):
+    """
+    Tests that job_pipeline correctly handles exceptions raised by job.execute().
+
+    Regression test for: Job stuck in RUNNING forever when job_pipeline raises.
+    The except block must:
+      1. Set job.status = FAILED
+      2. Set job.finished_analysis_time = now()
+      3. Append the error to job.errors
+      4. Persist via job.save()
+      5. Push a WebSocket notification so the frontend stops spinning
+    """
+
+    def setUp(self):
+        self.analyzable = Analyzable.objects.create(
+            name="8.8.8.8",
+            classification=Classification.IP,
+        )
+        self.job = Job.objects.create(
+            user=self.superuser,
+            status=Job.STATUSES.PENDING.value,
+            analyzable=self.analyzable,
+        )
+
+    def tearDown(self):
+        self.job.delete()
+        self.analyzable.delete()
+
+    def test_job_status_set_to_failed_on_exception(self, mock_ws, mock_now):
+        """job.status must be FAILED after execute() raises — not left as RUNNING."""
+        with patch.object(Job, "execute", side_effect=RuntimeError("broker down")):
+            job_pipeline(self.job.pk)
+
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.status, Job.STATUSES.FAILED.value)
+
+    def test_finished_analysis_time_set_on_exception(self, mock_ws, mock_now):
+        """finished_analysis_time must be set so remove_old_jobs can clean the job up."""
+        with patch.object(Job, "execute", side_effect=RuntimeError("broker down")):
+            job_pipeline(self.job.pk)
+
+        self.job.refresh_from_db()
+        self.assertEqual(self.job.finished_analysis_time, _FAKE_NOW)
+
+    def test_error_appended_to_job_errors_on_exception(self, mock_ws, mock_now):
+        """Exception message must be recorded in job.errors."""
+        with patch.object(Job, "execute", side_effect=RuntimeError("broker down")):
+            job_pipeline(self.job.pk)
+
+        self.job.refresh_from_db()
+        self.assertIn("broker down", self.job.errors)
+
+    def test_websocket_notification_sent_on_exception(self, mock_ws, mock_now):
+        """Frontend must be notified immediately so the spinner stops."""
+        with patch.object(Job, "execute", side_effect=RuntimeError("broker down")):
+            job_pipeline(self.job.pk)
+
+        mock_ws.assert_called_once_with(self.job)
+
+    def test_no_exception_when_execute_succeeds(self, mock_ws, mock_now):
+        """Happy path must not be broken by the fix."""
+        with patch.object(Job, "execute", return_value=None):
+            try:
+                job_pipeline(self.job.pk)
+            except Exception as e:
+                self.fail(f"job_pipeline raised unexpectedly on success path: {e}")


### PR DESCRIPTION
## Description

When `job.execute()` raises inside `job_pipeline`, the `except` block only marked individual plugin reports as failed it never updated the `Job` row itself.
Since `execute()` sets `job.status = RUNNING` as its first action, and the Celery chain (including `job_set_final_status`) never dispatches on exception, the job gets permanently stuck in `RUNNING`.

**Consequences:**
- Frontend shows an infinite spinner no WebSocket notification is ever sent
- `remove_old_jobs` never cleans the job `finished_analysis_time` stays `NULL`
- Parent `Investigation` status is never updated
- Exception message is silently discarded

**Fix:** In the `except` block, immediately set `job.status = FAILED`, `job.finished_analysis_time = now()`, append the error, persist with `job.save(update_fields=[...])`, push a WebSocket notification, and propagate failure to the parent `Investigation` if one exists.
This matches the pattern already used in `run_plugin` (line 295 of `tasks.py`).

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

Issue #3653

## Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed — **not applicable**
- [x] I have inserted the copyright banner at the start of the file
- [x] No new libraries were added as requirements
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the bug I solved (see `tests/` folder). All tests gave 0 errors
- [x] I have reviewed and verified any LLM-generated code included in this PR. I have explicitly stated that I used an LLM (Claude) to assist in identifying the bug, writing the fix, and the verification script. All output was manually reviewed and validated against the real source.