### PR TITLE
fix(tasks): mark job as failed when pipeline raises. Closes #3653

### DIFF
--- a/intel_owl/tasks.py
+++ b/intel_owl/tasks.py
@@ -248,12 +248,17 @@ def job_pipeline(
     job_id: int,
 ):
     from api_app.models import Job
+    from api_app.websocket import JobConsumer
 
     job = Job.objects.get(pk=job_id)
     try:
         job.execute()
     except Exception as e:
         logger.exception(e)
+        job.status = Job.STATUSES.FAILED.value
+        job.errors = (job.errors or []) + [f"{e.__class__.__name__}: {e}"[:900]]
+        job.finished_analysis_time = now()
+        job.save(update_fields=["status", "errors", "finished_analysis_time"])
         for report in (
             list(job.analyzerreports.all())
             + list(job.connectorreports.all())
@@ -261,7 +266,10 @@ def job_pipeline(
             + list(job.visualizerreports.all())
         ):
             report.status = report.STATUSES.FAILED.value
-            report.save()
+            report.save(update_fields=["status"])
+        if root_investigation := job.get_root().investigation:
+            root_investigation.set_correct_status(save=True)
+        JobConsumer.serialize_and_send_job(job)
 
 
 @shared_task(base=FailureLoggedTask, name="run_plugin", soft_time_limit=500)

--- a/tests/intel_owl/test_tasks.py
+++ b/tests/intel_owl/test_tasks.py
@@ -15,10 +15,43 @@ from api_app.visualizers_manager.models import VisualizerConfig, VisualizerRepor
 from certego_saas.apps.organization.membership import Membership
 from certego_saas.apps.organization.organization import Organization
 from certego_saas.apps.user.models import User
-from intel_owl.tasks import send_plugin_report_to_elastic
+from intel_owl.tasks import job_pipeline, send_plugin_report_to_elastic
 from tests import CustomTestCase
 
 _now = datetime.datetime(2024, 10, 29, 11, tzinfo=datetime.UTC)
+
+
+@patch("intel_owl.tasks.now", return_value=_now)
+class JobPipelineTestCase(CustomTestCase):
+    def test_job_status_failed_when_execute_raises(self, *args, **kwargs):
+        analyzable = Analyzable.objects.create(name="dns.google.com", classification=Classification.DOMAIN)
+        job = Job.objects.create(
+            tlp="AMBER",
+            user=self.user,
+            analyzable=analyzable,
+            status=Job.STATUSES.PENDING,
+        )
+        report = AnalyzerReport.objects.create(
+            config=AnalyzerConfig.objects.get(name="Classic_DNS"),
+            job=job,
+            status=AnalyzerReport.STATUSES.PENDING,
+            task_id=uuid(),
+            parameters={},
+        )
+
+        with (
+            patch.object(Job, "execute", side_effect=RuntimeError("pipeline failed")),
+            patch("api_app.websocket.JobConsumer.serialize_and_send_job") as mocked_send_job,
+        ):
+            job_pipeline(job.pk)
+
+        job.refresh_from_db()
+        report.refresh_from_db()
+        self.assertEqual(job.status, Job.STATUSES.FAILED)
+        self.assertEqual(job.errors, ["RuntimeError: pipeline failed"])
+        self.assertEqual(job.finished_analysis_time, _now)
+        self.assertEqual(report.status, AnalyzerReport.STATUSES.FAILED)
+        mocked_send_job.assert_called_once_with(job)
 
 
 @patch("intel_owl.tasks.get_environment", return_value="unittest")


### PR DESCRIPTION
# Description

Fixes the `job_pipeline` exception path so a job does not remain stuck in a non-terminal state when
`job.execute()` raises before the Celery pipeline can complete.

`Job.execute()` sets the job status to `running` before building and invoking the pipeline. If that step
raises, the previous `job_pipeline` handler only marked plugin reports as `FAILED`, leaving the `Job`
itself as `running` with no `finished_analysis_time`. That makes the UI keep showing a running job until
the stuck-analysis cleanup catches it later.

Related PR: #3972 by @Aditya30ag, who asked for review/help on the same issue. This PR keeps the fix as a
small branch against `develop` with a focused regression test.

## Changes

- Set the job status to `failed` in the `job_pipeline` exception handler.
- Store the exception message in `job.errors` and set `finished_analysis_time`.
- Keep marking related analyzer/connector/pivot/visualizer reports as `FAILED`.
- Refresh the parent investigation status when present.
- Send the job WebSocket update immediately so the frontend sees the terminal state.
- Add a regression test for the `job.execute()` failure path.

Closes #3653

## Type of change

- [x] Bug fix (non-breaking change which fixes an issue).

# Checklist

- [x] I have read and understood the rules about [how to Contribute](https://intelowlproject.github.io/docs/IntelOwl/contribute/) to this project
- [x] The pull request is for the branch `develop`
- [ ] A new plugin (analyzer, connector, visualizer, playbook, pivot or ingestor) was added or changed — N/A
- [x] I have inserted the copyright banner at the start of the file — existing files already had it
- [x] Please avoid adding new libraries as requirements whenever it is possible — no new dependencies
- [ ] If external libraries/packages with restrictive licenses were added — N/A
- [x] Linters (`Ruff`) gave 0 errors
- [x] I have added tests for the bug I solved
- [ ] If the GUI has been modified — N/A
- [x] After submitting the PR, I will resolve any `DeepSource` / `Django Doctors` / third-party alerts from CI
- [x] I have addressed raised Copilot issues — will address any raised on the PR
- [x] I have reviewed and verified any LLM-generated code included in this PR

## Local verification

```bash
python -m ruff check intel_owl/tasks.py tests/intel_owl/test_tasks.py
python -m ruff format --check intel_owl/tasks.py tests/intel_owl/test_tasks.py
git diff --check
```

The targeted Django test could not be executed in this local environment because the non-Docker setup is
missing project/runtime dependencies and system libraries required by IntelOwl's Django settings.
