### PR TITLE
Add ScanMalware observable analyzer

### DIFF
--- a/api_app/analyzers_manager/migrations/0197_analyzer_config_scanmalware.py
+++ b/api_app/analyzers_manager/migrations/0197_analyzer_config_scanmalware.py
@@ -1,0 +1,146 @@
+from django.db import migrations
+from django.db.models.fields.related_descriptors import (
+    ForwardManyToOneDescriptor,
+    ForwardOneToOneDescriptor,
+    ManyToManyDescriptor,
+    ReverseManyToOneDescriptor,
+    ReverseOneToOneDescriptor,
+)
+
+
+plugin = {
+    "python_module": {
+        "health_check_schedule": None,
+        "update_schedule": None,
+        "module": "scanmalware.ScanMalware",
+        "base_path": "api_app.analyzers_manager.observable_analyzers",
+    },
+    "name": "ScanMalware",
+    "description": (
+        "Query the public [ScanMalware](https://scanmalware.com/) archive "
+        "for existing sandbox scans of domains, URLs and IP addresses. "
+        "Read-only; never submits new scans."
+    ),
+    "disabled": False,
+    "soft_time_limit": 60,
+    "routing_key": "default",
+    "health_check_status": True,
+    "type": "observable",
+    "docker_based": False,
+    "maximum_tlp": "AMBER",
+    "observable_supported": ["ip", "domain", "url"],
+    "supported_filetypes": [],
+    "run_hash": False,
+    "run_hash_type": "",
+    "not_supported_filetypes": [],
+    "mapping_data_model": {},
+    "model": "analyzers_manager.AnalyzerConfig",
+}
+
+
+params = []
+values = []
+
+
+def _get_real_obj(Model, field, value):
+    def _get_obj(Model, other_model, value):
+        if isinstance(value, dict):
+            real_vals = {}
+            for key, real_val in value.items():
+                real_vals[key] = _get_real_obj(other_model, key, real_val)
+            value = other_model.objects.get_or_create(**real_vals)[0]
+        else:
+            if isinstance(value, int):
+                if Model.__name__ == "PluginConfig":
+                    value = other_model.objects.get(name=plugin["name"])
+                else:
+                    value = other_model.objects.get(pk=value)
+            else:
+                value = other_model.objects.get(name=value)
+        return value
+
+    if (
+        type(getattr(Model, field))
+        in [
+            ForwardManyToOneDescriptor,
+            ReverseManyToOneDescriptor,
+            ReverseOneToOneDescriptor,
+            ForwardOneToOneDescriptor,
+        ]
+        and value
+    ):
+        other_model = getattr(Model, field).get_queryset().model
+        value = _get_obj(Model, other_model, value)
+    elif type(getattr(Model, field)) in [ManyToManyDescriptor] and value:
+        other_model = getattr(Model, field).rel.model
+        value = [_get_obj(Model, other_model, val) for val in value]
+
+    return value
+
+
+def _create_object(Model, data):
+    mtm, no_mtm = {}, {}
+
+    for field, value in data.items():
+        value = _get_real_obj(Model, field, value)
+
+        if type(getattr(Model, field)) is ManyToManyDescriptor:
+            mtm[field] = value
+        else:
+            no_mtm[field] = value
+
+    try:
+        o = Model.objects.get(**no_mtm)
+    except Model.DoesNotExist:
+        o = Model(**no_mtm)
+        o.full_clean()
+        o.save()
+
+        for field, value in mtm.items():
+            attribute = getattr(o, field)
+            if value is not None:
+                attribute.set(value)
+
+        return False
+
+    return True
+
+
+def migrate(apps, schema_editor):
+    Parameter = apps.get_model("api_app", "Parameter")
+    PluginConfig = apps.get_model("api_app", "PluginConfig")
+
+    plugin_data = dict(plugin)
+    python_path = plugin_data.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+
+    if not Model.objects.filter(name=plugin_data["name"]).exists():
+        exists = _create_object(Model, plugin_data)
+
+        if not exists:
+            for param in params:
+                _create_object(Parameter, param)
+
+            for value in values:
+                _create_object(PluginConfig, value)
+
+
+def reverse_migrate(apps, schema_editor):
+    plugin_data = dict(plugin)
+    python_path = plugin_data.pop("model")
+    Model = apps.get_model(*python_path.split("."))
+
+    Model.objects.get(name=plugin_data["name"]).delete()
+
+
+class Migration(migrations.Migration):
+    atomic = False
+
+    dependencies = [
+        ("api_app", "0073_alter_updatecheckstatus_last_checked_at_and_more"),
+        ("analyzers_manager", "0196_data_model_phishing_lists"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate, reverse_migrate),
+    ]

--- a/api_app/analyzers_manager/observable_analyzers/scanmalware.py
+++ b/api_app/analyzers_manager/observable_analyzers/scanmalware.py
@@ -1,0 +1,195 @@
+import logging
+
+import requests
+
+from api_app.analyzers_manager import classes
+from api_app.analyzers_manager.exceptions import AnalyzerRunException
+from api_app.choices import Classification
+
+logger = logging.getLogger(__name__)
+
+
+class ScanMalware(classes.ObservableAnalyzer):
+    """Read-only wrapper for the public ScanMalware API."""
+
+    url = "https://scanmalware.com/api/v1"
+
+    def update(self) -> bool:
+        return False
+
+    @staticmethod
+    def _extract_scan_id(data):
+        """Extract scan_id from ScanMalware API responses."""
+
+        scans = data.get("scans")
+        if isinstance(scans, list) and scans:
+            return scans[0].get("scan_id")
+
+        results = data.get("results")
+        if isinstance(results, list) and results:
+            return results[0].get("scan_id")
+
+        return None
+
+    def _get_latest_scan_id(self):
+        """Find the latest available ScanMalware scan."""
+
+        if self.observable_classification == Classification.URL:
+            response = requests.get(
+                f"{self.url}/search",
+                params={
+                    "q": self.observable_name,
+                    "type": "url",
+                    "page": 1,
+                    "limit": 1,
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            return self._extract_scan_id(response.json())
+
+        if self.observable_classification == Classification.DOMAIN:
+            response = requests.get(
+                f"{self.url}/domain/history/{self.observable_name}",
+                params={
+                    "page": 1,
+                    "limit": 1,
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            return self._extract_scan_id(response.json())
+
+        if self.observable_classification == Classification.IP:
+            response = requests.get(
+                f"{self.url}/search/ip/{self.observable_name}",
+                params={
+                    "page": 1,
+                    "limit": 1,
+                },
+                timeout=10,
+            )
+            response.raise_for_status()
+            return self._extract_scan_id(response.json())
+
+        raise AnalyzerRunException(
+            f"{self.observable_classification} is not a supported observable type "
+            "for ScanMalware (supported: ip, domain, url)"
+        )
+
+    @staticmethod
+    def _get_optional_json(url):
+        """GET JSON from an optional ScanMalware endpoint."""
+
+        try:
+            response = requests.get(url, timeout=10)
+        except requests.RequestException as e:
+            logger.warning(
+                "Optional ScanMalware request failed: %s (%s)",
+                url,
+                e,
+            )
+            return None
+
+        if response.status_code == 404:
+            logger.warning(
+                "ScanMalware endpoint returned 404: %s",
+                url,
+            )
+            return None
+
+        response.raise_for_status()
+        return response.json()
+
+    def run(self):
+        logger.info(
+            "Running ScanMalware Analyzer for %s",
+            self.observable_name,
+        )
+
+        try:
+            result = {
+                "observable": self.observable_name,
+                "observable_type": self.observable_classification,
+            }
+
+            if self.observable_classification == Classification.DOMAIN:
+                response = requests.get(
+                    f"{self.url}/domain/stats/{self.observable_name}",
+                    timeout=10,
+                )
+                response.raise_for_status()
+                result["domain_stats"] = response.json()
+
+                history_response = requests.get(
+                    f"{self.url}/domain/history/{self.observable_name}",
+                    params={
+                        "page": 1,
+                        "limit": 5,
+                    },
+                    timeout=10,
+                )
+                history_response.raise_for_status()
+                result["domain_history"] = history_response.json()
+
+            if self.observable_classification == Classification.IP:
+                ct_data = self._get_optional_json(
+                    f"{self.url}/ct/ip/{self.observable_name}"
+                )
+                if ct_data is not None:
+                    result["certificate_transparency"] = ct_data
+
+            scan_id = self._get_latest_scan_id()
+
+            if not scan_id:
+                result["scan_found"] = False
+                result["message"] = (
+                    "No existing ScanMalware scan was found for this observable."
+                )
+                return result
+
+            result["scan_found"] = True
+            result["scan_id"] = scan_id
+
+            summary = self._get_optional_json(
+                f"{self.url}/scan/{scan_id}/summary"
+            )
+            result["summary"] = summary if summary is not None else {}
+
+            ioc = self._get_optional_json(
+                f"{self.url}/ioc/{scan_id}"
+            )
+            result["ioc"] = ioc if ioc is not None else {}
+
+            analyzer_results = self._get_optional_json(
+                f"{self.url}/analyzers/{scan_id}"
+            )
+
+            if analyzer_results is not None:
+                result["analyzers"] = analyzer_results
+            else:
+                result["analyzers"] = {
+                    "available": False,
+                    "reason": "No analyzer results available for this scan.",
+                }
+
+            ai_results = self._get_optional_json(
+                f"{self.url}/ai/{scan_id}"
+            )
+
+            if ai_results is not None:
+                result["ai"] = ai_results
+            else:
+                result["ai"] = {
+                    "available": False,
+                    "reason": "No AI analysis available for this scan.",
+                }
+
+            return result
+
+        except requests.RequestException as e:
+            logger.exception(
+                "ScanMalware API request failed for %s",
+                self.observable_name,
+            )
+            raise AnalyzerRunException(str(e)) from e

--- a/api_app/analyzers_manager/observable_analyzers/scanmalware.py
+++ b/api_app/analyzers_manager/observable_analyzers/scanmalware.py
@@ -119,7 +119,12 @@ class ScanMalware(classes.ObservableAnalyzer):
                     timeout=10,
                 )
                 response.raise_for_status()
-                result["domain_stats"] = response.json()
+                try:
+                    result["domain_stats"] = response.json()
+                except ValueError as e:
+                    raise AnalyzerRunException(
+                        f"ScanMalware domain stats endpoint returned non-JSON: {e}"
+                    ) from e
 
                 history_response = requests.get(
                     f"{self.url}/domain/history/{self.observable_name}",
@@ -130,7 +135,12 @@ class ScanMalware(classes.ObservableAnalyzer):
                     timeout=10,
                 )
                 history_response.raise_for_status()
-                result["domain_history"] = history_response.json()
+                try:
+                    result["domain_history"] = history_response.json()
+                except ValueError as e:
+                    raise AnalyzerRunException(
+                        f"ScanMalware domain history endpoint returned non-JSON: {e}"
+                    ) from e
 
             if self.observable_classification == Classification.IP:
                 ct_data = self._get_optional_json(

--- a/api_app/playbooks_manager/migrations/0069_add_scanmalware_to_free_to_use.py
+++ b/api_app/playbooks_manager/migrations/0069_add_scanmalware_to_free_to_use.py
@@ -1,0 +1,32 @@
+from django.db import migrations
+
+
+def migrate(apps, schema_editor):
+    playbook_config = apps.get_model("playbooks_manager", "PlaybookConfig")
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+
+    pc = playbook_config.objects.get(name="FREE_TO_USE_ANALYZERS")
+    pc.analyzers.add(AnalyzerConfig.objects.get(name="ScanMalware").id)
+    pc.full_clean()
+    pc.save()
+
+
+def reverse_migrate(apps, schema_editor):
+    playbook_config = apps.get_model("playbooks_manager", "PlaybookConfig")
+    AnalyzerConfig = apps.get_model("analyzers_manager", "AnalyzerConfig")
+
+    pc = playbook_config.objects.get(name="FREE_TO_USE_ANALYZERS")
+    pc.analyzers.remove(AnalyzerConfig.objects.get(name="ScanMalware").id)
+    pc.full_clean()
+    pc.save()
+
+
+class Migration(migrations.Migration):
+    dependencies = [
+        ("playbooks_manager", "0068_add_rdap_to_free_to_use"),
+        ("analyzers_manager", "0197_analyzer_config_scanmalware"),
+    ]
+
+    operations = [
+        migrations.RunPython(migrate, reverse_migrate),
+    ]

--- a/tests/api_app/analyzers_manager/observable_analyzers/test_scanmalware.py
+++ b/tests/api_app/analyzers_manager/observable_analyzers/test_scanmalware.py
@@ -1,0 +1,107 @@
+# This file is a part of IntelOwl https://github.com/intelowlproject/IntelOwl
+# See the file 'LICENSE' for copying permission.
+
+from unittest.mock import MagicMock, patch
+
+from api_app.analyzers_manager.exceptions import AnalyzerRunException
+from api_app.analyzers_manager.observable_analyzers.scanmalware import ScanMalware
+from api_app.choices import Classification
+from tests import CustomTestCase
+
+
+class ScanMalwareTestCase(CustomTestCase):
+    """Unit tests for the ScanMalware analyzer (mocked HTTP, no live calls)."""
+
+    @staticmethod
+    def _analyzer(observable_name, classification):
+        analyzer = ScanMalware(config={})
+        analyzer.observable_name = observable_name
+        analyzer.observable_classification = classification
+        return analyzer
+
+    @staticmethod
+    def _ok(json_data):
+        response = MagicMock(status_code=200)
+        response.raise_for_status.return_value = None
+        response.json.return_value = json_data
+        return response
+
+    @patch("api_app.analyzers_manager.observable_analyzers.scanmalware.requests.get")
+    def test_domain_returns_stats_and_scan_data(self, mock_get):
+        mock_get.side_effect = [
+            self._ok({"domain": "example.com", "total_scans": 5}),
+            self._ok({"scans": [{"scan_id": "scan-123"}]}),
+            self._ok({"scans": [{"scan_id": "scan-123"}]}),
+            self._ok({"scan_id": "scan-123", "risk_score": 10}),
+            self._ok({"summary": {"total_matches": 0}}),
+            MagicMock(status_code=404),
+            self._ok({"results": {"analysis": {"classification": "LEGITIMATE"}}}),
+        ]
+
+        result = self._analyzer("example.com", Classification.DOMAIN).run()
+
+        self.assertTrue(result["scan_found"])
+        self.assertEqual(result["scan_id"], "scan-123")
+        self.assertEqual(result["domain_stats"]["total_scans"], 5)
+        self.assertEqual(
+            result["domain_history"]["scans"][0]["scan_id"],
+            "scan-123",
+        )
+        self.assertEqual(result["summary"]["risk_score"], 10)
+        self.assertEqual(
+            result["ai"]["results"]["analysis"]["classification"],
+            "LEGITIMATE",
+        )
+
+    @patch("api_app.analyzers_manager.observable_analyzers.scanmalware.requests.get")
+    def test_url_uses_search_endpoint(self, mock_get):
+        mock_get.side_effect = [
+            self._ok({"results": [{"scan_id": "scan-456"}]}),
+            self._ok({"scan_id": "scan-456"}),
+            self._ok({"summary": {}}),
+            MagicMock(status_code=404),
+            self._ok({"results": {"analysis": {"classification": "LOW_RISK"}}}),
+        ]
+
+        result = self._analyzer(
+            "https://example.com",
+            Classification.URL,
+        ).run()
+
+        self.assertTrue(result["scan_found"])
+        self.assertEqual(result["scan_id"], "scan-456")
+        self.assertIn("/search", mock_get.call_args_list[0].args[0])
+
+    @patch("api_app.analyzers_manager.observable_analyzers.scanmalware.requests.get")
+    def test_ip_includes_ct_when_available(self, mock_get):
+        mock_get.side_effect = [
+            self._ok({"ip": "1.1.1.1", "domains": ["example.com"], "total": 1}),
+            self._ok({"results": [{"scan_id": "scan-789"}]}),
+            self._ok({"scan_id": "scan-789"}),
+            self._ok({"summary": {}}),
+            MagicMock(status_code=404),
+            self._ok({"results": {"analysis": {"classification": "HIGH_RISK"}}}),
+        ]
+
+        result = self._analyzer("1.1.1.1", Classification.IP).run()
+
+        self.assertEqual(
+            result["certificate_transparency"]["domains"],
+            ["example.com"],
+        )
+        self.assertEqual(result["scan_id"], "scan-789")
+
+    @patch("api_app.analyzers_manager.observable_analyzers.scanmalware.requests.get")
+    def test_ip_ct_timeout_does_not_fail(self, mock_get):
+        mock_get.side_effect = [
+            __import__("requests").RequestException("timeout"),
+            self._ok({"results": []}),
+        ]
+
+        result = self._analyzer("1.1.1.1", Classification.IP).run()
+
+        self.assertFalse(result["scan_found"])
+
+    def test_unsupported_classification_raises(self):
+        with self.assertRaises(AnalyzerRunException):
+            self._analyzer("deadbeefdeadbeef", Classification.HASH).run()


### PR DESCRIPTION


Adds a read-only ScanMalware observable analyzer for domains, URLs, and IP addresses.

## Changes

* Add `ScanMalware` observable analyzer.
* Support domain, URL, and IP observables.
* Retrieve domain scan statistics and scan history.
* Retrieve IP Certificate Transparency data.
* Retrieve the latest available ScanMalware scan.
* Include scan summary, IOC, and AI analysis when available.
* Handle optional API endpoints and unavailable results gracefully.
* Add ScanMalware to `FREE_TO_USE_ANALYZERS`.
* Add mocked unit tests for supported observable types and error handling.

## Important

The analyzer is strictly read-only and never submits new scans to ScanMalware.

## Testing

* `python -m py_compile api_app/analyzers_manager/observable_analyzers/scanmalware.py`
* Django test suite: **5/5 tests passed**
* `git diff --check`
